### PR TITLE
Add announcement updater

### DIFF
--- a/test/models/user_interest_test.exs
+++ b/test/models/user_interest_test.exs
@@ -1,12 +1,12 @@
 defmodule Constable.UserInterestTest do
-  use Constable.ModelCase
+  use Constable.TestWithEcto
 
   alias Constable.UserInterest
 
   test "validates uniqueness scoped user_id" do
-    first_user = Forge.saved_user(Repo)
-    second_user = Forge.saved_user(Repo)
-    interest = Forge.saved_interest(Repo)
+    first_user = create(:user)
+    second_user = create(:user)
+    interest = create(:interest)
 
     assert Repo.insert! %UserInterest{user_id: first_user.id, interest_id: interest.id}
     assert Repo.insert! %UserInterest{user_id: second_user.id, interest_id: interest.id}

--- a/test/services/announcement_updater_test.exs
+++ b/test/services/announcement_updater_test.exs
@@ -1,0 +1,33 @@
+defmodule Constable.Services.AnnouncementUpdaterTest do
+  use Constable.TestWithEcto, async: false
+
+  alias Constable.Repo
+  alias Constable.Announcement
+  alias Constable.Services.AnnouncementUpdater
+
+  test "updates an announcement and its interests" do
+    user = create(:user)
+    announcement = create(:announcement, user: user)
+    interest = create(:interest, name: "old")
+
+    create(:announcement_interest,
+      announcement: announcement,
+      interest: interest,
+    )
+
+    params = %{title: "New!", body: "# Bar!"}
+    {:ok, _} = AnnouncementUpdater.update(announcement, params, ["new", "newer"])
+
+    announcement = Repo.get!(Announcement, announcement.id) |> Repo.preload(:interests)
+
+    assert announcement.title == "New!"
+    assert announcement.body == "# Bar!"
+    assert announcement_has_interest_named?(announcement, "new")
+    assert announcement_has_interest_named?(announcement, "newer")
+    refute announcement_has_interest_named?(announcement, "old")
+  end
+
+  defp announcement_has_interest_named?(announcement, interest_name) do
+    announcement.interests |> Enum.any?(&(&1.name == interest_name))
+  end
+end

--- a/web/services/announcement_interest_associator.ex
+++ b/web/services/announcement_interest_associator.ex
@@ -1,0 +1,54 @@
+defmodule Constable.Services.AnnouncementInterestAssociator do
+  alias Constable.Repo
+  alias Constable.Interest
+  alias Constable.AnnouncementInterest
+
+  alias Constable.InterestView
+
+  def add_interests(announcement, names) do
+    get_or_create_interests(names)
+    |> associate_interests_with_announcement(announcement)
+  end
+
+  defp get_or_create_interests(names) do
+    List.wrap(names)
+    |> Enum.reject(&blank_interest?/1)
+    |> Enum.map(fn(name) ->
+      interest = Interest.changeset(%{name: name})
+
+      case Repo.get_by(Interest, interest.changes) do
+        nil -> create_and_broadcast(interest)
+        interest -> interest
+      end
+    end)
+    |> Enum.uniq
+  end
+
+  defp associate_interests_with_announcement(interests, announcement) do
+    Enum.each(interests, fn(interest) ->
+      %AnnouncementInterest{
+        interest_id: interest.id,
+        announcement_id: announcement.id
+      }
+      |> Repo.insert!
+    end)
+
+    announcement
+  end
+
+  defp blank_interest?(" " <> rest), do: blank_interest?(rest)
+  defp blank_interest?(""), do: true
+  defp blank_interest?(_), do: false
+
+  defp create_and_broadcast(changeset) do
+    interest = changeset |> Repo.insert!
+
+    Constable.Endpoint.broadcast!(
+      "update",
+      "interest:add", 
+      InterestView.render("show.json", %{interest: interest})
+    )
+
+    interest
+  end
+end

--- a/web/services/announcement_updater.ex
+++ b/web/services/announcement_updater.ex
@@ -1,0 +1,33 @@
+defmodule Constable.Services.AnnouncementUpdater do
+  import Ecto.Query
+
+  alias Constable.Announcement
+  alias Constable.AnnouncementInterest
+  alias Constable.Services.AnnouncementInterestAssociator
+  alias Constable.Repo
+
+  def update(announcement, params, interest_names) do
+    changeset = Announcement.changeset(announcement, :update, params)
+
+    case Repo.update(changeset) do
+      {:ok, announcement} ->
+        announcement
+        |> clear_interests
+        |> update_interests(interest_names)
+        {:ok, announcement}
+      error -> error
+    end
+  end
+
+  defp clear_interests(announcement) do
+    Repo.delete_all(from ai in AnnouncementInterest,
+      where: ai.announcement_id == ^announcement.id
+    )
+
+    announcement
+  end
+
+  defp update_interests(announcement, names) do
+    AnnouncementInterestAssociator.add_interests(announcement, names)
+  end
+end


### PR DESCRIPTION
This adds an announcement updater which is required for updating since
the relationship of interests has to be cleared each time an
announcement is updated.
