### PR TITLE
Sort comments with `Enum.sort` in serializer

### DIFF
--- a/test/channels/accouncement_channel_test.exs
+++ b/test/channels/accouncement_channel_test.exs
@@ -17,6 +17,7 @@ defmodule AnnouncementChannelTest do
       announcements:
       Map.put(%{}, announcement_id, Serializers.to_json(announcement))
     }
+
     assert_socket_replied_with_payload("announcements:index", announcements)
   end
 

--- a/web/channels/announcement_channel.ex
+++ b/web/channels/announcement_channel.ex
@@ -4,6 +4,7 @@ defmodule ConstableApi.AnnouncementChannel do
   alias ConstableApi.Announcement
   alias ConstableApi.Serializers
   alias ConstableApi.Channel.Helpers
+  alias ConstableApi.Queries
   import Ecto.Query
 
   def join(_topic, %{"token" => token}, socket) do
@@ -11,9 +12,10 @@ defmodule ConstableApi.AnnouncementChannel do
   end
 
   def handle_in("announcements:index", _params, socket) do
-    announcements = Repo.all(from a in Announcement, preload: :comments)
-    |> Enum.map(&Serializers.to_json/1)
-    |> set_ids_as_keys
+    announcements = 
+      Repo.all(Queries.Announcement.with_sorted_comments)
+      |> Enum.map(&Serializers.to_json/1)
+      |> set_ids_as_keys
     reply socket, "announcements:index", %{announcements: announcements}
   end
 

--- a/web/models/queries/announcement.ex
+++ b/web/models/queries/announcement.ex
@@ -1,0 +1,11 @@
+defmodule ConstableApi.Queries.Announcement do
+  alias ConstableApi.Announcement
+  import Ecto.Query
+
+  def with_sorted_comments do
+    from a in Announcement,
+      left_join: c in assoc(a, :comments),
+      order_by: [asc: c.inserted_at],
+      preload: [comments: c]
+  end
+end


### PR DESCRIPTION
I'm not sure how to do this with Ecto, but would prefer to do it in the query.
