### PR TITLE
Subscribe author to new announcement

### DIFF
--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -2,6 +2,7 @@ defmodule Constable.Services.AnnouncementCreatorTest do
   use Constable.TestWithEcto, async: false
   alias Constable.Repo
   alias Constable.Announcement
+  alias Constable.Subscription
   alias Constable.Services.AnnouncementCreator
 
   test "creates an announcement with new and existing interests" do
@@ -20,6 +21,22 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     announcement = Repo.one(Announcement) |> Repo.preload([:interests])
     assert announcement_has_interest_named?(announcement, new_interest_name)
     assert announcement_has_interest_named?(announcement, existing_interest.name)
+  end
+
+  test "subscribes the author to the newly created announcement" do
+    user = Forge.saved_user(Repo)
+    announcement_params = %{
+      title: "Title",
+      body: "Body",
+      user_id: user.id
+    }
+
+    AnnouncementCreator.create(announcement_params, [])
+
+    announcement = Repo.one(Announcement)
+    subscription = Repo.one(Subscription)
+    assert subscription.user_id == user.id
+    assert subscription.announcement_id == announcement.id
   end
 
   test "does not create blank interests" do

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -4,10 +4,12 @@ defmodule Constable.Services.AnnouncementCreator do
   alias Constable.Interest
   alias Constable.AnnouncementInterest
   alias Constable.Announcement
+  alias Constable.Subscription
 
   def create(announcement_params, interest_names) do
     create_announcement(announcement_params)
     |> add_interests(interest_names)
+    |> subscribe_author
   end
 
   defp create_announcement(params) do
@@ -19,6 +21,15 @@ defmodule Constable.Services.AnnouncementCreator do
     interest_names
     |> get_or_create_interests
     |> associate_interests_with_announcement(announcement)
+    announcement
+  end
+
+  defp subscribe_author(announcement) do
+    Subscription.changeset(%{
+      user_id: announcement.user_id,
+      announcement_id: announcement.id
+    })
+    |> Repo.insert
     announcement
   end
 


### PR DESCRIPTION
Before the author had to subscribe themselves, but that was not
intuitive. This makes it so that the author is susbscribed to their own
announcement.
