### PR TITLE
Serialize and update announcement updated_at field

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule ConstableApi.Mixfile do
   defp deps do
     [
       {:postgrex, ">= 0.0.0"},
-      {:ecto, "~> 0.5"},
+      {:ecto, "~> 0.8.1"},
       {:phoenix, "~> 0.8.0"},
       {:cowboy, "~> 1.0"},
       {:dotenv, "~> 0.0.4"},

--- a/test/channels/comment_channel_test.exs
+++ b/test/channels/comment_channel_test.exs
@@ -2,6 +2,7 @@ defmodule CommentChannelTest do
   use ConstableApi.TestWithEcto, async: false
   import Ecto.Query
   import ChannelTestHelper
+  alias ConstableApi.Announcement
   alias ConstableApi.Repo
   alias ConstableApi.Comment
   alias ConstableApi.CommentChannel
@@ -17,15 +18,11 @@ defmodule CommentChannelTest do
     Pact.override(self, :comment_mailer, FakeCommentMailer)
     user = Forge.saved_user(Repo)
     announcement = Forge.saved_announcement(Repo, user_id: user.id)
-    Phoenix.PubSub.subscribe(self, "comments:create")
-    comment_params = %{
-      "announcement_id" => announcement.id,
-      "body" => "Bar"
-    }
 
+    Phoenix.PubSub.subscribe(self, "comments:create")
     socket_with_topic("comments:create")
     |> assign_current_user(user.id)
-    |> handle_in_topic(CommentChannel, comment_params)
+    |> handle_in_topic(CommentChannel, comment_params_for(announcement))
 
     comment = Repo.one(from c in Comment, preload: :user) |> Serializers.to_json
     assert_socket_broadcasted_with_payload("comments:create", comment)
@@ -34,18 +31,40 @@ defmodule CommentChannelTest do
   test "comments:create sends a notification email to all users" do
     Pact.override(self, :comment_mailer, FakeCommentMailer)
     user = Forge.saved_user(Repo)
-    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    announcement = Forge.saved_announcement(Repo,user_id: user.id,)
+
     Phoenix.PubSub.subscribe(self, "comments:create")
+    socket_with_topic("comments:create")
+    |> assign_current_user(user.id)
+    |> handle_in_topic(CommentChannel, comment_params_for(announcement))
+
+    comment = Repo.one(from c in Comment, preload: :user) |> Serializers.to_json
+    assert_received {:new_comment_email_sent, comment}
+  end
+
+  test "comments:create updates the announcements timestamp" do
+    Pact.override(self, :comment_mailer, FakeCommentMailer)
+    user = Forge.saved_user(Repo)
+    {:ok, date} = Ecto.DateTime.load({{2000, 12, 25}, {11, 42, 42}})
+    announcement = Forge.saved_announcement(
+      Repo,
+      user_id: user.id,
+      updated_at: date
+    )
+
+    Phoenix.PubSub.subscribe(self, "comments:create")
+    socket_with_topic("comments:create")
+    |> assign_current_user(user.id)
+    |> handle_in_topic(CommentChannel, comment_params_for(announcement))
+
+    updated_announcement = Repo.get(Announcement, announcement.id)
+    assert announcement.updated_at != updated_announcement.updated_at
+  end
+
+  def comment_params_for(announcement) do
     comment_params = %{
       "announcement_id" => announcement.id,
       "body" => "Bar"
     }
-
-    socket_with_topic("comments:create")
-    |> assign_current_user(user.id)
-    |> handle_in_topic(CommentChannel, comment_params)
-
-    comment = Repo.one(from c in Comment, preload: :user) |> Serializers.to_json
-    assert_received {:new_comment_email_sent, comment}
   end
 end

--- a/test/models/serializers/announcement_test.exs
+++ b/test/models/serializers/announcement_test.exs
@@ -16,7 +16,8 @@ defmodule ConstableApi.Serializers.AnnouncementTest do
       body: announcement.body,
       user: Serializers.to_json(user),
       comments: [Serializers.to_json(comment)],
-      inserted_at: Ecto.DateTime.to_string(announcement.inserted_at)
+      inserted_at: Ecto.DateTime.to_string(announcement.inserted_at),
+      updated_at: Ecto.DateTime.to_string(announcement.updated_at)
     }
   end
 end

--- a/test/support/forge.ex
+++ b/test/support/forge.ex
@@ -11,7 +11,8 @@ defmodule Forge do
     __struct__: Announcement,
     title: "Post Title",
     body: "Post Body",
-    inserted_at: Ecto.DateTime.utc
+    inserted_at: Ecto.DateTime.utc,
+    updated_at: Ecto.DateTime.utc
 
   register :comment,
     __struct__: Comment,

--- a/web/channels/comment_channel.ex
+++ b/web/channels/comment_channel.ex
@@ -19,7 +19,14 @@ defmodule ConstableApi.CommentChannel do
     |> Repo.insert
     |> Repo.preload(:user)
 
+    update_announcement_timestamps(announcement_id)
     Pact.get(:comment_mailer).created(comment)
+
     broadcast socket, "comments:create", Serializers.to_json(comment)
+  end
+
+  defp update_announcement_timestamps(announcement_id) do
+    announcement = Repo.get(Announcement, announcement_id)
+    Repo.update(%{announcement | updated_at: Ecto.DateTime.utc})
   end
 end

--- a/web/models/serializers/announcement.ex
+++ b/web/models/serializers/announcement.ex
@@ -8,7 +8,8 @@ defimpl ConstableApi.Serializers, for: ConstableApi.Announcement do
       body: announcement.body,
       user: Serializers.to_json(announcement.user),
       comments: Enum.map(announcement.comments, &Serializers.to_json/1),
-      inserted_at: Ecto.DateTime.to_string(announcement.inserted_at)
+      inserted_at: Ecto.DateTime.to_string(announcement.inserted_at),
+      updated_at: Ecto.DateTime.to_string(announcement.updated_at)
     }
   end
 end


### PR DESCRIPTION
When a comment is created we touch the announcements `updated_at`
property manually since Ecto doesn't have this ability yet.

We also serialize the updated_at property so we can sort by the most
recently commented on stories on the front-end.
