### PR TITLE
Don't email author of comments and announcements

### DIFF
--- a/test/controllers/api/comment_controller_test.exs
+++ b/test/controllers/api/comment_controller_test.exs
@@ -21,7 +21,7 @@ defmodule Constable.Api.CommentControllerTest do
     Pact.override self, :comment_mailer, FakeCommentMailer
 
     announcement = create(:announcement)
-    user |> with_subscription(announcement)
+    subscribed_user = create(:user) |> with_subscription(announcement)
 
     conn = post conn, comment_path(conn, :create), comment: %{
       body: "Foo",
@@ -33,6 +33,6 @@ defmodule Constable.Api.CommentControllerTest do
     assert comment.body == "Foo"
     assert comment.user_id == user.id
     assert comment.announcement_id == announcement.id
-    assert_received {:users, [user]}
+    assert_received {:users, [subscribed_user]}
   end
 end

--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -94,22 +94,22 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     )
   end
 
-  test "sends announcement email" do
-    user = create(:user)
+  test "sends announcement email to subscribed users except author" do
     interest = create(:interest, name: "foo")
-    create(:user_interest, user: user, interest: interest)
+    author = create(:user) |> with_interest(interest)
+    subscribed_user = create(:user) |> with_interest(interest)
 
     announcement_params = %{
       title: "Title",
       body: "Body",
-      user_id: user.id
+      user_id: author.id
     }
 
     AnnouncementCreator.create(announcement_params, ["foo"])
 
     announcement = Repo.one(Announcement)
     assert_received {:announcement, ^announcement}
-    assert_received {:users, [^user]}
+    assert_received {:users, [^subscribed_user]}
   end
 
   defp announcement_has_interest_named?(announcement, interest_name) do

--- a/test/services/comment_creator_test.exs
+++ b/test/services/comment_creator_test.exs
@@ -42,7 +42,7 @@ defmodule Constable.Services.CommentCreatorTest do
     announcement = create(:announcement) |> with_subscriber(user)
 
     {:ok, comment} = CommentCreator.create(%{
-      user_id: user.id,
+      user_id: create(:user).id,
       body: "Foo",
       announcement_id: announcement.id
     })
@@ -57,7 +57,7 @@ defmodule Constable.Services.CommentCreatorTest do
     announcement = create(:announcement, user: user)
 
     {:ok, comment} = CommentCreator.create(%{
-      user_id: user.id,
+      user_id: create(:user).id,
       body: "Hey @#{mentioned_username}, @fakeuser was looking for you.",
       announcement_id: announcement.id
     })
@@ -82,5 +82,22 @@ defmodule Constable.Services.CommentCreatorTest do
 
     assert_receive {:mentioned_comment, ^comment}
     assert_receive {:mentioned_users, [^user]}
+  end
+
+  test "create does not email author of comment" do
+    author = create(:user)
+    announcement = create(:announcement) |> with_subscriber(author)
+
+    {:ok, comment} = CommentCreator.create(%{
+      user_id: author.id,
+      body: "Foo!",
+      announcement_id: announcement.id
+    })
+
+    assert_received {:comment, comment}
+    assert_received {:users, []}
+
+    assert_receive {:mentioned_comment, ^comment}
+    assert_receive {:mentioned_users, []}
   end
 end

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -36,6 +36,9 @@ defmodule Constable.Services.AnnouncementCreator do
   end
 
   defp email_users(announcement, users) do
+    users = Enum.reject(users, fn(user) ->
+      user.id == announcement.user_id
+    end)
     Pact.get(:announcement_mailer).created(announcement, users)
     announcement
   end

--- a/web/services/comment_creator.ex
+++ b/web/services/comment_creator.ex
@@ -18,6 +18,7 @@ defmodule Constable.Services.CommentCreator do
 
   defp email_subscribers(comment, mentioned_users) do
     users = find_subscribed_users(comment.announcement_id) -- mentioned_users
+    |> Enum.reject(fn (user) -> user.id == comment.user_id end)
 
     Pact.get(:comment_mailer).created(comment, users)
     comment


### PR DESCRIPTION
When a user creates an announcement or comment we send the email to them
as well as the other users. This removes the author from the list of
recipients passed to the mailers.
