### PR TITLE
Introduce Constable.ConnTestHelper

### DIFF
--- a/test/controllers/api/interest_controller_test.exs
+++ b/test/controllers/api/interest_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Constable.Api.InterestControllerTest do
   use Constable.ConnCase
 
-  alias Constable.Api.InterestView
+  @view Constable.Api.InterestView
 
   setup do
     {:ok, authenticate}
@@ -12,7 +12,7 @@ defmodule Constable.Api.InterestControllerTest do
 
     conn = get conn, interest_path(conn, :index)
 
-    assert json_response(conn, 200) == render_json(interests)
+    assert json_response(conn, 200) == render_json("index.json", interests: interests)
   end
 
   test "#show displays a single interest", %{conn: conn} do
@@ -21,10 +21,5 @@ defmodule Constable.Api.InterestControllerTest do
     conn = get conn, interest_path(conn, :show, interest.id)
 
     assert json_response(conn, 200)["interest"]["id"] == interest.id
-  end
-
-  defp render_json(interests) do
-    InterestView.render("index.json", interests: interests)
-    |> format_json
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,6 +21,7 @@ defmodule Constable.ConnCase do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
       use Constable.Web, :view
+      import Constable.ConnTestHelper
 
       # Alias the data repository and import query/model functions
       alias Constable.Repo
@@ -33,34 +34,6 @@ defmodule Constable.ConnCase do
 
       # The default endpoint for testing
       @endpoint Constable.Endpoint
-
-      def authenticate(user \\ create(:user)) do
-        conn = conn()
-        |> put_req_header("accept", "application/json")
-        |> put_req_header("authorization", user.token)
-        %{conn: conn, user: user}
-      end
-
-      defp fetch_json_ids(key, conn, status \\ 200) do
-        records = json_response(conn, status)[key]
-        Enum.map(records, fn(json) ->
-          Map.get(json, "id")
-        end)
-      end
-
-      defmacro render_json(template, assigns) do
-        view = Module.get_attribute(__CALLER__.module, :view)
-        quote do
-          render_json(unquote(template), unquote(view), unquote(assigns))
-        end
-      end
-      def render_json(template, view, assigns) do
-        view.render(template, assigns) |> format_json
-      end
-
-      defp format_json(data) do
-        data |> Poison.encode! |> Poison.decode!
-      end
     end
   end
 

--- a/test/support/conn_case_helper.ex
+++ b/test/support/conn_case_helper.ex
@@ -1,0 +1,33 @@
+defmodule Constable.ConnTestHelper do
+  import Constable.Factories
+  import Phoenix.ConnTest
+  import Plug.Conn
+
+  def authenticate(user \\ create(:user)) do
+    conn = conn()
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("authorization", user.token)
+    %{conn: conn, user: user}
+  end
+
+  def fetch_json_ids(key, conn, status \\ 200) do
+    records = json_response(conn, status)[key]
+    Enum.map(records, fn(json) ->
+      Map.get(json, "id")
+    end)
+  end
+
+  defmacro render_json(template, assigns) do
+    view = Module.get_attribute(__CALLER__.module, :view)
+    quote do
+      render_json(unquote(template), unquote(view), unquote(assigns))
+    end
+  end
+  def render_json(template, view, assigns) do
+    view.render(template, assigns) |> format_json
+  end
+
+  defp format_json(data) do
+    data |> Poison.encode! |> Poison.decode!
+  end
+end


### PR DESCRIPTION
It is considered bad practice to define functions in the quoted block.
It is easier to test, modify and reuse functions if you import a module
instead.
