### PR TITLE
Add mobile_callback route for mobile app to authenticate

### DIFF
--- a/test/services/google_strategy_test.exs
+++ b/test/services/google_strategy_test.exs
@@ -1,0 +1,28 @@
+defmodule Constable.GoogleStrategyTest do
+  use Constable.TestWithEcto, async: false
+
+  test ".tokeninfo_url adds correct headers" do
+    client = GoogleStrategy.new()
+
+    {client, _} = GoogleStrategy.tokeninfo_url(client, "1234")
+
+    {"Content-Type", content_type} = List.first(client.headers)
+    assert content_type == "application/x-www-form-urlencoded"
+  end
+
+  test ".tokeninfo_url adds correct params" do
+    client = GoogleStrategy.new()
+
+    {client, _} = GoogleStrategy.tokeninfo_url(client, "1234")
+
+    assert Map.get(client.params, "id_token") == "1234"
+  end
+
+  test ".tokeninfo_url adds id_token to the URL" do
+    client = GoogleStrategy.new()
+
+    {_, url} = GoogleStrategy.tokeninfo_url(client, "1234")
+
+    assert String.ends_with?(url, "id_token=1234")
+  end
+end

--- a/test/views/auth_view_test.exs
+++ b/test/views/auth_view_test.exs
@@ -1,0 +1,19 @@
+defmodule Constable.AuthViewTest do
+  use Constable.ViewCase
+  alias Constable.AuthView
+
+  test "show.json returns correct fields" do
+    user = create(:user)
+
+    rendered_user = render_one(user, AuthView, "show.json", as: :user)
+
+    assert rendered_user == %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        token: user.token,
+      }
+    }
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -9,9 +9,12 @@ defmodule Constable.Router do
     plug :fetch_flash
   end
 
+  pipeline :authenticated do
+    plug Constable.AuthPlug
+  end
+
   pipeline :api do
     plug :accepts, ~w(json)
-    plug Constable.AuthPlug
   end
 
   scope "/", Constable do
@@ -28,8 +31,14 @@ defmodule Constable.Router do
     get "/callback", AuthController, :callback
   end
 
-  scope "/api", alias: Constable.Api do
+  scope "/auth", alias: Constable do
     pipe_through :api
+
+    post "/mobile_callback", AuthController, :mobile_callback
+  end
+
+  scope "/api", alias: Constable.Api do
+    pipe_through [:api, :authenticated]
 
     resources "/announcements", AnnouncementController
     resources "/comments", CommentController, only: [:create]

--- a/web/services/google_strategy.ex
+++ b/web/services/google_strategy.ex
@@ -1,5 +1,6 @@
 defmodule GoogleStrategy do
   use OAuth2.Strategy
+  alias OAuth2.Request
 
   def new do
     OAuth2.new([
@@ -22,6 +23,38 @@ defmodule GoogleStrategy do
     OAuth2.Client.get_token!(new(), params, headers, options)
   end
 
+  @doc """
+  Makes a request to the tokeninfo endpoint
+  that validates the given token is valid.
+
+  Returns the response.body from the request
+  or raises an error if received.
+
+  The body contains the users's information:
+  email, name, etc.
+
+  More information available:
+  https://developers.google.com/identity/sign-in/ios/backend-auth#calling-the-tokeninfo-endpoint
+
+  ## Arguments
+
+  * `id_token` - id_token received from Google
+  """
+  def get_tokeninfo!(id_token) do
+    {client, url} = tokeninfo_url(new(), id_token)
+    case Request.post(url, client.params, client.headers) do
+      {:ok, response} -> response.body
+      {:error, error} -> raise error
+    end
+  end
+
+  def tokeninfo_url(client, id_token) do
+    client
+    |> put_header("Content-Type", "application/x-www-form-urlencoded")
+    |> put_param(:id_token, id_token)
+    |> to_url("https://www.googleapis.com/oauth2/v3/tokeninfo")
+  end
+
   # Strategy Callbacks
 
   def authorize_url(client, params) do
@@ -32,5 +65,10 @@ defmodule GoogleStrategy do
     client
     |> put_header("Accept", "application/json")
     |> OAuth2.Strategy.AuthCode.get_token(params, headers)
+  end
+
+  defp to_url(client, endpoint) do
+    url = endpoint <> "?" <> URI.encode_query(client.params)
+    {client, url}
   end
 end

--- a/web/views/auth_view.ex
+++ b/web/views/auth_view.ex
@@ -1,0 +1,14 @@
+defmodule Constable.AuthView do
+  use Constable.Web, :view
+
+  def render("show.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        token: user.token,
+      }
+    }
+  end
+end


### PR DESCRIPTION
WIP because I'm working locally off a forked OAuth2
to add the missing method `get_tokeninfo!` that I'm using.

 Why:
- We need to authenticate with the server using Google Sign In
  to log in and view the users posts

This addresses this need by:
- Adding a route that the app posts the token to which returns the user
  to log in as.
