### PR TITLE
Fix comment link. Show interests correctly.

### DIFF
--- a/web/mailers/announcement.ex
+++ b/web/mailers/announcement.ex
@@ -37,7 +37,8 @@ defmodule Constable.Mailers.Announcement do
     announcement
     |> Repo.preload(:interests)
     |> Map.get(:interests)
-    |> Enum.map(&(&1.name))
+    |> Enum.map(&("##{&1.name}"))
+    |> Enum.join(", ")
   end
 
   defp render_template(path, bindings) do

--- a/web/templates/mailers/comments/new.eex
+++ b/web/templates/mailers/comments/new.eex
@@ -172,12 +172,8 @@
             <tr>
               <td width='40'></td>
               <td align='center'>
-                <a href='#' style='color: #c32f34;'>
+                <a href='<%= front_end_uri %>/announcements/<%= comment.announcement.id  %>' style='color: #c32f34;'>
                   <h4 style='#c32f34 font-size: 18px; margin: 0; padding-bottom: 5px;'>View this announcement on #Constable</h4>
-                  <a href='<%= front_end_uri
-                    %>/announcements/<%= comment.announcement.id  %>' style='color: #babdd1;'>
-                    <%= front_end_uri %>/announcements/<%= comment.announcement.id  %>
-                  </a>
                 </a>
               </td>
               <td width='40'></td>


### PR DESCRIPTION
- The comment email formatting made it so that you couldn't click the
  "View" link. This changes it to match the announcement email.
- Makes the interests show up separated by commas and with the #tag
