### PR TITLE
Don't reply and broadcast

### DIFF
--- a/test/channels/comment_channel_test.exs
+++ b/test/channels/comment_channel_test.exs
@@ -19,7 +19,6 @@ defmodule CommentChannelTest do
     handle_in_topic(CommentChannel, "comments:create", comment_params)
 
     comment = Repo.one(Comment) |> Serializers.to_json
-    assert_socket_replied_with_payload("comments:create", comment)
     assert_socket_broadcasted_with_payload("comments:create", comment)
   end
 end

--- a/web/channels/comment_channel.ex
+++ b/web/channels/comment_channel.ex
@@ -14,7 +14,6 @@ defmodule ConstableApi.CommentChannel do
     comment = %Comment{body: body, announcement_id: announcement_id}
     |> Repo.insert
 
-    reply socket, "comments:create", Serializers.to_json(comment)
     broadcast socket, "comments:create", Serializers.to_json(comment)
   end
 end


### PR DESCRIPTION
Broadcast includes the client, causing the client to receive the same
message twice.
