### PR TITLE
Use https gravatar url

### DIFF
--- a/web/models/serializers/user.ex
+++ b/web/models/serializers/user.ex
@@ -8,7 +8,7 @@ defimpl Poison.Encoder, for:  Constable.User do
       id: user.id,
       email: user.email,
       name: user.name,
-      gravatar_url: Exgravatar.generate(user.email),
+      gravatar_url: Exgravatar.generate(user.email, %{}, true),
       user_interests: user.user_interests,
       subscriptions: user.subscriptions
     } |> Poison.encode!([])


### PR DESCRIPTION
Production is getting mixed content warnings from gravatars being served
from http instead of https. This tells Exgravatar to generate gravatars
using https instead of http.
