### PR TITLE
Set up TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+addons:
+  postgresql: '9.3'
+branches:
+  only:
+  - master
+install:
+- MIX_ENV=test bin/setup
+language: elixir
+notifications:
+  email: false
+  slack:
+    secure: WzgbZxJJRmbZ+DjmL/tQ0WdtDogqO0aAOg6Ziv0pvGK6+A/uNmIheVXvoLQQjhuRgz2B7Rj5vB1HioKkR4WodEbf7efnJBXlifOOGLBQZvRlbXPcQgV0TNjcu6wQpltZ5vpXuIzGH934eIesNOlikcnrRZeDVmM+sON/+q6+1bQ=
+otp_release:
+- 17.4
+sudo: false

--- a/bin/setup
+++ b/bin/setup
@@ -7,6 +7,7 @@ set -e
 cp .sample.env .env
 
 # Set up phoenix
+mix local.hex --force
 mix deps.get
 mix deps.compile
 mix compile
@@ -15,10 +16,12 @@ mix compile
 mix ecto.create
 mix ecto.migrate
 
-# Set up heroku
+# Only if this isn't CI
+if [ -z "$CI" ]; then
+  # Set up Heroku
+  heroku join --app constable-api-staging
+  heroku git:remote -r staging -a constable-api-staging
 
-heroku join --app constable-api-staging
-heroku git:remote -r staging -a constable-api-staging
-
-heroku join --app constable-api-production
-heroku git:remote -r production -a constable-api-production
+  heroku join --app constable-api-production
+  heroku git:remote -r production -a constable-api-production
+fi


### PR DESCRIPTION
Why:
- Have nice testing and deployment pipeline.

How it addresses the need:
- Set up TravisCI.
- Re-use `bin/setup` on CI for environment parity.
- Don't run Heroku commands on CI; they are meant for individuals.
- Use same Postgres version as Heroku Postgres production database.
- Don't send email; prefer Slack.
- Use container-based architecture to
  start up faster,
  allow the use of caches,
  disallow the use of `sudo`.
  http://docs.travis-ci.com/user/workers/container-based-infrastructure/
- Force install without shell prompt
  to avoid `Shall I install hex? [Yn]` hanging.
  http://elixir-lang.org/docs/stable/mix/Mix.Tasks.Local.Hex.html
