### PR TITLE
Send email async

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -8,7 +8,10 @@ defmodule ConstableApi.Mandrill do
       key: System.get_env("MANDRILL_KEY"),
       message: message_params
     } |> Poison.encode!
-    HTTPoison.post!(@mandrill_url, params).body
+
+    Task.async(fn ->
+      HTTPoison.post!(@mandrill_url, params).body
+    end)
   end
 
   def format_users(users), do: Enum.map(users, &format_user/1)

--- a/web/channels/comment_channel.ex
+++ b/web/channels/comment_channel.ex
@@ -20,10 +20,10 @@ defmodule ConstableApi.CommentChannel do
     |> Repo.preload(:user)
     |> Repo.preload(:announcement)
 
-    broadcast socket, "comments:create", Serializers.to_json(comment)
-
     update_announcement_timestamps(announcement_id)
     Pact.get(:comment_mailer).created(comment)
+
+    broadcast socket, "comments:create", Serializers.to_json(comment)
   end
 
   defp update_announcement_timestamps(announcement_id) do


### PR DESCRIPTION
When a comment or announcement is created we send a notification email
to all user which is blocking the reply/broadcast. This makes the
mandrill call async which means a faster response for the websocket
clients.
