### PR TITLE
Fix mandrill email issues

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -9,10 +9,18 @@ defmodule Constable.Mandrill do
       message: message_params
     } |> Poison.encode!
 
-    Task.async(fn ->
-      HTTPoison.post!(@mandrill_url, params).body
+    Task.start_link(fn ->
+      %{status_code: 200} = HTTPoison.post!(@mandrill_url, params)
     end)
   end
 
-  def format_users(users), do: Poison.encode!(users, for: :mandrill)
+  def format_users(users) do
+    Enum.map(users, fn(user) ->
+      %{
+        email: user.email,
+        name: user.name,
+        type: "bcc"
+      }
+    end)
+  end
 end

--- a/test/mandrill_test.exs
+++ b/test/mandrill_test.exs
@@ -1,0 +1,16 @@
+defmodule Constable.MandrillTest do
+  use ExUnit.Case, async: true
+  alias Constable.Mandrill
+
+  test "returns map with email, name, and type" do
+    user = Forge.user
+
+    users_as_json = Mandrill.format_users([user])
+
+    assert users_as_json == [%{
+      email: user.email,
+      name: user.name,
+      type: "bcc"
+    }]
+  end
+end

--- a/test/models/serializers/user_test.exs
+++ b/test/models/serializers/user_test.exs
@@ -14,16 +14,4 @@ defmodule Constable.UserSerializerTest do
       gravatar_url: Exgravatar.generate(user.email)
     }
   end
-
-  test "returns json with email, name, and type" do
-    user = Forge.user
-
-    user_as_json = Poison.encode!(user, for: :mandrill)
-
-    assert user_as_json == Poison.encode! %{
-      email: user.email,
-      name: user.name,
-      type: "bcc"
-    }
-  end
 end

--- a/web/models/serializers/user.ex
+++ b/web/models/serializers/user.ex
@@ -1,12 +1,4 @@
 defimpl Poison.Encoder, for:  Constable.User do
-  def encode(user, for: :mandrill) do
-    %{
-      email: user.email,
-      name: user.name,
-      type: "bcc"
-    } |> Poison.encode!
-  end
-
   def encode(user, _options) do
     %{
       id: user.id,


### PR DESCRIPTION
- Fixes problem where users were encoded twice
- Fixes problem where error responses from Mandrill were silently
  ignored

Task.async was causing issues with the WebSocket transport layer
