### PR TITLE
Add announcement updates for current user

### DIFF
--- a/test/channels/comment_channel_test.exs
+++ b/test/channels/comment_channel_test.exs
@@ -42,7 +42,7 @@ defmodule CommentChannelTest do
   end
 
   def comment_params_for(announcement) do
-    comment_params = %{
+    %{
       "announcement_id" => announcement.id,
       "body" => "Bar"
     }

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -3,7 +3,6 @@ defmodule AuthControllerTest do
   use RouterHelper
   alias ConstableApi.User
   alias ConstableApi.Repo
-  import Ecto.Query
 
   @google_authorize_url "https://accounts.google.com/o/oauth2/auth"
   @oauth_email_address "fake@example.com"
@@ -55,7 +54,7 @@ defmodule AuthControllerTest do
   test "callback redirects to success URI with existing user token" do
     Pact.override(self, "token_retriever", FakeTokenRetriever)
     Pact.override(self, "request_with_access_token", FakeRequestWithAccessToken)
-    existing_user = Forge.saved_user(Repo, email: @oauth_email_address)
+    Forge.saved_user(Repo, email: @oauth_email_address)
 
     conn = phoenix_conn(:get, "/auth/callback", %{"code" => "foo"})
     |> put_redirect_after_success("foo.com")

--- a/web/channels/announcement_channel.ex
+++ b/web/channels/announcement_channel.ex
@@ -23,9 +23,38 @@ defmodule ConstableApi.AnnouncementChannel do
     announcement =
       %Announcement{title: title, body: body, user_id: current_user_id(socket)}
       |> Repo.insert
-      |> Repo.preload([:user, comments: :user])
+      |> preload_associations
     Pact.get(:announcement_mailer).created(announcement)
     broadcast socket, "announcements:create", Serializers.to_json(announcement)
+  end
+
+  def handle_in("announcements:update", attributes = %{"id" => id}, socket) do
+    user_id = current_user_id(socket)
+    announcement = Repo.one(
+      Queries.Announcement.find_by_id_and_user(id, user_id)
+    )
+
+    if announcement do
+      announcement
+        |> update_announcement(attributes)
+        |> preload_associations
+        |> broadcast_announcement(socket, "announcements:update")
+    else
+      {:ok, socket}
+    end
+  end
+
+  defp broadcast_announcement(announcement, socket, topic) do
+    broadcast(socket, "announcements:update", Serializers.to_json(announcement))
+  end
+
+  defp update_announcement(announcement, attributes) do
+    Announcement.changeset(announcement, :update, attributes)
+    |> Repo.update
+  end
+
+  defp preload_associations(announcement) do
+    Repo.preload(announcement, [:user, comments: :user])
   end
 
   defp set_ids_as_keys(announcements) do

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -11,4 +11,9 @@ defmodule ConstableApi.Announcement do
     has_many :comments, Comment
     timestamps
   end
+
+  def changeset(announcement, :update, params \\ nil) do
+    params
+    |> cast(announcement, ~w{}, ~w{title body})
+  end
 end

--- a/web/models/queries/announcement.ex
+++ b/web/models/queries/announcement.ex
@@ -9,4 +9,8 @@ defmodule ConstableApi.Queries.Announcement do
       order_by: [asc: c.inserted_at],
       preload: [:user, comments: {c, user: u}]
   end
+
+  def find_by_id_and_user(id, user_id) do
+    from a in Announcement, where: a.id == ^id and a.user_id == ^user_id
+  end
 end


### PR DESCRIPTION
Allow users to update their own announcements and broadcast an `update`
with the new attributes. If they don't own it, we do nothing.
