### PR TITLE
Add sync mandrill email method

### DIFF
--- a/lib/constable/mandrill.ex
+++ b/lib/constable/mandrill.ex
@@ -3,16 +3,13 @@ defmodule Constable.Mandrill do
 
   @mandrill_url "https://mandrillapp.com/api/1.0/messages/send.json"
 
-  def message_send(message_params) do
-    params = %{
-      key: System.get_env("MANDRILL_KEY"),
-      message: message_params
-    } |> Poison.encode!
+  def message_send_sync(message_params) do
+    send_message(message_params)
+  end
 
+  def message_send(message_params) do
     Task.async(fn ->
-      Logger.info "Sending email with params:"
-      Logger.info inspect(params)
-      HTTPoison.post(@mandrill_url, params) |> inspect |> Logger.info
+      send_message(message_params)
     end)
   end
 
@@ -24,5 +21,16 @@ defmodule Constable.Mandrill do
         type: "bcc"
       }
     end)
+  end
+
+  defp send_message(message_params) do
+    params = %{
+      key: System.get_env("MANDRILL_KEY"),
+      message: message_params
+    } |> Poison.encode!
+
+    Logger.info "Sending email with params:"
+    Logger.info inspect(params)
+    HTTPoison.post(@mandrill_url, params) |> inspect |> Logger.info
   end
 end

--- a/test/services/daily_digest_test.exs
+++ b/test/services/daily_digest_test.exs
@@ -5,7 +5,7 @@ defmodule Constable.DailyDigestTest do
   alias Constable.DailyDigest
 
   defmodule FakeMandrill do
-    def message_send(message_params) do
+    def message_send_sync(message_params) do
       send self, {:to, message_params.to}
       send self, {:subject, message_params.subject}
       send self, {:from_email, message_params.from_email}

--- a/web/services/daily_digest.ex
+++ b/web/services/daily_digest.ex
@@ -20,7 +20,7 @@ defmodule Constable.DailyDigest do
         to: Mandrill.format_users(users),
         tags: ["daily-digest"]
       }
-      |> Pact.get(:mailer).message_send
+      |> Pact.get(:mailer).message_send_sync
     end
   end
 


### PR DESCRIPTION
This introduces `message_send_sync` to mandrill to allow emails to be
sent in the same process and block execution of the application. This is
necessary because the daily digest email exits before the HTTP request
to mandrill can be sent to deliver emails.
