### PR TITLE
Update circle.yml to install Elixir 1.0.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   pre:
     - wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
     - sudo apt-get update
-    - sudo apt-get install elixir
+    - sudo apt-get install elixir=1.0.5-2
     - yes | mix deps.get
     - mix local.rebar
 test:


### PR DESCRIPTION
Why:
- The app won't run on a higher version currently.
- This matches what we're installing on Heroku with the build pack

This change addresses the need by:
- Configuring Circle to install the correct version
