### PR TITLE
Add unsubscribe link to emails

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,7 @@ use Mix.Config
 # disk for the key and cert.
 
 config :constable, Constable.Endpoint,
-  url: [host: "example.com"],
+  url: [host: System.get_env("HOST")],
   http: [port: System.get_env("PORT"), compress: true],
   secret_key_base: "tJ+MdrPlKWMpmz7JyJgSu/11xvwnNZo7Sz8IAacy9MM6di3GqackE9iNjhkHI9p8"
 

--- a/priv/repo/migrations/20150921193646_add_token_to_subscription.exs
+++ b/priv/repo/migrations/20150921193646_add_token_to_subscription.exs
@@ -1,0 +1,9 @@
+defmodule Constable.Repo.Migrations.AddTokenToSubscription do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      add :token, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20150921194253_generate_subscription_tokens.exs
+++ b/priv/repo/migrations/20150921194253_generate_subscription_tokens.exs
@@ -1,0 +1,36 @@
+defmodule Constable.Repo.Migrations.GenerateSubscriptionTokens do
+  use Ecto.Migration
+
+  alias Constable.Repo
+
+  defmodule Subscription do
+    use Ecto.Model
+
+    schema "subscriptions" do
+      field :token
+    end
+  end
+
+  def up do
+    subscriptions = Repo.all(Subscription)
+
+    Enum.each(subscriptions, fn(subscription) ->
+      %{subscription | token: SecureRandom.urlsafe_base64(32)}
+      |> Repo.update
+    end)
+
+    alter table(:subscriptions) do
+      modify :token, :string, null: false
+    end
+
+    create index(:subscriptions, [:token], %{unique: true})
+  end
+
+  def down do
+    alter table(:subscriptions) do
+      modify :token, :string, null: true
+    end
+
+    drop index(:subscriptions, [:token], %{unique: true})
+  end
+end

--- a/test/controllers/api/comment_controller_test.exs
+++ b/test/controllers/api/comment_controller_test.exs
@@ -33,6 +33,6 @@ defmodule Constable.Api.CommentControllerTest do
     assert comment.body == "Foo"
     assert comment.user_id == user.id
     assert comment.announcement_id == announcement.id
-    assert_received {:users, [subscribed_user]}
+    assert_received {:users, [^subscribed_user]}
   end
 end

--- a/test/controllers/unsubscribe_controller_test.exs
+++ b/test/controllers/unsubscribe_controller_test.exs
@@ -1,0 +1,19 @@
+defmodule Constable.UsubscribeController.Test do
+  use Constable.ConnCase
+
+  alias Constable.Repo
+  alias Constable.Subscription
+
+  setup do
+    System.put_env("FRONT_END_URI", "http://localhost:8000")
+    {:ok, %{}}
+  end
+
+  test "#show deletes subscription" do
+    subscription = create(:subscription)
+
+    get conn, unsubscribe_path(conn, :show, subscription.token)
+
+    assert Repo.one(Subscription) == nil
+  end
+end

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -18,13 +18,15 @@ defmodule Constable.Mailers.CommentMailerTest do
   test "sends markdown formatted new comment email" do
     Pact.override(self, :mailer, FakeMandrill)
     author = create(:user)
-    users = [author, create(:user)]
+    user = create(:user)
+    users = [author, user]
     title = "Foo Announcement"
     subject = "Re: #{title}"
     comment_body = "Bar is cool"
     from_name = "#{author.name} (Constable)"
     announcement = create(:announcement, title: title, user: author)
     from_email = "constable-#{announcement.id}@#{System.get_env("EMAIL_DOMAIN")}"
+    create(:subscription, user: author, announcement: announcement)
     comment = create(:comment,
       body: comment_body,
       user: author,

--- a/web/controllers/api/announcement_controller.ex
+++ b/web/controllers/api/announcement_controller.ex
@@ -45,6 +45,7 @@ defmodule Constable.Api.AnnouncementController do
       "id" => id, "announcement" => announcement_params,
       "interest_names" => interest_names
     }) do
+
     current_user = current_user(conn)
     announcement = Repo.get!(Announcement, id)
 

--- a/web/controllers/api/comment_controller.ex
+++ b/web/controllers/api/comment_controller.ex
@@ -1,7 +1,6 @@
 defmodule Constable.Api.CommentController do
   use Constable.Web, :controller
 
-  alias Constable.Comment
   alias Constable.Api.CommentView
   alias Constable.Services.CommentCreator
 

--- a/web/controllers/unsubscribe_controller.ex
+++ b/web/controllers/unsubscribe_controller.ex
@@ -1,0 +1,13 @@
+defmodule Constable.UnsubscribeController do
+  use Phoenix.Controller
+
+  alias Constable.Subscription
+  alias Constable.Repo
+
+  def show(conn, %{"id" => token}) do
+    subscription = Repo.get_by!(Subscription, token: token)
+    Repo.delete(subscription)
+
+    conn |> redirect(external: System.get_env("FRONT_END_URI"))
+  end
+end

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -7,10 +7,15 @@ defmodule Constable.Mailers.Base do
   end
 
   def default_bindings do
-    [front_end_uri: System.get_env("FRONT_END_URI")]
+    [front_end_uri: System.get_env("FRONT_END_URI"),
+     back_end_uri: "http://#{back_end_host}"]
   end
 
   def email_domain do
     System.get_env("EMAIL_DOMAIN")
+  end
+
+  def back_end_host do
+    Application.get_env(:constable, Constable.Endpoint) |> get_in([:url, :host])
   end
 end

--- a/web/models/subscription.ex
+++ b/web/models/subscription.ex
@@ -3,7 +3,10 @@ defmodule Constable.Subscription do
   alias Constable.Announcement
   alias Constable.User
 
+  before_insert :generate_token
+
   schema "subscriptions" do
+    field :token
     belongs_to :user, User
     belongs_to :announcement, Announcement
     timestamps
@@ -12,5 +15,10 @@ defmodule Constable.Subscription do
   def changeset(subscription \\ %__MODULE__{}, _, params) do
     subscription
     |> cast(params, ~w(user_id announcement_id))
+  end
+
+  defp generate_token(changeset) do
+    token = SecureRandom.urlsafe_base64(32)
+    put_change changeset, :token, token
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -18,6 +18,7 @@ defmodule Constable.Router do
     pipe_through :browser
 
     resources "/email_replies", EmailReplyController, only: [:create]
+    resources "/unsubscribe", UnsubscribeController, only: [:show]
   end
 
   scope "/auth", alias: Constable do

--- a/web/services/comment_creator.ex
+++ b/web/services/comment_creator.ex
@@ -31,7 +31,7 @@ defmodule Constable.Services.CommentCreator do
   end
 
   defp find_subscribed_users(announcement_id) do
-    users = Repo.all(Queries.Subscription.for_announcement(announcement_id))
+    Repo.all(Queries.Subscription.for_announcement(announcement_id))
     |> Enum.map(fn (subscription) -> subscription.user end)
   end
 

--- a/web/templates/mailers/comments/new.html.eex
+++ b/web/templates/mailers/comments/new.html.eex
@@ -199,6 +199,7 @@
                   <!-- Vertical Spacer -->
                   <tr>
                     <td colspan='3' height='30'></td>
+                    <td style="text-align: center;"><a href="<%= back_end_uri %>/unsubscribe/{{subscription_id}}/">unsubscribe me from this announcement</a></td>
                   </tr>
                 </table>
               </td>

--- a/web/templates/mailers/comments/new.text.eex
+++ b/web/templates/mailers/comments/new.text.eex
@@ -4,3 +4,4 @@
 
 <%= comment.body %>
 
+Unsubscribe: <%= back_end_uri %>/unsubscribe/{{subscription_id}}/


### PR DESCRIPTION
This adds an unsubscribe link to new comment emails for announcements. This
takes advantage of mandrills variables and handlebar templating to insert
the proper token for each users subscription to an announcement.
