### PR TITLE
Send daily digest if there are any new items

### DIFF
--- a/web/services/daily_digest.ex
+++ b/web/services/daily_digest.ex
@@ -24,8 +24,7 @@ defmodule Constable.DailyDigest do
   end
 
   defp new_items_since?(time) do
-    !Enum.empty?(announcements_since(time)) 
-      && !Enum.empty?(interests_since(time))
+    !Enum.empty?(announcements_since(time)) || !Enum.empty?(interests_since(time))
   end
 
   defp email_text(time) do


### PR DESCRIPTION
There was a problem with the digest because it was only being sent out
if there were new announcements _and_ new interests. It should be sent
if _either_ of those conditions are true.
