### PR TITLE
Comments email subscribers and mentioned users

### DIFF
--- a/priv/repo/migrations/20150825202821_add_username_to_users.exs
+++ b/priv/repo/migrations/20150825202821_add_username_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Constable.Repo.Migrations.AddUsernameToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :username, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20150826133822_add_null_constraint_to_username.exs
+++ b/priv/repo/migrations/20150826133822_add_null_constraint_to_username.exs
@@ -1,0 +1,25 @@
+defmodule Constable.Repo.Migrations.AddNullConstrainToUsername do
+  use Ecto.Migration
+  alias Constable.Repo
+
+  def up do
+    %{rows: users} = Ecto.Adapters.SQL.query(Repo, "SELECT id,email FROM users", [])
+
+    Enum.each(users, fn([id, email]) ->
+      [name, _] = String.split(email, "@")
+
+      query = "UPDATE users SET username = $1 WHERE id = $2"
+      Ecto.Adapters.SQL.query(Repo, query, [name, id])
+    end)
+
+    alter table(:users) do
+      modify :username, :string, null: false
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      modify :username, :string, null: true
+    end
+  end
+end

--- a/test/services/comment_creator_test.exs
+++ b/test/services/comment_creator_test.exs
@@ -1,0 +1,89 @@
+defmodule Constable.Services.CommentCreatorTest do
+  use Constable.TestWithEcto, async: false
+
+  alias Constable.Repo
+  alias Constable.Comment
+  alias Constable.Services.CommentCreator
+
+  defmodule FakeCommentMailer do
+    def created(comment, users) do
+      send self, {:comment, comment}
+      send self, {:users, users}
+    end
+
+    def mentioned(comment, users) do
+      send self, {:mentioned_comment, comment}
+      send self, {:mentioned_users, users}
+    end
+  end
+
+  setup do
+    Pact.override self, :comment_mailer, __MODULE__.FakeCommentMailer
+    {:ok, %{}}
+  end
+
+  test "creates a comment" do
+    user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+
+    CommentCreator.create(%{
+      user_id: user.id,
+      body: "Foo",
+      announcement_id: announcement.id
+    })
+
+    comment = Repo.one(Comment)
+
+    assert comment.user_id == user.id
+    assert comment.announcement_id == announcement.id
+    assert comment.body == "Foo"
+  end
+
+  test "create emails announcement subscribers" do
+    user = Forge.saved_user(Repo)
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    Forge.saved_subscription(Repo, user_id: user.id, announcement_id: announcement.id)
+
+    {:ok, comment} = CommentCreator.create(%{
+      user_id: user.id,
+      body: "Foo",
+      announcement_id: announcement.id
+    })
+
+    assert_receive {:comment, ^comment}
+    assert_receive {:users, [^user]}
+  end
+
+  test "create emails mentioned users" do
+    user = Forge.saved_user(Repo, username: "blake")
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+
+    {:ok, comment} = CommentCreator.create(%{
+      user_id: user.id,
+      body: "Hey @blake, @fakeuser was looking for you.",
+      announcement_id: announcement.id
+    })
+
+    assert_receive {:mentioned_comment, ^comment}
+    assert_receive {:mentioned_users, [^user]}
+  end
+
+  test "create only emails user once if subscribed and mentioned" do
+    user = Forge.saved_user(Repo, username: "blake")
+    announcement = Forge.saved_announcement(Repo, user_id: user.id)
+    Forge.saved_subscription(Repo, user_id: user.id, announcement_id: announcement.id)
+
+    {:ok, comment} = CommentCreator.create(%{
+      user_id: user.id,
+      body: "Hey @blake",
+      announcement_id: announcement.id
+    })
+
+    assert_received {:comment, comment}
+    assert_received {:users, []}
+
+
+    assert_receive {:mentioned_comment, ^comment}
+    assert_receive {:mentioned_users, [^user]}
+  end
+end

--- a/test/views/api/user_view_test.exs
+++ b/test/views/api/user_view_test.exs
@@ -17,7 +17,8 @@ defmodule Constable.Api.UserViewTest do
         name: user.name,
         gravatar_url: Exgravatar.generate(user.email),
         user_interests: [user_interest.id],
-        subscriptions: [subscription.id]
+        subscriptions: [subscription.id],
+        username: user.username
       }
     }
   end

--- a/web/controllers/api/user_controller.ex
+++ b/web/controllers/api/user_controller.ex
@@ -17,4 +17,18 @@ defmodule Constable.Api.UserController do
     user = Repo.get!(User, id)
     render(conn, "show.json", user: user)
   end
+
+  def update(conn, %{"user" => params}) do
+    current_user = current_user(conn)
+    changeset = User.changeset(current_user, params)
+
+    case Repo.update(changeset) do
+      {:ok, user} ->
+        render(conn, "show.json", user: user)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
 end

--- a/web/mailers/comment.ex
+++ b/web/mailers/comment.ex
@@ -6,11 +6,12 @@ defmodule Constable.Mailers.Comment do
 
   @template_base "web/templates/mailers/comments"
 
+  def created(comment, []), do: nil
   def created(comment, users) do
     default_attributes(announcement: comment.announcement, author: comment.user)
     |> Map.merge(%{
-      html: email_html(comment),
-      text: email_text(comment),
+      html: created_html(comment),
+      text: created_text(comment),
       subject: "Re: #{comment.announcement.title}",
       to: Mandrill.format_users(users),
       tags: ["new-comment"]
@@ -18,15 +19,43 @@ defmodule Constable.Mailers.Comment do
     |> Pact.get(:mailer).message_send
   end
 
-  defp email_text(comment) do
+  def mentioned(comment, []), do: nil
+  def mentioned(comment, users) do
+    default_attributes(announcement: comment.announcement, author: comment.user)
+    |> Map.merge(%{
+      html: mentioned_html(comment),
+      text: mentioned_text(comment),
+      subject: "You were mentioned in: #{comment.announcement.title}",
+      to: Mandrill.format_users(users),
+      tags: ["mention"]
+    })
+    |> Pact.get(:mailer).message_send
+  end
+
+  defp created_text(comment) do
     render_template("new.text",
       comment: comment,
       author: comment.user,
     )
   end
 
-  defp email_html(comment) do
+  defp created_html(comment) do
     render_template("new.html",
+      comment: comment,
+      author: comment.user,
+      author_avatar_url: Exgravatar.generate(comment.user.email)
+    )
+  end
+
+  defp mentioned_text(comment) do
+    render_template("mentioned.text",
+      comment: comment,
+      author: comment.user,
+    )
+  end
+
+  defp mentioned_html(comment) do
+    render_template("mentioned.html",
       comment: comment,
       author: comment.user,
       author_avatar_url: Exgravatar.generate(comment.user.email)

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -9,6 +9,7 @@ defmodule Constable.User do
     field :email
     field :token
     field :name
+    field :username
 
     has_many :user_interests, UserInterest, on_delete: :fetch_and_delete
     has_many :subscriptions, Subscription, on_delete: :fetch_and_delete

--- a/web/services/comment_creator.ex
+++ b/web/services/comment_creator.ex
@@ -1,0 +1,43 @@
+defmodule Constable.Services.CommentCreator do
+  alias Constable.Repo
+  alias Constable.Comment
+  alias Constable.Queries
+  alias Constable.User
+
+  def create(params) do
+    changeset = Comment.changeset(:create, params)
+
+    case Repo.insert(changeset) do
+      {:ok, comment} ->
+        mentioned_users = email_mentioned_users(comment)
+        email_subscribers(comment, mentioned_users)
+        {:ok, comment}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp email_subscribers(comment, mentioned_users) do
+    users = find_subscribed_users(comment.announcement_id) -- mentioned_users
+
+    Pact.get(:comment_mailer).created(comment, users)
+    comment
+  end
+
+  defp email_mentioned_users(comment) do
+    users = find_mentioned_users(comment.body)
+    Pact.get(:comment_mailer).mentioned(comment, users)
+    users
+  end
+
+  defp find_subscribed_users(announcement_id) do
+    users = Repo.all(Queries.Subscription.for_announcement(announcement_id))
+    |> Enum.map(fn (subscription) -> subscription.user end)
+  end
+
+  defp find_mentioned_users(body) do
+    Regex.scan(~r/@(\w+)/, body)
+    |> Enum.map(fn ([_, username]) -> username end)
+    |> Enum.map(&(Repo.get_by(User, username: &1)))
+    |> Enum.reject(&is_nil/1)
+  end
+end

--- a/web/templates/mailers/comments/mentioned.html.eex
+++ b/web/templates/mailers/comments/mentioned.html.eex
@@ -1,0 +1,211 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width" />
+    <title>Constable comment</title>
+    <style>
+      * {
+        text-rendering: optimizeLegibility;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        text-decoration: none; !important;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5 {
+        margin-bottom: .5em; !important;
+      }
+
+      @media (max-width: 320px) {
+
+        /* Forces the button to full width */
+
+        .btn-full {
+          width: 100% !important;
+        }
+      }
+
+      @media (max-width: 600px) {
+
+        /* Typography */
+
+        table {
+          font-size: 12px !important;
+        }
+
+        h1 {
+          font-size: 20px !important;
+        }
+
+        h2 {
+          font-size: 18px !important;
+        }
+
+        h3 {
+          font-size: 16px !important; }
+
+        h4 {
+          font-size: 14px !important; }
+
+        h5 {
+          font-size: 14px !important;
+        }
+
+        /* Makes fixed width items flexible */
+
+        .flex-size {
+          width: 100% !important;
+        }
+
+        /* Contains content images */
+
+        .flex-size img {
+          max-width: 100% !important;
+        }
+      }
+    </style>
+  </head>
+
+  <body leftmargin="0" marginwidth="0" marginheight="0" offset="0" topmargin="0" style="padding: 0;">
+    <table bgcolor="#fefefe" border="0" cellspacing="0" cellpadding="0" width="100%">
+      <tr>
+        <td>
+          <center>
+          <!-- ===================================== -->
+          <!-- Header Includes -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Header Container -->
+          <!-- ===================================== -->
+          <table bgcolor='#2e303b' border='0' cellpadding='0' cellspacing='0' style='border-bottom: 1px solid #727791;' width='100%'>
+            <tr>
+              <td></td>
+            </tr>
+          </table>
+          <!-- ===================================== -->
+          <!-- Announcement Include -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Announcement Container -->
+          <!-- ===================================== -->
+          <table bgcolor='#2e303b' border='0' cellpadding='0' cellspacing='0' style='border-bottom: 1px solid #727791;' width='100%'>
+            <tr>
+              <td>
+                <!-- ===================================== -->
+                <!-- Announcement Content -->
+                <!-- ===================================== -->
+                <table align='center' border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #ffffff; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;' width='700'>
+                  <!-- Vertical Spacer -->
+                  <tr>
+                    <td colspan='3' height='40'></td>
+                  </tr>
+                  <tr>
+                    <td width='40'></td>
+                    <td align='center' style='vertical-align: top;'>
+                      <img alt='avatar' class='avatar' src='<%= author_avatar_url %>' style='border-radius: 50%;' width='70'>
+                    </td>
+                    <td width='40'></td>
+                  </tr>
+                  <!-- Vertical Spacer -->
+                  <tr>
+                    <td colspan='3' height='10'></td>
+                  </tr>
+                  <tr>
+                    <td width='40'></td>
+                    <td align='center'>
+                      <h4 style='color: #7b819c; font-size: 14px; margin: 0;'>
+                        <%= author.name %> mentioned you in a comment on <%= comment.announcement.title %>
+                      </h4>
+                    </td>
+                  </tr>
+                  <!-- Vertical Spacer -->
+                  <tr>
+                    <td colspan='3' height='10'></td>
+                  </tr>
+                </table>
+                <table align='center' border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #ffffff; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;' width='700'>
+                  <tr>
+                    <td colspan='3' height='10'></td>
+                  </tr>
+                  <tr>
+                    <td colspan='3' height='35'></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <!-- ===================================== -->
+          <!-- Content Name -->
+          <!-- ===================================== -->
+          <table border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #666A80; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;' width='700'>
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='35'></td>
+            </tr>
+            <!-- ===================================== -->
+            <!-- Content -->
+            <!-- ===================================== -->
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='10'></td>
+            </tr>
+            <tr>
+              <td width='40'></td>
+              <td align='left'>
+                <%= Earmark.to_html(comment.body) %>
+              </td>
+              <td width='40'></td>
+            </tr>
+            <!-- ===================================== -->
+            <!-- Closing -->
+            <!-- ===================================== -->
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='45'></td>
+            </tr>
+            <tr>
+              <td width='40'></td>
+              <td align='center'>
+                <a href='<%= front_end_uri %>/announcements/<%= comment.announcement.id  %>' style='color: #c32f34;'>
+                  <h4 style='#c32f34 font-size: 18px; margin: 0; padding-bottom: 5px;'>View this announcement on #Constable</h4>
+                </a>
+              </td>
+              <td width='40'></td>
+            </tr>
+            <!-- Spacer -->
+            <tr>
+              <td colspan='3' height='45'></td>
+            </tr>
+          </table>
+          <!-- ===================================== -->
+          <!-- Footer Include -->
+          <!-- ===================================== -->
+          <!-- ===================================== -->
+          <!-- Footer Container -->
+          <!-- ===================================== -->
+          <table bgcolor='#ffffff' border='0' cellpadding='0' cellspacing='0' width='100%'>
+            <tr>
+              <td>
+                <!-- ===================================== -->
+                <!-- Footer Content -->
+                <!-- ===================================== -->
+                <table align='center' border='0' cellpadding='0' cellspacing='0' class='flex-size' style='color: #d4d4d4; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5; font-size: 14px;' width='700'>
+                  <!-- Vertical Spacer -->
+                  <tr>
+                    <td colspan='3' height='30'></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+          </center>
+        </td>
+      </tr>
+    </table>
+  </body>

--- a/web/templates/mailers/comments/mentioned.text.eex
+++ b/web/templates/mailers/comments/mentioned.text.eex
@@ -1,0 +1,6 @@
+<%= author.name %> mentioned you on <%= comment.announcement.title %>
+
+<%= front_end_uri %>/announcements/<%= comment.announcement.id %>
+
+<%= comment.body %>
+

--- a/web/views/api/user_view.ex
+++ b/web/views/api/user_view.ex
@@ -15,6 +15,7 @@ defmodule Constable.Api.UserView do
       id: user.id,
       name: user.name,
       gravatar_url: Exgravatar.generate(user.email),
+      username: user.username,
       user_interests: pluck(user.user_interests, :id),
       subscriptions: pluck(user.subscriptions, :id)
     }


### PR DESCRIPTION
When adding a comment, you can now @mention users by their username. This
also re-adds the missing functionality of emailing subscribers when a
comment is created on announcements they've subscribed to.
