### PR TITLE
Use SSL with gravatar

### DIFF
--- a/test/views/api/user_view_test.exs
+++ b/test/views/api/user_view_test.exs
@@ -14,7 +14,7 @@ defmodule Constable.Api.UserViewTest do
       user: %{
         id: user.id,
         name: user.name,
-        gravatar_url: Exgravatar.generate(user.email),
+        gravatar_url: Exgravatar.generate(user.email, %{}, true),
         daily_digest: user.daily_digest,
         auto_subscribe: user.auto_subscribe,
         username: user.username,

--- a/test/views/user_view_test.exs
+++ b/test/views/user_view_test.exs
@@ -15,7 +15,7 @@ defmodule Constable.UserViewTest do
       id: user.id,
       email: user.email,
       name: user.name,
-      gravatar_url: Exgravatar.generate(user.email),
+      gravatar_url: Exgravatar.generate(user.email, %{}, true),
       user_interests: render_many(user.user_interests, UserInterestView, "show.json"),
       subscriptions: render_many(user.subscriptions, SubscriptionView, "show.json")
     }

--- a/web/views/api/user_view.ex
+++ b/web/views/api/user_view.ex
@@ -17,7 +17,7 @@ defmodule Constable.Api.UserView do
       name: user.name,
       auto_subscribe: user.auto_subscribe,
       daily_digest: user.daily_digest,
-      gravatar_url: Exgravatar.generate(user.email),
+      gravatar_url: Exgravatar.generate(user.email, %{}, true),
       username: user.username,
       user_interests: pluck(user.user_interests, :id),
       subscriptions: pluck(user.subscriptions, :id)

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -10,7 +10,7 @@ defmodule Constable.UserView do
       id: user.id,
       email: user.email,
       name: user.name,
-      gravatar_url: Exgravatar.generate(user.email),
+      gravatar_url: Exgravatar.generate(user.email, %{}, true),
       user_interests: render_many(user.user_interests, UserInterestView, "show.json"),
       subscriptions: render_many(user.subscriptions, SubscriptionView, "show.json")
     }


### PR DESCRIPTION
Production is getting a lot of mixed content warnings due to ExGravatar's
default being http. This changes ExGravatar to generate SSL urls.
