### PR TITLE
Add username to user

### DIFF
--- a/priv/repo/migrations/20150302210455_add_username_to_user.exs
+++ b/priv/repo/migrations/20150302210455_add_username_to_user.exs
@@ -1,0 +1,29 @@
+defmodule Constable.Repo.Migrations.AddUsernameToUser do
+  use Ecto.Migration
+  alias Constable.Repo
+
+  def up do
+    alter table(:users) do
+      add :username, :string
+    end
+
+    Constable.Repo.all(Constable.User)
+    |> Enum.each(&add_username_to_user/1)
+
+    alter table(:users) do
+      modify :username, :string, null: false, unique: true
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      remove :username
+    end
+  end
+
+  defp add_username_to_user(user) do
+    username = String.split(user.email, "@", parts: 2) |> List.first
+    user = %{user | username: username}
+    Repo.update(user)
+  end
+end

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -24,6 +24,20 @@ defmodule AuthControllerTest do
     end
   end
 
+  test "inserts user with correct information" do
+    Pact.override(self, "token_retriever", FakeTokenRetriever)
+    Pact.override(self, "request_with_access_token", FakeRequestWithAccessToken)
+
+    conn = phoenix_conn(:get, "/auth/callback", %{"code" => "foo"})
+    |> put_redirect_after_success("foo.com")
+    |> call_router
+
+    user = Repo.one(User)
+    assert user.email == "fake@example.com"
+    assert user.name == "Gumbo McGee"
+    assert user.username == "fake"
+  end
+
   test "index redirects to google with the correct redirect URI" do
     conn = phoenix_conn(:get, "/auth", %{redirect_uri: "foo.com"})
     |> call_router

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -43,8 +43,9 @@ defmodule Constable.AuthController do
     userinfo = get_userinfo(token)
     email = userinfo["email"]
     name = userinfo["name"]
+    username = String.split(userinfo["email"], "@", parts: 2) |> List.first
     unless user = Repo.one(from u in User, where: u.email == ^email) do
-      user = %User{email: email, name: name} |> Repo.insert
+      user = %User{email: email, name: name, username: username} |> Repo.insert
     end
     user
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -7,6 +7,7 @@ defmodule Constable.User do
     field :email
     field :token
     field :name
+    field :username
 
     timestamps
   end


### PR DESCRIPTION
When creating a user we generate their username based on their email
address before the `@` symbol. This should also migrate all existing
users to have usernames.
