### PR TITLE
Upgrade Hackney to 1.3.0

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,3 +1,3 @@
-erlang_version=17.2
-elixir_version=1.0.2
+erlang_version=18.0.2
+elixir_version=1.0.5
 always_rebuild=true

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule Constable.Mixfile do
       {:phoenix, "~> 0.16.1"},
       {:postgrex, ">= 0.0.0"},
       {:timex, "~> 0.19.0"},
-      {:secure_random, "~> 0.1"}
+      {:secure_random, "~> 0.1"},
+      {:httpoison, github: "edgurgel/httpoison", override: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "exgravatar": {:hex, :exgravatar, "0.2.0"},
   "faker": {:hex, :faker, "0.5.1"},
   "hackney": {:hex, :hackney, "1.3.1"},
-  "httpoison": {:hex, :httpoison, "0.7.2"},
+  "httpoison": {:git, "git://github.com/edgurgel/httpoison.git", "fb0daee6729fd3402634da5a8dd9b04d18cba6d6", []},
   "idna": {:hex, :idna, "1.0.2"},
   "oauth2": {:hex, :oauth2, "0.2.0"},
   "pact": {:hex, :pact, "0.1.0"},


### PR DESCRIPTION
When sending requests through `https` the request will fail due to the
reason `unknown ca`. This is a known issue with hackney not support
partial chains in the ssl handshake process.

This upgrades and overrides Hackney to the 1.3.0 until a new version of
HTTPoison is released that includes the updated version of Hackney.
