### PR TITLE
Add scope to user interest validations

### DIFF
--- a/test/models/user_interest_test.ex
+++ b/test/models/user_interest_test.ex
@@ -1,0 +1,14 @@
+defmodule Constable.UserInterestTest do
+  use Constable.ModelCase
+
+  alias Constable.UserInterest
+
+  test "validates uniqueness scoped user_id" do
+    first_user = Forge.saved_user(Repo)
+    second_user = Forge.saved_user(Repo)
+    interest = Forge.saved_interest(Repo)
+
+    assert Repo.insert %UserInterest{user_id: first_user.id, interest_id: interest.id}
+    assert Repo.insert %UserInterest{user_id: second_user.id, interest_id: interest.id}
+  end
+end

--- a/web/models/user_interest.ex
+++ b/web/models/user_interest.ex
@@ -14,7 +14,7 @@ defmodule Constable.UserInterest do
   def changeset(user_interest \\ %__MODULE__{}, params) do
     user_interest
     |> cast(params, ~w(user_id interest_id))
-    |> validate_unique(:user_id, on: Repo)
-    |> validate_unique(:interest_id, on: Repo)
+    |> validate_unique(:user_id, on: Repo, scope: [:interest_id])
+    |> validate_unique(:interest_id, on: Repo, scope: [:user_id])
   end
 end


### PR DESCRIPTION
When trying to add a user interest the request would fail since the
validation checked for uniqueness on both `user_id` and `interest_id`
individually.

This adds the `scope` option to `validate_unique` to ensure that it's
scoped to a single user.
