### PR TITLE
Only subscribe a user to an announcement once

### DIFF
--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -17,6 +17,15 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     {:ok, %{}}
   end
 
+  test "doesn't subscribe creator twice when interested in announcement and autosubscribe is set" do
+    interest = create(:interest)
+    author = create(:user, auto_subscribe: true) |> with_interest(interest)
+
+    announcement_params = build(:announcement_params, user: author)
+
+    assert AnnouncementCreator.create(announcement_params, [interest.name])
+  end
+
   test "creates an announcement with new and existing interests" do
     author = create(:user)
     existing_interest = create(:interest)

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -86,8 +86,8 @@ defmodule Constable.Factories do
     create(:comment, announcement: announcement).announcement
   end
 
-  def with_interest(user) do
-    create(:user_interest, user: user).user
+  def with_interest(user, interest \\ create(:interest)) do
+    create(:user_interest, user: user, interest: interest).user
   end
 
   def with_subscription(user) do

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -61,6 +61,6 @@ defmodule Constable.Services.AnnouncementCreator do
       user_id: user_id,
       announcement_id: announcement.id
     })
-    |> Repo.insert!
+    |> Repo.get_or_insert
   end
 end


### PR DESCRIPTION
When a user creates, and is also interested in an announcement it
attempts to create the subscription twice causing an error to be thrown.

This checks for the existence of a Subscription before creating one.
