### PR TITLE
Temporarily bring back serializers

### DIFF
--- a/web/models/serializers/announcement.ex
+++ b/web/models/serializers/announcement.ex
@@ -1,0 +1,26 @@
+defimpl Poison.Encoder, for: Constable.Announcement do
+  alias Constable.Repo
+  @attributes ~W(
+    id
+    title
+    body
+    user
+    comments
+    interests
+    inserted_at
+    updated_at
+  )a
+
+  def encode(announcement, _options) do
+    announcement
+    |> Repo.preload([:comments, :user, :interests])
+    |> Map.take(@attributes)
+    |> set_interests
+    |> Poison.encode!
+  end
+
+  def set_interests(announcement) do
+    interest_names = Enum.map(announcement.interests, fn (interest) -> interest.name end)
+    Map.put(announcement, "interests", interest_names)
+  end
+end

--- a/web/models/serializers/comment.ex
+++ b/web/models/serializers/comment.ex
@@ -1,0 +1,7 @@
+defimpl Poison.Encoder, for: Constable.Comment do
+  @attributes ~W(id body user announcement_id inserted_at)a
+
+  def encode(comment, _options) do
+    comment |> Map.take(@attributes) |> Poison.encode!
+  end
+end

--- a/web/models/serializers/interest.ex
+++ b/web/models/serializers/interest.ex
@@ -1,0 +1,8 @@
+defimpl Poison.Encoder, for: Constable.Interest do
+  def encode(interest, _options) do
+    %{
+      id: interest.id,
+      name: interest.name
+    } |> Poison.encode!
+  end
+end

--- a/web/models/serializers/serializers.ex
+++ b/web/models/serializers/serializers.ex
@@ -1,0 +1,7 @@
+defmodule Constable.Serializers do
+  def ids_as_keys(objects) do
+    Enum.reduce(objects, %{}, fn(object, objects) ->
+      Map.put(objects, to_string(object.id), object)
+    end)
+  end
+end

--- a/web/models/serializers/subscription.ex
+++ b/web/models/serializers/subscription.ex
@@ -1,0 +1,9 @@
+defimpl Poison.Encoder, for: Constable.Subscription do
+  def encode(subscription, _options) do
+    %{
+      id: subscription.id,
+      user_id: subscription.user_id,
+      announcement_id: subscription.announcement_id
+    } |> Poison.encode!
+  end
+end

--- a/web/models/serializers/user.ex
+++ b/web/models/serializers/user.ex
@@ -1,0 +1,12 @@
+defimpl Poison.Encoder, for:  Constable.User do
+  def encode(user, _options) do
+    %{
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      gravatar_url: Exgravatar.generate(user.email),
+      user_interests: user.user_interests,
+      subscriptions: user.subscriptions
+    } |> Poison.encode!([])
+  end
+end

--- a/web/models/serializers/user_interest.ex
+++ b/web/models/serializers/user_interest.ex
@@ -1,0 +1,9 @@
+defimpl Poison.Encoder, for: Constable.UserInterest do
+  def encode(user_interest, _options) do
+    %{
+      id: user_interest.id,
+      user_id: user_interest.user_id,
+      interest_id: user_interest.interest_id
+    } |> Poison.encode!
+  end
+end


### PR DESCRIPTION
This temporarily brings serializers back into the application until the
websocket API is replaced by the REST api.
