### PR TITLE
Handle incoming email replies

### DIFF
--- a/test/controllers/email_reply_controller_test.exs
+++ b/test/controllers/email_reply_controller_test.exs
@@ -12,16 +12,46 @@ defmodule Constable.EmailReplyTest do
       email: "constable-#{announcement.id}@thoughtbot.com"
     )
 
-    post conn, "/email_replies", email_reply_webhook
+    conn = post(conn, "/email_replies", email_reply_webhook)
 
-    comment = Repo.one(Comment)
+    comment = Repo.one(Comment, preload: [:user, :announcement])
+    assert conn.status == 200
     assert comment.announcement_id == announcement.id
     assert comment.user_id == user.id
     assert comment.body == "YO DAWG"
   end
 
+  test "removes the last quoted section from the email reply" do
+    user_text = """
+    Text that I wrote
+
+    > With a quote. Will it work?
+
+    Sure looks like it!!
+    """
+    body_text = """
+    #{user_text}\n> On Oct 16, 2015, at 5:05 PM, Paul Smith (Constable) <constable-40@staging.constable.io> wrote:\n> \n> \t\n> my text\t\n\n\n
+    """
+    announcement = create(:announcement)
+    email_reply_webhook = create_email_reply_webhook(
+      from_email: announcement.user.email,
+      text: body_text,
+      email: "constable-#{announcement.id}@thoughtbot.com"
+    )
+
+    post(conn, "/email_replies", email_reply_webhook)
+
+    comment = Repo.one(Comment)
+    assert comment.body == user_text
+  end
+
   defp create_email_reply_webhook(message_attributes) do
     email_reply_message = build(:email_reply_message, message_attributes)
-    build(:email_reply_webhook, msg: email_reply_message)
+
+    reply_events =
+      build(:email_reply_event, msg: email_reply_message)
+      |> List.wrap
+      |> Poison.encode!
+    build(:email_reply_webhook, mandrill_events: reply_events)
   end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -9,10 +9,16 @@ defmodule Constable.Factories do
     }
   end
 
-  factory :email_reply_webhook do
+  factory :email_reply_event do
     %{
       event: "inbound",
       msg: build(:email_reply_message)
+    }
+  end
+
+  factory :email_reply_webhook do
+    %{
+      mandrill_events: [build(:email_reply_event)]
     }
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -20,8 +20,13 @@ defmodule Constable.Router do
   scope "/", Constable do
     pipe_through :browser
 
-    resources "/email_replies", EmailReplyController, only: [:create]
     resources "/unsubscribe", UnsubscribeController, only: [:show]
+  end
+
+  scope "/", Constable do
+    pipe_through :api
+
+    resources "/email_replies", EmailReplyController, only: [:create]
   end
 
   scope "/auth", alias: Constable do


### PR DESCRIPTION
This doesn't do anything to strip out the quoted portion yet, but it does add the comment to the correct announcement.

This requires #46 because that PR sets the correct "from" address
