### PR TITLE
Serialize announcement_id, change formatting

### DIFF
--- a/test/channels/comment_channel_test.exs
+++ b/test/channels/comment_channel_test.exs
@@ -19,6 +19,7 @@ defmodule CommentChannelTest do
     handle_in_topic(CommentChannel, "comments:create", comment_params)
 
     comment = Repo.one(Comment) |> Serializers.to_json
+    assert_socket_replied_with_payload("comments:create", comment)
     assert_socket_broadcasted_with_payload("comments:create", comment)
   end
 end

--- a/test/models/serializers/comment_test.exs
+++ b/test/models/serializers/comment_test.exs
@@ -11,7 +11,8 @@ defmodule CommentTest do
 
     assert comment_as_json == %{
       id: comment.id,
-      body: comment.body
+      body: comment.body,
+      announcement_id: comment.announcement_id
     }
   end
 end

--- a/web/channels/comment_channel.ex
+++ b/web/channels/comment_channel.ex
@@ -14,6 +14,7 @@ defmodule ConstableApi.CommentChannel do
     comment = %Comment{body: body, announcement_id: announcement_id}
     |> Repo.insert
 
+    reply socket, "comments:create", Serializers.to_json(comment)
     broadcast socket, "comments:create", Serializers.to_json(comment)
   end
 end

--- a/web/models/serializers/comment.ex
+++ b/web/models/serializers/comment.ex
@@ -2,7 +2,8 @@ defimpl ConstableApi.Serializers, for: ConstableApi.Comment do
   def to_json(comment) do
     %{
       id: comment.id,
-      body: comment.body
+      body: comment.body,
+      announcement_id: comment.announcement_id
     }
   end
 end


### PR DESCRIPTION
When dealing with the client expect everything to come in as camel case
and change to underscore case as needed.

The API also needs to know which announcement to push the comment to so
`announcementId` was added to determine that.
