### PR TITLE
Add gravatar_url to mobile auth response

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -116,8 +116,9 @@ defmodule AuthControllerTest do
 
     conn = post conn, auth_path(conn, :mobile_callback), auth_params
 
+    user_auth_token = Repo.one(User).token
     assert json_response(conn, 201)
-    assert json_response(conn, 201)["user"]["email"] == @oauth_email_address
+    assert json_response(conn, 201)["user"]["token"] == user_auth_token
   end
 
   test "mobile_callback returns error json when user has non-thoughtbot email" do

--- a/test/views/auth_view_test.exs
+++ b/test/views/auth_view_test.exs
@@ -1,19 +1,15 @@
 defmodule Constable.AuthViewTest do
   use Constable.ViewCase
   alias Constable.AuthView
+  alias Constable.Api.UserView
 
   test "show.json returns correct fields" do
     user = create(:user)
 
     rendered_user = render_one(user, AuthView, "show.json", as: :user)
+    user_view_json = render_one(user, UserView, "show.json")
+    user_with_token = user_view_json |> put_in([:user, :token], user.token)
 
-    assert rendered_user == %{
-      user: %{
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        token: user.token,
-      }
-    }
+    assert rendered_user == user_with_token
   end
 end

--- a/web/views/auth_view.ex
+++ b/web/views/auth_view.ex
@@ -1,14 +1,10 @@
 defmodule Constable.AuthView do
   use Constable.Web, :view
 
+  alias Constable.Api.UserView
+
   def render("show.json", %{user: user}) do
-    %{
-      user: %{
-        id: user.id,
-        name: user.name,
-        email: user.email,
-        token: user.token,
-      }
-    }
+    rendered_user = render_one(user, UserView, "show.json")
+    rendered_user |> put_in([:user, :token], user.token)
   end
 end


### PR DESCRIPTION
Why:
- I'm now expecting this to parse and display the user's image so I need
  it in this response.

This change addresses the need by:
- Adding the `gravatar_url` to the `AuthView`s json.
- Removing `email`. I was not actually using it for anything.
