### PR TITLE
Add basic API

### DIFF
--- a/lib/auth_plug.ex
+++ b/lib/auth_plug.ex
@@ -1,0 +1,36 @@
+defmodule Constable.AuthPlug do
+  import Plug.Conn
+  import Ecto.Query
+
+  alias Constable.Repo
+  alias Constable.User
+
+  def init(default), do: default
+
+  def call(conn, _) do
+    case find_user(conn) do
+      nil ->
+        unauthorized(conn)
+      user ->
+        conn |> assign(:current_user, user)
+    end
+  end
+
+  def find_user(conn) do
+    fetch_token(conn)
+    |> find_user_from_token
+  end
+
+  def fetch_token(conn) do
+    get_req_header(conn, "authorization") |> List.first
+  end
+
+  def find_user_from_token(nil), do: nil
+  def find_user_from_token(token) do
+    Repo.get_by(User, token: token)
+  end
+
+  def unauthorized(conn) do
+    conn |> send_resp(401, "") |> halt
+  end
+end

--- a/test/controllers/api/announcement_controller_test.exs
+++ b/test/controllers/api/announcement_controller_test.exs
@@ -1,0 +1,100 @@
+defmodule Constable.Api.AnnouncementControllerTest do
+  use Constable.ConnCase
+
+  alias Constable.Announcement
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#index lists all announcements", %{conn: conn, user: user} do
+    Forge.saved_announcement(Repo, id: 1, user_id: user.id)
+    Forge.saved_announcement(Repo, id: 2, user_id: user.id)
+    conn = get conn, announcement_path(conn, :index)
+
+    ids = fetch_json_ids(conn)
+
+    assert ids == [1, 2]
+  end
+
+  test "#show renders single announcement", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, id: 1, user_id: user.id)
+
+    conn = get conn, announcement_path(conn, :show, announcement.id)
+    assert json_response(conn, 200)["data"]["id"] == announcement.id
+  end
+
+  test "#create with valid attributes saves an announcement", %{conn: conn} do
+    conn = post conn, announcement_path(conn, :create), %{
+      announcement: %{
+        title: "Foo",
+        body: "#bar",
+      },
+      interest_names: ["foo"]
+    }
+
+    json_response(conn, 201)["data"]
+    announcement = Repo.one(Announcement) |> Repo.preload(:interests)
+    interest_names = Enum.map(announcement.interests, fn(interest) ->
+      interest.name
+    end)
+
+    assert announcement.title == "Foo"
+    assert announcement.body == "#bar"
+    assert interest_names == ["foo"]
+  end
+
+  test "#create with invalid attributes renders errors", %{conn: conn} do
+    conn = post conn, announcement_path(conn, :create), announcement: %{}, interest_names: %{}
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "#update with valid attributes updates announcement", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id, title: "Foo")
+
+    put conn, announcement_path(conn, :update, announcement), announcement: %{
+      title: "Foobar"
+    }
+
+    announcement = Repo.one(Announcement)
+
+    assert announcement.title == "Foobar"
+  end
+
+  test "#update with invalid attributes renders errors", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id, title: "Foo")
+
+    conn = put conn, announcement_path(conn, :update, announcement), announcement: %{
+      title: nil,
+      body: nil
+    }
+
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "#update only creator can update attributes", %{conn: conn} do
+    other_user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: other_user.id, title: "Foo")
+
+    conn = put conn, announcement_path(conn, :update, announcement), announcement: %{}
+
+    assert response(conn, 401)
+  end
+
+  test "#delete deletes announcement", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id, title: "Foo")
+
+    conn = delete conn, announcement_path(conn, :delete, announcement)
+
+    assert response(conn, 204)
+  end
+
+  test "#delete only owner can delete announcement", %{conn: conn} do
+    other_user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: other_user.id, title: "Foo")
+
+    conn = delete conn, announcement_path(conn, :delete, announcement)
+
+    assert response(conn, 401)
+  end
+end

--- a/test/controllers/api/comment_controller_test.exs
+++ b/test/controllers/api/comment_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule Constable.Api.CommentControllerTest do
+  import Ecto.Query
+  use Constable.ConnCase
+
+  alias Constable.Comment
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#create creates a comment for user and announcement", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+
+    post conn, comment_path(conn, :create), comment: %{
+      body: "Foo",
+      announcement_id: announcement.id
+    }
+
+    comment = Repo.one(Comment)
+    assert comment.body == "Foo"
+    assert comment.user_id == user.id
+    assert comment.announcement_id == announcement.id
+  end
+end

--- a/test/controllers/api/interest_controller_test.exs
+++ b/test/controllers/api/interest_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule Constable.Api.InterestControllerTest do
+  use Constable.ConnCase
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#index displays all interests", %{conn: conn} do
+    Forge.saved_interest(Repo, id: 1)
+    Forge.saved_interest(Repo, id: 2)
+
+    conn = get conn, interest_path(conn, :index)
+    ids = fetch_json_ids(conn)
+
+    assert ids == [1, 2]
+  end
+
+  test "#show displays a single interest", %{conn: conn} do
+    interest = Forge.saved_interest(Repo)
+
+    conn = get conn, interest_path(conn, :show, interest.id)
+    assert json_response(conn, 200)["data"]["id"] == interest.id
+  end
+end

--- a/test/controllers/api/subscription_controller_test.exs
+++ b/test/controllers/api/subscription_controller_test.exs
@@ -1,0 +1,60 @@
+defmodule Constable.Api.SubscriptionControllerTest do
+  import Ecto.Query
+  use Constable.ConnCase
+
+  alias Constable.Subscription
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#index shows all current users subscriptions", %{conn: conn, user: user} do
+    other_user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    other_announcement = Forge.saved_announcement(Repo, user_id: user.id)
+
+    subscription_1 = Forge.saved_subscription(Repo, user_id: user.id, announcement_id: announcement.id)
+    subscription_2= Forge.saved_subscription(Repo, user_id: user.id, announcement_id: other_announcement.id)
+    Forge.saved_subscription(Repo, user_id: other_user.id, announcement_id: announcement.id)
+
+    conn = get conn, subscription_path(conn, :index)
+
+    json_response(conn, 200)["data"]
+    ids = fetch_json_ids(conn)
+
+    assert ids == [subscription_1.id, subscription_2.id]
+  end
+
+  test "#create subscribes the current user to an announcement", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    conn = post conn, subscription_path(conn, :create), subscription: %{
+      announcement_id: announcement.id
+    }
+
+    json_response(conn, 201)
+
+    subscription = Repo.one!(Subscription)
+
+    assert subscription.user_id == user.id
+    assert subscription.announcement_id == announcement.id
+  end
+
+  test "#delete destroys subscription", %{conn: conn, user: user} do
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    subscription = Forge.saved_subscription(Repo, user_id: user.id, announcement_id: announcement.id)
+
+    conn = delete conn, subscription_path(conn, :delete, subscription.id)
+
+    assert response(conn, 204)
+  end
+
+  test "#delete can only destroys current users subscriptions", %{conn: conn} do
+    user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    subscription = Forge.saved_subscription(Repo, user_id: user.id, announcement_id: announcement.id)
+
+    conn = delete conn, subscription_path(conn, :delete, subscription.id)
+
+    assert response(conn, 401)
+  end
+end

--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule Constable.Api.UserControllerTest do
+  use Constable.ConnCase
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#index returns all users", %{conn: conn, user: user} do
+    other_user = Forge.saved_user(Repo)
+    conn = get conn, user_path(conn, :index)
+
+    json_response(conn, 200)["data"]
+    ids = fetch_json_ids(conn)
+
+    assert ids == [user.id, other_user.id]
+  end
+
+  test "#show returns user", %{conn: conn} do
+    user = Forge.saved_user(Repo)
+    conn = get conn, user_path(conn, :show, user.id)
+
+    assert json_response(conn, 200)["data"]["id"] == user.id
+  end
+
+  test "#show returns current user when id is me", %{conn: conn, user: user} do
+    conn = get conn, user_path(conn, :show, user.id)
+
+    assert json_response(conn, 200)["data"]["id"] == user.id
+  end
+end

--- a/test/controllers/api/user_interest_controller_test.exs
+++ b/test/controllers/api/user_interest_controller_test.exs
@@ -1,0 +1,40 @@
+defmodule Constable.Api.UserInterestControllerTest do
+  use Constable.ConnCase
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "#index returns current users user_interests", %{conn: conn, user: user} do
+    Forge.saved_user_interest(Repo, id: 1, user_id: user.id)
+    Forge.saved_user_interest(Repo, id: 2, user_id: user.id)
+    conn = get conn, user_interest_path(conn, :index)
+
+    json_response(conn, 200)["data"]
+    ids = fetch_json_ids(conn)
+
+    assert ids == [1, 2]
+  end
+
+  test "#show returns invidual interest", %{conn: conn} do
+    user_interest = Forge.saved_user_interest(Repo, id: 2)
+    conn = get conn, user_interest_path(conn, :show, user_interest.id)
+
+    assert json_response(conn, 200)["data"]["id"] == user_interest.id
+  end
+
+  test "#destroy destroys a user interest", %{conn: conn, user: user} do
+    user_interest = Forge.saved_user_interest(Repo, id: 2, user_id: user.id)
+    conn = delete conn, user_interest_path(conn, :delete, user_interest.id)
+
+    assert response(conn, 204)
+  end
+
+  test "#destroy only allows current user to destroy user interest", %{conn: conn} do
+    other_user = Forge.saved_user(Repo)
+    user_interest = Forge.saved_user_interest(Repo, id: 2, user_id: other_user.id)
+    conn = delete conn, user_interest_path(conn, :delete, user_interest.id)
+
+    assert response(conn, 401)
+  end
+end

--- a/test/services/daily_digest_test.exs
+++ b/test/services/daily_digest_test.exs
@@ -1,7 +1,6 @@
 defmodule Constable.DailyDigestTest do
   use Constable.ModelCase, async: false
   require Forge
-  alias Timex.Date
   alias Constable.Repo
   alias Constable.Mandrill
   alias Constable.DailyDigest

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -31,6 +31,24 @@ defmodule Constable.ConnCase do
 
       # The default endpoint for testing
       @endpoint Constable.Endpoint
+
+      def authenticate(user \\ nil) do
+        unless user do
+          user = Forge.saved_user(Repo)
+        end
+
+        conn = conn()
+        |> put_req_header("accept", "application/json")
+        |> put_req_header("authorization", user.token)
+        %{conn: conn, user: user}
+      end
+
+      defp fetch_json_ids(conn, status \\ 200) do
+        records = json_response(conn, status)["data"]
+        Enum.map(records, fn(json) ->
+          Map.get(json, "id")
+        end)
+      end
     end
   end
 

--- a/test/views/api/announcement_view_test.exs
+++ b/test/views/api/announcement_view_test.exs
@@ -1,0 +1,27 @@
+defmodule Constable.Api.AnnouncementViewTest do
+  use Constable.ViewCase, async: true
+  alias Constable.Api.AnnouncementView
+
+  test "show.json returns correct fields" do
+    user = Forge.user
+    interest = Forge.interest
+    announcement = Forge.announcement(user: user, interests: [interest])
+    comment = Forge.comment(announcement: announcement, user: user)
+    announcement = Map.put(announcement, :comments, [comment])
+
+    rendered_announcement = render_one(announcement, AnnouncementView, "show.json")
+
+    assert rendered_announcement == %{
+      data: %{
+        id: announcement.id,
+        title: announcement.title,
+        body: announcement.body,
+        inserted_at: announcement.inserted_at,
+        updated_at: announcement.updated_at,
+        user: announcement.user_id,
+        comments: [comment.id],
+        interests: [interest.id],
+      }
+    }
+  end
+end

--- a/test/views/api/comment_view_test.exs
+++ b/test/views/api/comment_view_test.exs
@@ -1,0 +1,21 @@
+defmodule Constable.Api.CommentViewTest do
+  use Constable.ViewCase, async: true
+  alias Constable.Api.CommentView
+
+  test "show.json returns correct fields" do
+    user = Forge.user
+    announcement = Forge.announcement(user: user)
+    comment = Forge.comment(announcement: announcement, user: user)
+
+    rendered_comment = render_one(comment, CommentView, "show.json")
+
+    assert rendered_comment == %{
+      data: %{
+        id: comment.id,
+        body: comment.body,
+        announcement_id: announcement.id,
+        user_id: user.id,
+      }
+    }
+  end
+end

--- a/test/views/api/interest_view_test.exs
+++ b/test/views/api/interest_view_test.exs
@@ -1,0 +1,17 @@
+defmodule Constable.Api.InterestViewTest do
+  use Constable.ViewCase, async: true
+  alias Constable.Api.InterestView
+
+  test "show.json returns correct fields" do
+    interest = Forge.interest
+
+    rendered_interest = render_one(interest, InterestView, "show.json")
+
+    assert rendered_interest == %{
+      data: %{
+        id: interest.id,
+        name: interest.name,
+      }
+    }
+  end
+end

--- a/test/views/api/subscription_view_test.exs
+++ b/test/views/api/subscription_view_test.exs
@@ -1,0 +1,20 @@
+defmodule Constable.Api.SubscriptionViewTest do
+  use Constable.ViewCase, async: true
+  alias Constable.Api.SubscriptionView
+
+  test "show.json returns correct fields" do
+    user = Forge.user
+    announcement = Forge.announcement(user: user)
+    subscription = Forge.subscription(announcement: announcement, user: user)
+
+    rendered_subscription = render_one(subscription, SubscriptionView, "show.json")
+
+    assert rendered_subscription == %{
+      data: %{
+        id: subscription.id,
+        announcement_id: announcement.id,
+        user_id: user.id,
+      }
+    }
+  end
+end

--- a/test/views/api/user_interest_view_test.exs
+++ b/test/views/api/user_interest_view_test.exs
@@ -1,0 +1,20 @@
+defmodule Constable.Api.UserInterestViewTest do
+  use Constable.ViewCase, async: true
+  alias Constable.Api.UserInterestView
+
+  test "show.json returns correct fields" do
+    user = Forge.user
+    interest = Forge.interest
+    user_interest = Forge.user_interest(user: user, interest: interest)
+
+    rendered_user_interest = render_one(user_interest, UserInterestView, "show.json")
+
+    assert rendered_user_interest == %{
+      data: %{
+        id: user_interest.id,
+        interest_id: interest.id,
+        user_id: user.id,
+      }
+    }
+  end
+end

--- a/test/views/api/user_view_test.exs
+++ b/test/views/api/user_view_test.exs
@@ -1,0 +1,24 @@
+defmodule Constable.Api.UserViewTest do
+  use Constable.ViewCase, async: false
+  alias Constable.Api.UserView
+
+  test "show.json returns correct fields" do
+    user_interest = Forge.user_interest
+    subscription = Forge.subscription
+    user = Forge.saved_user(Repo)
+      |> Map.put(:user_interests, [user_interest])
+      |> Map.put(:subscriptions, [subscription])
+
+    rendered_user = render_one(user, UserView, "show.json")
+
+    assert rendered_user == %{
+      data: %{
+        id: user.id,
+        name: user.name,
+        gravatar_url: Exgravatar.generate(user.email),
+        user_interests: [user_interest.id],
+        subscriptions: [subscription.id]
+      }
+    }
+  end
+end

--- a/web/channels/announcement_channel.ex
+++ b/web/channels/announcement_channel.ex
@@ -20,11 +20,12 @@ defmodule Constable.AnnouncementChannel do
   end
 
   def handle_in("create", %{"announcement" => announcement_params}, socket) do
-    announcement =
+    {:ok, announcement} =
       announcement_params
       |> Map.merge(%{"user_id" => current_user_id(socket)})
       |> AnnouncementCreator.create(announcement_params["interests"])
-      |> preload_associations
+
+    announcement = announcement |> preload_associations
 
     Pact.get(:announcement_mailer).created(announcement)
 

--- a/web/channels/comment_channel.ex
+++ b/web/channels/comment_channel.ex
@@ -42,7 +42,7 @@ defmodule Constable.CommentChannel do
   end
 
   defp subscribe_author(comment) do
-    Subscription.changeset(%{
+    Subscription.changeset(:create, %{
       user_id: comment.user_id,
       announcement_id: comment.announcement_id
     }) |> Repo.get_or_insert

--- a/web/channels/subscription_channel.ex
+++ b/web/channels/subscription_channel.ex
@@ -15,7 +15,7 @@ defmodule Constable.SubscriptionChannel do
 
   def handle_in("create", %{"subscription" =>  subscription}, socket) do
     user_id = current_user_id(socket)
-    subscription = Subscription.changeset(%{
+    subscription = Subscription.changeset(:create, %{
       user_id: user_id,
       announcement_id: Map.get(subscription, "announcement_id")
     }) |> Repo.insert!

--- a/web/controllers/api/announcement_controller.ex
+++ b/web/controllers/api/announcement_controller.ex
@@ -1,0 +1,66 @@
+defmodule Constable.Api.AnnouncementController do
+  use Constable.Web, :controller
+
+  alias Constable.Announcement
+  alias Constable.Services.AnnouncementCreator
+
+  plug :scrub_params, "announcement" when action in [:create, :update]
+
+  def index(conn, _params) do
+    announcements = Repo.all(Announcement)
+    render(conn, "index.json", announcements: announcements)
+  end
+
+  def create(conn,
+      %{"announcement" => announcement_params, "interest_names" => interest_names}) do
+    current_user = current_user(conn)
+    announcement_params = Map.put(announcement_params, "user_id", current_user.id)
+
+    case AnnouncementCreator.create(announcement_params, interest_names) do
+      {:ok, announcement} ->
+        conn
+        |> put_status(:created)
+        |> render("show.json", announcement: announcement)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    announcement = Repo.get!(Announcement, id)
+    render conn, "show.json", announcement: announcement
+  end
+
+  def update(conn, %{"id" => id, "announcement" => announcement_params}) do
+    current_user = current_user(conn)
+    announcement = Repo.get!(Announcement, id)
+    changeset = Announcement.changeset(announcement, :update, announcement_params)
+
+    if announcement.user_id == current_user.id do
+      case Repo.update(changeset) do
+        {:ok, announcement} ->
+          render(conn, "show.json", announcement: announcement)
+        {:error, changeset} ->
+          conn
+          |> put_status(:unprocessable_entity)
+          |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+      end
+    else
+      unauthorized(conn)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    current_user = current_user(conn)
+    announcement = Repo.get!(Announcement, id)
+
+    if announcement.user_id == current_user.id do
+      Repo.delete!(announcement)
+      send_resp(conn, 204, "")
+    else
+      unauthorized(conn)
+    end
+  end
+end

--- a/web/controllers/api/comment_controller.ex
+++ b/web/controllers/api/comment_controller.ex
@@ -1,0 +1,23 @@
+defmodule Constable.Api.CommentController do
+  use Constable.Web, :controller
+
+  alias Constable.Comment
+
+  plug :scrub_params, "comment" when action in [:create]
+
+  def create(conn, %{"comment" => params}) do
+    current_user = current_user(conn)
+    params = Map.put(params, "user_id", current_user.id)
+
+    changeset = Comment.changeset(:create, params)
+
+    case Repo.insert(changeset) do
+      {:ok, comment} ->
+        conn |> put_status(201) |> render("show.json", comment: comment)
+      {:error, changeset} ->
+        conn
+        |> put_status(422)
+        |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+end

--- a/web/controllers/api/interest_controller.ex
+++ b/web/controllers/api/interest_controller.ex
@@ -1,0 +1,16 @@
+defmodule Constable.Api.InterestController do
+  use Constable.Web, :controller
+
+  alias Constable.Interest
+
+  def index(conn, _params) do
+    interests = Repo.all(Interest)
+
+    render(conn, "index.json", interests: interests)
+  end
+
+  def show(conn, %{"id" => id}) do
+    interest = Repo.get!(Interest, id)
+    render conn, "show.json", interest: interest
+  end
+end

--- a/web/controllers/api/subscription_controller.ex
+++ b/web/controllers/api/subscription_controller.ex
@@ -1,0 +1,43 @@
+defmodule Constable.Api.SubscriptionController do
+  use Constable.Web, :controller
+
+  alias Constable.Subscription
+
+  def index(conn, _params) do
+    current_user = current_user(conn)
+    subscriptions = subscriptions_for(current_user)
+
+    render conn, "index.json", subscriptions: subscriptions
+  end
+
+  def create(conn, %{"subscription" => params}) do
+    current_user = current_user(conn)
+    params = params |> Map.put("user_id", current_user.id)
+
+    changeset = Subscription.changeset(:create, params)
+
+    case Repo.insert(changeset) do
+      {:ok, subscription} ->
+        conn |> put_status(201) |> render("show.json", subscription: subscription)
+      {:error, changset} ->
+        conn
+        |> put_status(422)
+        |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    current_user = current_user(conn)
+    subscription = Repo.get!(Subscription, id)
+
+    if current_user.id == subscription.user_id do
+      send_resp(conn, 204, "")
+    else
+      unauthorized(conn)
+    end
+  end
+
+  defp subscriptions_for(user) do
+    Repo.all assoc(user, :subscriptions)
+  end
+end

--- a/web/controllers/api/user.ex
+++ b/web/controllers/api/user.ex
@@ -1,0 +1,20 @@
+defmodule Constable.Api.UserController do
+  use Constable.Web, :controller
+
+  alias Constable.User
+
+  def index(conn, _params) do
+    users = Repo.all(User)
+
+    render(conn, "index.json", users: users)
+  end
+
+  def show(conn, %{"id" => "me"}) do
+    current_user = current_user(conn)
+    render(conn, "show.json", user: current_user)
+  end
+  def show(conn, %{"id" => id}) do
+    user = Repo.get!(User, id)
+    render(conn, "show.json", user: user)
+  end
+end

--- a/web/controllers/api/user_interest_controller.ex
+++ b/web/controllers/api/user_interest_controller.ex
@@ -1,0 +1,33 @@
+defmodule Constable.Api.UserInterestController do
+  use Constable.Web, :controller
+
+  alias Constable.UserInterest
+
+  def index(conn, _params) do
+    current_user = current_user(conn)
+    user_interests = user_interests_for(current_user)
+
+    render(conn, "index.json", user_interests: user_interests)
+  end
+
+  def show(conn, %{"id" => id}) do
+    user_interest = Repo.get!(UserInterest, id)
+    render conn, "show.json", user_interest: user_interest
+  end
+
+  def delete(conn, %{"id" => id}) do
+    current_user = current_user(conn)
+    user_interest = Repo.get!(UserInterest, id)
+
+    if current_user.id == user_interest.user_id do
+      Repo.delete!(user_interest)
+      send_resp(conn, 204, "")
+    else
+      unauthorized(conn)
+    end
+  end
+
+  defp user_interests_for(user) do
+    Repo.all assoc(user, :user_interests)
+  end
+end

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -21,7 +21,7 @@ defmodule Constable.Announcement do
   def changeset(announcement, context, params \\ nil)
   def changeset(announcement, :update, params) do
     announcement
-    |> cast(params, ~w(), ~w(title body))
+    |> cast(params, ~w(title body))
   end
 
   def changeset(announcement, :create, params) do

--- a/web/models/subscription.ex
+++ b/web/models/subscription.ex
@@ -9,7 +9,7 @@ defmodule Constable.Subscription do
     timestamps
   end
 
-  def changeset(subscription \\ %__MODULE__{}, params) do
+  def changeset(subscription \\ %__MODULE__{}, _, params) do
     subscription
     |> cast(params, ~w(user_id announcement_id))
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -1,5 +1,6 @@
 defmodule Constable.Router do
   use Phoenix.Router
+  import Ecto.Query
   alias OAuth2.Strategy
 
   pipeline :browser do
@@ -10,10 +11,11 @@ defmodule Constable.Router do
 
   pipeline :api do
     plug :accepts, ~w(json)
+    plug Constable.AuthPlug
   end
 
   scope "/", Constable do
-    pipe_through :browser # Use the default browser stack
+    pipe_through :browser
 
     resources "/email_replies", EmailReplyController, only: [:create]
   end
@@ -23,5 +25,15 @@ defmodule Constable.Router do
 
     get "/", AuthController, :index
     get "/callback", AuthController, :callback
+  end
+
+  scope "/api", alias: Constable.Api do
+    pipe_through :api
+    resources "/announcements", AnnouncementController
+    resources "/comments", CommentController, only: [:create]
+    resources "/interests", InterestController, only: [:index, :show]
+    resources "/subscriptions", SubscriptionController, only: [:index, :create, :delete]
+    resources "/user_interests", UserInterestController, only: [:index, :show, :delete]
+    resources "/user", UserController, only: [:index, :show]
   end
 end

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -7,14 +7,20 @@ defmodule Constable.Services.AnnouncementCreator do
   alias Constable.Subscription
 
   def create(announcement_params, interest_names) do
-    create_announcement(announcement_params)
-    |> add_interests(interest_names)
-    |> subscribe_author
+    case create_announcement(announcement_params) do
+      {:ok, announcement} ->
+        announcement = announcement
+        |> add_interests(interest_names)
+        |> subscribe_author
+
+        {:ok, announcement}
+      error -> error
+    end
   end
 
   defp create_announcement(params) do
     Announcement.changeset(%Announcement{}, :create, params)
-    |> Repo.insert!
+    |> Repo.insert
   end
 
   defp add_interests(announcement, interest_names) do
@@ -25,7 +31,7 @@ defmodule Constable.Services.AnnouncementCreator do
   end
 
   defp subscribe_author(announcement) do
-    Subscription.changeset(%{
+    Subscription.changeset(:create, %{
       user_id: announcement.user_id,
       announcement_id: announcement.id
     })

--- a/web/views/api/announcement_view.ex
+++ b/web/views/api/announcement_view.ex
@@ -1,0 +1,25 @@
+defmodule Constable.Api.AnnouncementView do
+  use Constable.Web, :view
+
+  def render("index.json", %{announcements: announcements}) do
+    %{data: render_many(announcements, Constable.Api.AnnouncementView, "announcement.json")}
+  end
+
+  def render("show.json", %{announcement: announcement}) do
+    %{data: render_one(announcement, Constable.Api.AnnouncementView, "announcement.json")}
+  end
+
+  def render("announcement.json", %{announcement: announcement}) do
+    announcement = announcement |> Repo.preload([:comments, :interests])
+    %{
+      id: announcement.id,
+      title: announcement.title,
+      body: announcement.body,
+      inserted_at: announcement.inserted_at,
+      updated_at: announcement.updated_at,
+      user: announcement.user_id,
+      comments: pluck(announcement.comments, :id),
+      interests: pluck(announcement.interests, :id)
+    }
+  end
+end

--- a/web/views/api/comment_view.ex
+++ b/web/views/api/comment_view.ex
@@ -1,0 +1,20 @@
+defmodule Constable.Api.CommentView do
+  use Constable.Web, :view
+
+  def render("index.json", %{comments: comments}) do
+    %{data: render_many(comments, Constable.Api.CommentView, "comment.json")}
+  end
+
+  def render("show.json", %{comment: comment}) do
+    %{data: render_one(comment, Constable.Api.CommentView, "comment.json")}
+  end
+
+  def render("comment.json", %{comment: comment}) do
+    %{
+      id: comment.id,
+      body: comment.body,
+      announcement_id: comment.announcement_id,
+      user_id: comment.user_id,
+    }
+  end
+end

--- a/web/views/api/interest_view.ex
+++ b/web/views/api/interest_view.ex
@@ -1,0 +1,18 @@
+defmodule Constable.Api.InterestView do
+  use Constable.Web, :view
+
+  def render("index.json", %{interests: interests}) do
+    %{data: render_many(interests, Constable.Api.InterestView, "interest.json")}
+  end
+
+  def render("show.json", %{interest: interest}) do
+    %{data: render_one(interest, Constable.Api.InterestView, "interest.json")}
+  end
+
+  def render("interest.json", %{interest: interest}) do
+    %{
+      id: interest.id,
+      name: interest.name,
+    }
+  end
+end

--- a/web/views/api/subscription_view.ex
+++ b/web/views/api/subscription_view.ex
@@ -1,0 +1,19 @@
+defmodule Constable.Api.SubscriptionView do
+  use Constable.Web, :view
+
+  def render("index.json", %{subscriptions: subscriptions}) do
+    %{data: render_many(subscriptions, Constable.Api.SubscriptionView, "subscription.json")}
+  end
+
+  def render("show.json", %{subscription: subscription}) do
+    %{data: render_one(subscription, Constable.Api.SubscriptionView, "subscription.json")}
+  end
+
+  def render("subscription.json", %{subscription: subscription}) do
+    %{
+      id: subscription.id,
+      user_id: subscription.user_id,
+      announcement_id: subscription.announcement_id
+    }
+  end
+end

--- a/web/views/api/user_interest_view.ex
+++ b/web/views/api/user_interest_view.ex
@@ -1,0 +1,19 @@
+defmodule Constable.Api.UserInterestView do
+  use Constable.Web, :view
+
+  def render("index.json", %{user_interests: user_interests}) do
+    %{data: render_many(user_interests, Constable.Api.UserInterestView, "user_interest.json")}
+  end
+
+  def render("show.json", %{user_interest: user_interest}) do
+    %{data: render_one(user_interest, Constable.Api.UserInterestView, "user_interest.json")}
+  end
+
+  def render("user_interest.json", %{user_interest: user_interest}) do
+    %{
+      id: user_interest.id,
+      user_id: user_interest.user_id,
+      interest_id: user_interest.interest_id
+    }
+  end
+end

--- a/web/views/api/user_view.ex
+++ b/web/views/api/user_view.ex
@@ -1,0 +1,22 @@
+defmodule Constable.Api.UserView do
+  use Constable.Web, :view
+
+  def render("index.json", %{users: users}) do
+    %{data: render_many(users, Constable.Api.UserView, "user.json")}
+  end
+
+  def render("show.json", %{user: user}) do
+    %{data: render_one(user, Constable.Api.UserView, "user.json")}
+  end
+
+  def render("user.json", %{user: user}) do
+    user = user |> Repo.preload([:user_interests, :subscriptions])
+    %{
+      id: user.id,
+      name: user.name,
+      gravatar_url: Exgravatar.generate(user.email),
+      user_interests: pluck(user.user_interests, :id),
+      subscriptions: pluck(user.subscriptions, :id)
+    }
+  end
+end

--- a/web/views/changeset_view.ex
+++ b/web/views/changeset_view.ex
@@ -1,0 +1,9 @@
+defmodule Constable.ChangesetView do
+  use Constable.Web, :view
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: changeset}
+  end
+end

--- a/web/web.ex
+++ b/web/web.ex
@@ -16,8 +16,15 @@ defmodule Constable.Web do
     quote do
       use Phoenix.HTML
       use Phoenix.View, root: "web/templates"
+      alias Constable.Repo
 
       import Constable.Router.Helpers
+
+      def pluck(enumerable, property) do
+        Enum.map(enumerable, fn(object) ->
+          Map.get(object, property)
+        end)
+      end
     end
   end
 
@@ -26,7 +33,18 @@ defmodule Constable.Web do
       use Phoenix.Controller
 
       import Constable.Router.Helpers
+      import Ecto.Query
+      import Ecto.Model
+
       alias Constable.Repo
+
+      def unauthorized(conn) do
+        send_resp(conn, 401, "")
+      end
+
+      def current_user(conn) do
+        conn.assigns[:current_user]
+      end
     end
   end
 


### PR DESCRIPTION
This adds the beginning of the API to support the transition away from channels being the single method of communication to a combination of channels and API.
