### PR TITLE
Update comment serializer payload

### DIFF
--- a/test/models/serializers/comment_test.exs
+++ b/test/models/serializers/comment_test.exs
@@ -11,7 +11,7 @@ defmodule Constable.CommentSerializerTest do
     assert comment_as_json == Poison.encode! %{
       id: comment.id,
       body: comment.body,
-      user_id: comment.user_id,
+      user: comment.user,
       announcement_id: comment.announcement_id,
       inserted_at: comment.inserted_at
     }

--- a/web/models/serializers/comment.ex
+++ b/web/models/serializers/comment.ex
@@ -1,5 +1,5 @@
 defimpl Poison.Encoder, for: Constable.Comment do
-  @attributes ~W(id body user_id announcement_id inserted_at)a
+  @attributes ~W(id body user announcement_id inserted_at)a
 
   def encode(comment, _options) do
     comment |> Map.take(@attributes) |> Poison.encode!


### PR DESCRIPTION
The front-end expects `user` instead of `user_id`.
