### PR TITLE
Add user creation endpoint for onboarding script

### DIFF
--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -1,8 +1,22 @@
 defmodule Constable.Api.UserControllerTest do
   use Constable.ConnCase
+  alias Constable.User
+
+  @view Constable.Api.UserView
 
   setup do
     {:ok, authenticate}
+  end
+
+  test "#create creates a user", %{conn: conn} do
+    name = "Ian D. Anderson"
+    conn = post conn, user_path(conn, :create), user: %{
+      name: name,
+      email: "ian@thoughtbot.com"
+    }
+
+    user = Repo.get_by!(User, email: "ian@thoughtbot.com", username: "ian")
+    assert json_response(conn, 200) == render_json("show.json", user: user)
   end
 
   test "#index returns all users", %{conn: conn, user: user} do

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,0 +1,26 @@
+defmodule Constable.UserTest do
+  use Constable.TestWithEcto
+
+  alias Constable.User
+
+  test "create_changeset sets token and username" do
+    changeset = User.create_changeset(%User{}, %{
+      email: "foo@thoughtbot.com",
+      name: "Foo Bar"
+    })
+
+    assert changeset.valid?
+    assert changeset.changes.username == "foo"
+    assert String.length(changeset.changes.token) == 43
+  end
+
+  test "create_changeset validates email ends with thoughtbot.com" do
+    changeset = User.create_changeset(%User{}, %{
+      email: "bcardella@dockyard.com",
+      name: "Foo Bar"
+    })
+
+    refute changeset.valid?
+    assert changeset.errors[:email] == "must be a member of thoughtbot"
+  end
+end

--- a/web/controllers/api/user_controller.ex
+++ b/web/controllers/api/user_controller.ex
@@ -3,6 +3,19 @@ defmodule Constable.Api.UserController do
 
   alias Constable.User
 
+  def create(conn, %{"user" => user_params}) do
+    changeset = User.create_changeset(%User{}, user_params)
+
+    case Repo.insert(changeset) do
+      {:ok, user} ->
+        render(conn, "show.json", user: user)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Constable.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
   def index(conn, _params) do
     users = Repo.all(User)
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -48,4 +48,10 @@ defmodule Constable.Router do
     resources "/users", UserController, only: [:index, :show]
     resources "/users", UserController, only: [:update], singleton: true
   end
+
+  scope "/api", alias: Constable.Api do
+    pipe_through :api
+
+    resources "/users", UserController, only: [:create]
+  end
 end


### PR DESCRIPTION
This adds an endpoint to add new users from the API specifically for the
onboarding script.

This also extracts email validation, token generation, and username
generation into changesets.
