### PR TITLE
Downcase all interests

### DIFF
--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -38,6 +38,23 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     assert announcement.interests == []
   end
 
+  test "creates only downcased interests" do
+    user = Forge.saved_user(Repo)
+    interest_names = ["foo", "FOO", "FoO"]
+    announcement_params = %{
+      title: "Title",
+      body: "Body",
+      user_id: user.id
+    }
+
+    AnnouncementCreator.create(announcement_params, interest_names)
+
+    announcement = Repo.one(Announcement) |> Repo.preload([:interests])
+    assert announcement_has_interest_named?(announcement, "foo")
+    refute announcement_has_interest_named?(announcement, "FOO")
+    refute announcement_has_interest_named?(announcement, "FoO")
+  end
+
   defp announcement_has_interest_named?(announcement, interest_name) do
     announcement.interests |> Enum.any?(&(&1.name == interest_name))
   end

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -24,6 +24,7 @@ defmodule Constable.Services.AnnouncementCreator do
 
   defp get_or_create_interests(names) do
     List.wrap(names)
+    |> Enum.map(&String.downcase/1)
     |> Enum.uniq
     |> Enum.reject(&blank_interest?/1)
     |> Enum.map(fn(name) ->


### PR DESCRIPTION
All interests should be downcased before being created to keep
consistency and help prevent duplicates.
