### PR TITLE
Add basic daily digest email

### DIFF
--- a/lib/constable_api/time.ex
+++ b/lib/constable_api/time.ex
@@ -1,0 +1,19 @@
+defmodule Constable.Time do
+  alias Timex.Date
+
+  def now do
+    Date.now |> to_ecto
+  end
+
+  def yesterday do
+    days_ago(1)
+  end
+
+  def days_ago(count) do
+    Date.now |> Date.shift(days: -count) |> to_ecto
+  end
+
+  def to_ecto(date) do
+    date |> Timex.Date.Convert.to_erlang_datetime |> Ecto.DateTime.from_erl
+  end
+end

--- a/lib/mix/tasks/send_daily_digest.ex
+++ b/lib/mix/tasks/send_daily_digest.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Constable.SendDailyDigest do
+  use Mix.Task
+  import Ecto.Query
+
+  def run(_) do
+    Mix.Task.run "app.start"
+    users = Constable.Repo.all(Constable.User)
+    Constable.DailyDigest.send_email(users)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule Constable.Mixfile do
       {:phoenix_html, "~> 1.4"},
       {:phoenix, "~> 0.16.1"},
       {:postgrex, ">= 0.0.0"},
+      {:timex, "~> 0.19.0"},
       {:secure_random, "~> 0.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"blacksmith": {:hex, :blacksmith, "0.1.3"},
+  "combine": {:hex, :combine, "0.5.2"},
   "cowboy": {:hex, :cowboy, "1.0.2"},
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decimal": {:hex, :decimal, "1.1.0"},
@@ -21,4 +22,6 @@
   "postgrex": {:hex, :postgrex, "0.9.1"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "secure_random": {:hex, :secure_random, "0.1.1"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "timex": {:hex, :timex, "0.19.2"},
+  "tzdata": {:hex, :tzdata, "0.1.7"}}

--- a/test/lib/constable/time_test.exs
+++ b/test/lib/constable/time_test.exs
@@ -1,0 +1,17 @@
+defmodule Constable.TimeTest do
+  use ExUnit.Case, async: true
+
+  test "today returns todays date in Ecto.DateTime format" do
+    assert Constable.Time.now == Constable.Time.to_ecto(Timex.Date.now)
+  end
+
+  test "today returns yesterdays date in Ecto.DateTime format" do
+    yesterday = Timex.Date.now |> Timex.Date.shift(days: -1) |> Constable.Time.to_ecto
+    assert Constable.Time.yesterday == yesterday
+  end
+
+  test "to_ecto turns Timex dates into ecto dates" do
+    converted_time = Timex.Date.now |> Constable.Time.to_ecto
+    assert converted_time.__struct__ == Ecto.DateTime
+  end
+end

--- a/test/services/daily_digest_test.exs
+++ b/test/services/daily_digest_test.exs
@@ -1,0 +1,72 @@
+defmodule Constable.DailyDigestTest do
+  use Constable.ModelCase, async: false
+  require Forge
+  alias Timex.Date
+  alias Constable.Repo
+  alias Constable.Mandrill
+  alias Constable.DailyDigest
+
+  defmodule FakeMandrill do
+    def message_send(message_params) do
+      send self, {:to, message_params.to}
+      send self, {:subject, message_params.subject}
+      send self, {:from_email, message_params.from_email}
+      send self, {:from_name, message_params.from_name}
+      send self, {:html, message_params.html}
+      send self, {:text, message_params.text}
+    end
+  end
+
+  test "does not send email if there are no new announcements" do
+    Repo.delete_all(Constable.Announcement)
+    Pact.override(self, :mailer, FakeMandrill)
+    Forge.saved_user(Repo)
+    users = [Forge.saved_user(Repo)]
+
+    DailyDigest.send_email(users)
+
+    refute_receive {:to, _}
+  end
+
+  test "includes interests and announcements from the last 24 hours" do
+    Pact.override(self, :mailer, FakeMandrill)
+    author = Forge.saved_user(Repo)
+    users = [Forge.saved_user(Repo)]
+    old_interest = Forge.saved_interest(Repo, inserted_at: yesterday)
+    new_interest = Forge.saved_interest(Repo, inserted_at: today)
+    Forge.having(user_id: author.id) do
+      old_announcement = Forge.saved_announcement(Repo, inserted_at: yesterday)
+      new_announcement = Forge.saved_announcement(Repo, inserted_at: today)
+    end
+
+    DailyDigest.send_email(users)
+
+    subject = "Daily Digest"
+    from_name = "Constable (thoughtbot)"
+    from_email = "constable@#{System.get_env("EMAIL_DOMAIN")}"
+    users = Mandrill.format_users(users)
+    assert_receive {:to, ^users}
+    assert_receive {:subject, ^subject}
+    assert_receive {:from_name, ^from_name}
+    assert_receive {:from_email, ^from_email}
+    assert_receive {:html, email_html_body}
+    assert_receive {:text, email_text_body}
+
+    assert email_html_body =~ new_interest.name
+    assert email_text_body =~ new_interest.name
+    assert email_html_body =~ new_announcement.title
+    assert email_text_body =~ new_announcement.title
+    refute email_html_body =~ old_interest.name
+    refute email_text_body =~ old_interest.name
+    refute email_html_body =~ old_announcement.title
+    refute email_text_body =~ old_announcement.title
+  end
+
+  def today do
+    Constable.Time.now
+  end
+
+  def yesterday do
+    Constable.Time.yesterday
+  end
+end

--- a/test/support/forge.ex
+++ b/test/support/forge.ex
@@ -13,7 +13,7 @@ defmodule Forge do
 
   register :announcement,
     __struct__: Announcement,
-    title: "Post Title",
+    title: Sequence.next(:email, &"Post Title#{&1}"),
     body: "Post Body",
     inserted_at: Ecto.DateTime.utc,
     updated_at: Ecto.DateTime.utc

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -10,7 +10,7 @@ defmodule Constable.Mailers.Base do
     [front_end_uri: System.get_env("FRONT_END_URI")]
   end
 
-  defp email_domain do
+  def email_domain do
     System.get_env("EMAIL_DOMAIN")
   end
 end

--- a/web/services/daily_digest.ex
+++ b/web/services/daily_digest.ex
@@ -1,0 +1,54 @@
+defmodule Constable.DailyDigest do
+  alias Constable.Repo
+  alias Constable.Mandrill
+  alias Constable.Announcement
+  alias Constable.Time
+  alias Constable.Interest
+  import Ecto.Query
+  import Constable.Mailers.Base
+
+  @template_base "web/templates/mailers/daily_digest"
+
+  def send_email(users) do
+    if length(new_announcements) > 0 do
+      %{
+        from_email: "constable@#{email_domain}",
+        from_name: "Constable (thoughtbot)",
+        html: email_html,
+        text: email_text,
+        subject: "Daily Digest",
+        to: Mandrill.format_users(users),
+        tags: ["daily-digest"]
+      }
+      |> Pact.get(:mailer).message_send
+    end
+  end
+
+  defp email_text do
+    render_template("digest.text",
+      interests: new_interests,
+      announcements: new_announcements
+    )
+  end
+
+  defp email_html do
+    render_template("digest.html",
+      interests: new_interests,
+      announcements: new_announcements
+    )
+  end
+
+  defp new_interests do
+    Repo.all(from i in Interest, where: i.inserted_at > ^Time.yesterday)
+  end
+
+  defp new_announcements do
+    Repo.all(from i in Announcement, where: i.inserted_at > ^Time.yesterday)
+    |> Repo.preload(:user)
+  end
+
+  defp render_template(path, bindings) do
+    bindings = Dict.merge(default_bindings, bindings)
+    EEx.eval_file("#{@template_base}/#{path}.eex", bindings)
+  end
+end

--- a/web/templates/mailers/daily_digest/digest.html.eex
+++ b/web/templates/mailers/daily_digest/digest.html.eex
@@ -1,0 +1,186 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width" />
+    <title>Constable comment</title>
+    <style>
+      * {
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        text-decoration: none; !important;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5 {
+        margin-bottom: .5em; !important;
+      }
+
+      @media (max-width: 320px) {
+
+        /* Forces the button to full width */
+
+        .btn-full {
+          width: 100% !important;
+        }
+      }
+
+      @media (max-width: 600px) {
+
+        /* Typography */
+
+        table {
+          font-size: 12px !important;
+        }
+
+        h1 {
+          font-size: 20px !important;
+        }
+
+        h2 {
+          font-size: 18px !important;
+        }
+
+        h3 {
+          font-size: 16px !important; }
+
+        h4 {
+          font-size: 14px !important; }
+
+        h5 {
+          font-size: 14px !important;
+        }
+
+        /* Makes fixed width items flexible */
+
+        .flex-size {
+          width: 100% !important;
+        }
+
+        /* Contains content images */
+
+        .flex-size img {
+          max-width: 100% !important;
+        }
+      }
+    </style>
+  </head>
+
+  <body leftmargin="0" marginwidth="0" marginheight="0" offset="0" topmargin="0" style="padding: 0;">
+    <table bgcolor="#fefefe" border="0" cellspacing="0" cellpadding="0" width="100%">
+      <tr>
+        <td>
+          <center>
+          <!-- ===================================== -->
+          <!-- Header Includes -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Header Container -->
+          <!-- ===================================== -->
+          <table bgcolor='#2e303b' border='0' cellpadding='0' cellspacing='0' style='border-bottom: 1px solid #727791;' width='100%'>
+            <tr>
+              <td></td>
+            </tr>
+          </table>
+          <!-- ===================================== -->
+          <!-- Announcement Include -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Announcement Container -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Content Name -->
+          <!-- ===================================== -->
+          <table border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #666A80; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;' width='700'>
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='35'></td>
+            </tr>
+            <!-- ===================================== -->
+            <!-- Content -->
+            <!-- ===================================== -->
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='10'></td>
+            </tr>
+            <tr>
+              <td width='40'></td>
+              <td align='left'>
+                <h4>Recently added interests</h4>
+
+                <ul>
+                  <%= for interest <- interests do %>
+                    <li>#<%= interest.name %></li>
+                  <% end %>
+                </ul>
+
+                <h4>Recently added announcements</h4><!-- Change to h4 to match interests -->
+                <ul>
+                  <%= for announcement <- announcements do %>
+                    <li>
+                      <a href="<%= front_end_uri %>/announcements/<%= announcement.id %>" style='color: #c32f34;'>
+                        <%= announcement.title %>
+                      </a>
+                      posted by <strong><%= announcement.user.name %></strong>
+                    </li>
+                  <% end %>
+                </ul>
+
+              </td>
+              <td width='40'></td>
+            </tr>
+            <!-- ===================================== -->
+            <!-- Closing -->
+            <!-- ===================================== -->
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='45'></td>
+            </tr>
+            <tr>
+              <td width='40'></td>
+              <td align='center'>
+                <a href='<%= front_end_uri %>/announcements %>' style='color: #c32f34;'>
+                  <h4 style='#c32f34 font-size: 18px; margin: 0; padding-bottom: 5px;'>
+                    View Interests and Announcements on Constable
+                  </h4>
+                </a>
+              </td>
+              <td width='40'></td>
+            </tr>
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='45'></td>
+            </tr>
+          </table>
+          <!-- ===================================== -->
+          <!-- Footer Include -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Footer Container -->
+          <!-- ===================================== -->
+          <table bgcolor='#ffffff' border='0' cellpadding='0' cellspacing='0' width='100%'>
+            <tr>
+              <td>
+                <!-- ===================================== -->
+                <!-- Footer Content -->
+                <!-- ===================================== -->
+                <table align='center' border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #d4d4d4; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5; font-size: 14px;' width='700'>
+                  <!-- Vertical Spacer -->
+                  <tr>
+                    <td colspan='3' height='30'></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          </center>
+        </td>
+      </tr>
+    </table>
+  </body>

--- a/web/templates/mailers/daily_digest/digest.text.eex
+++ b/web/templates/mailers/daily_digest/digest.text.eex
@@ -1,0 +1,22 @@
+# Daily digest of new Interests and Announcements
+
+New Interests
+-------------
+
+<%= for interest <- interests do %>
+#<%= interest.name %>
+<% end %>
+
+
+New Announcements
+-----------------
+
+<%= for announcement <- announcements do %>
+<%= announcement.title %> - <%= front_end_uri %>/announcements/<%= announcement.id %>
+posted by <%= announcement.user.name %>
+
+<% end %>
+
+
+View Interests and Announcements on Constable
+<%= front_end_uri %>/announcements


### PR DESCRIPTION
This introduces the daily digest email, which is a daily email that mentions newly added interests, and displays/links announcements made since the past digest email.
