### PR TITLE
Serialize dates using iso8601 instead of to_string

### DIFF
--- a/web/models/serializers/ecto_date_time.ex
+++ b/web/models/serializers/ecto_date_time.ex
@@ -1,5 +1,0 @@
-defimpl Poison.Encoder, for: Ecto.DateTime do
-  def encode(date_time, _options) do
-    date_time |> Ecto.DateTime.to_string |> Poison.encode!
-  end
-end


### PR DESCRIPTION
When using to_string the front-end displays the wrong relative time,
using iso8601 allows momentjs to interpret the date/time properly.
