### PR TITLE
Fix failures with double #

### DIFF
--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -9,7 +9,10 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     user = Forge.saved_user(Repo)
     existing_interest = Forge.saved_interest(Repo)
     new_interest_name = "foo"
-    interest_names = [existing_interest.name, new_interest_name]
+    interest_name_with_hash = "#everyone"
+    duplicate_interest = "#foo"
+    interest_names =
+      [existing_interest.name, new_interest_name, interest_name_with_hash, duplicate_interest]
     announcement_params = %{
       title: "Title",
       body: "Body",
@@ -21,6 +24,7 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     announcement = Repo.one(Announcement) |> Repo.preload([:interests])
     assert announcement_has_interest_named?(announcement, new_interest_name)
     assert announcement_has_interest_named?(announcement, existing_interest.name)
+    assert announcement_has_interest_named?(announcement, "everyone")
   end
 
   test "subscribes the author to the newly created announcement" do

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -35,24 +35,16 @@ defmodule Constable.Services.AnnouncementCreator do
 
   defp get_or_create_interests(names) do
     List.wrap(names)
-    |> Enum.uniq
     |> Enum.reject(&blank_interest?/1)
     |> Enum.map(fn(name) ->
-      get_interest_by_name(name) || create_interest(%{name: name})
+      Repo.get_or_insert(Interest.changeset(%{name: name}))
     end)
+    |> Enum.uniq
   end
 
   defp blank_interest?(" " <> rest), do: blank_interest?(rest)
   defp blank_interest?(""), do: true
   defp blank_interest?(_), do: false
-
-  defp create_interest(params) do
-    Interest.changeset(%Interest{}, params) |> Repo.insert!
-  end
-
-  defp get_interest_by_name(interest_name) do
-    Repo.get_by(Interest, name: interest_name)
-  end
 
   defp associate_interests_with_announcement(interests, announcement) do
     Enum.each(interests, fn(interest) ->


### PR DESCRIPTION
Why?

When an interest already existed and the user attempted to add the
interest and accidentally included the "#" in the name, it would fail to
create any interests for that announcement

How does this address the need?

It uses `Repo.get_or_insert` to make sure that it is checking for
existing interests without a "#"
