### PR TITLE
Redirect URL

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,4 +1,3 @@
 CLIENT_ID=GetFromGoogleDeveloperConsole
 CLIENT_SECRET=GetFromGoogleDeveloperConsole
 REDIRECT_URI=http://localhost:4000/auth/callback
-REDIRECT_AFTER_SUCCESS_HOST=http://localhost:8000/token

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -21,7 +21,8 @@ defmodule AuthControllerTest do
   end
 
   test "index redirects to google with the correct redirect URI" do
-    conn = call_router(Router, :get, "/auth")
+    conn = phoenix_conn(:get, "/auth", %{redirect_uri: "foo.com"})
+    |> call_router
 
     auth_uri = google_auth_uri(
       client_id: "",
@@ -30,22 +31,30 @@ defmodule AuthControllerTest do
       scope: "openid email"
     )
     assert_redirected(conn, auth_uri)
+    assert get_session(conn, :redirect_after_success_uri) == "foo.com"
   end
 
   test "callback redirects to success URI with constable user auth token" do
     Pact.override(self, "token_retriever", FakeTokenRetriever)
     Pact.override(self, "request_with_access_token", FakeRequestWithAccessToken)
 
-    conn = call_router(Router, :get, "/auth/callback", %{"code" => "1234"})
+    conn = phoenix_conn(:get, "/auth/callback", %{"code" => "foo"})
+    |> put_redirect_after_success("foo.com")
+    |> call_router
 
     user_auth_token = Repo.one(from u in User).token
-    assert_redirected(conn, "/#{user_auth_token}")
+    assert_redirected(conn, "foo.com/#{user_auth_token}")
   end
 
   test "callback redirects to the root path when there is an error" do
-    conn = call_router(Router, :get, "/auth/callback", %{"error" => "Foo"})
+    conn = phoenix_conn(:get, "/auth/callback", %{"error" => "Foo"})
+    |> call_router
 
     assert_redirected(conn, "/")
+  end
+
+  defp put_redirect_after_success(conn, url) do
+    put_session(conn, :redirect_after_success_uri, url)
   end
 
   defp google_auth_uri(params) do

--- a/test/support/router_helper.ex
+++ b/test/support/router_helper.ex
@@ -26,15 +26,12 @@ defmodule RouterHelper do
     end
   end
 
-  def call_router(router, verb, path, params \\ nil, headers \\ []) do
-    conn = conn(verb, path, params, headers)
-    |> Plug.Conn.fetch_params
-    |> with_session
-    |> router.call(router.init([]))
+  def call_router(conn) do
+    conn |> ConstableApi.Router.call(ConstableApi.Router.init([]))
   end
 
-  def phoenix_conn(verb, params \\ nil, headers \\ []) do
-    conn = conn(verb, "/", params, headers)
+  def phoenix_conn(verb, path \\ "/", params \\ nil, headers \\ []) do
+    conn = conn(verb, path, params, headers)
     |> Plug.Conn.fetch_params
     |> with_session
   end


### PR DESCRIPTION
Since we often need to authorize from different sources (development, production, staging) we need to change where the authorization token goes. This makes it so that you can pass it as a query parameter.
