### PR TITLE
Cast string ID to integer

### DIFF
--- a/web/channels/subscription_channel.ex
+++ b/web/channels/subscription_channel.ex
@@ -17,10 +17,10 @@ defmodule Constable.SubscriptionChannel do
 
   def handle_in("subscriptions:create", %{"announcement_id" => announcement_id}, socket) do
     user_id = current_user_id(socket)
-    subscription = Repo.insert(%Subscription{
+    subscription = Subscription.changeset(%{
       user_id: user_id,
       announcement_id: announcement_id
-    })
+    }) |> Repo.insert
 
     reply socket, "subscriptions:create", subscription
   end

--- a/web/models/subscription.ex
+++ b/web/models/subscription.ex
@@ -8,4 +8,9 @@ defmodule Constable.Subscription do
     belongs_to :announcement, Announcement
     timestamps
   end
+
+  def changeset(subscription \\ %__MODULE__{}, params) do
+    subscription
+    |> cast(params, ~w(user_id announcement_id))
+  end
 end


### PR DESCRIPTION
It wasn't casting the string to integer. Now we're using a changeset to cast string to integers for ids
