### PR TITLE
Use spawn instead of task

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -9,7 +9,7 @@ defmodule ConstableApi.Mandrill do
       message: message_params
     } |> Poison.encode!
 
-    Task.async(fn ->
+    spawn(fn ->
       HTTPoison.post!(@mandrill_url, params).body
     end)
   end


### PR DESCRIPTION
Tasks send messages back to their original PID when finished, this is
causing crashes in certain edge cases. Use spawn which does not send a
message back to the original process.
