### PR TITLE
Fix interested users test

### DIFF
--- a/lib/mandrill.ex
+++ b/lib/mandrill.ex
@@ -12,8 +12,8 @@ defmodule Constable.Mandrill do
 
     Task.async(fn ->
       Logger.info "Sending email with params:"
-      IO.inspect params
-      HTTPoison.post(@mandrill_url, params) |> IO.inspect
+      Logger.info inspect(params)
+      HTTPoison.post(@mandrill_url, params) |> inspect |> Logger.info
     end)
   end
 

--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -17,8 +17,8 @@ defmodule Constable.Mailers.AnnouncementTest do
   test "sends announcement created email to people subscribed to the interest" do
     Pact.override(self, :mailer, FakeMandrill)
     interest = Forge.saved_interest(Repo)
-    announcement = create_announcement_with_interest(interest)
     interested_users = [create_interested_user(interest)]
+    announcement = create_announcement_with_interest(interest)
 
     Mailers.Announcement.created(announcement)
 


### PR DESCRIPTION
Need to create an interested user before creating and loading the
announcement or the preloaded association will not include the
interested users.
