### PR TITLE
Fix email domain for Mandrill on staging

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -1,4 +1,5 @@
 defmodule Constable.Mandrill do
+  require Logger
   alias Constable.Serializers
 
   @mandrill_url "https://mandrillapp.com/api/1.0/messages/send.json"
@@ -9,8 +10,10 @@ defmodule Constable.Mandrill do
       message: message_params
     } |> Poison.encode!
 
-    spawn(fn ->
-      %{status_code: 200} = HTTPoison.post!(@mandrill_url, params)
+    Task.async(fn ->
+      Logger.info "Sending email with params:"
+      IO.inspect params
+      HTTPoison.post(@mandrill_url, params) |> IO.inspect
     end)
   end
 

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -1,9 +1,12 @@
 defmodule Constable.Mailers.Base do
-  @email_domain System.get_env("EMAIL_DOMAIN")
   def default_attributes(announcement: announcement, author: author) do
     %{
-      from_email: "constable-#{announcement.id}@#{@email_domain}",
+      from_email: "constable-#{announcement.id}@#{email_domain}",
       from_name: "#{author.name} (Constable)"
     }
+  end
+
+  defp email_domain do
+    System.get_env("EMAIL_DOMAIN")
   end
 end


### PR DESCRIPTION
Heroku doesn't set the ENV during compile time so the @email_domain was
set to blank. Instead just grab it from a private method at runtime

Also adds some logging to make things easier in the future!
