### PR TITLE
Use different domains for inbound/outbound email

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -3,4 +3,5 @@ CLIENT_SECRET=GetFromGoogleDeveloperConsole
 REDIRECT_URI=http://localhost:4000/auth/callback
 MANDRILL_KEY=GetFromMandrillSettings
 FRONT_END_URI=http://localhost:8000
-EMAIL_DOMAIN=staging.constable.io
+OUTBOUND_EMAIL_DOMAIN=staging.constable.io
+INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io

--- a/lib/constable/env.ex
+++ b/lib/constable/env.ex
@@ -1,0 +1,8 @@
+defmodule Constable.Env do
+  @doc """
+  Gets a variable from the environment and throws an error if it does not exist
+  """
+  def get(key) do
+    System.get_env |> Dict.fetch!(key)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Constable.Mixfile do
   end
 
   defp app_list(:dev), do: [:dotenv | app_list]
-  defp app_list(:test), do: [:ex_machina | app_list]
+  defp app_list(:test), do: [:ex_machina, :dotenv | app_list]
   defp app_list(_), do: app_list
   defp app_list, do: [:phoenix, :cowboy, :logger, :postgrex, :ecto, :httpoison]
 

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -54,8 +54,8 @@ defmodule AuthControllerTest do
     conn = get(conn, "/auth", redirect_uri: "foo.com")
 
     auth_uri = google_auth_uri(
-      client_id: "",
-      redirect_uri: "",
+      client_id: Constable.Env.get("CLIENT_ID"),
+      redirect_uri: Constable.Env.get("REDIRECT_URI"),
       response_type: "code",
       scope: "email"
     )

--- a/test/controllers/email_reply_controller_test.exs
+++ b/test/controllers/email_reply_controller_test.exs
@@ -9,7 +9,7 @@ defmodule Constable.EmailReplyTest do
     email_reply_webhook = create_email_reply_webhook(
       from_email: user.email,
       text: "YO DAWG",
-      email: "constable-#{announcement.id}@thoughtbot.com"
+      email: "announcement-#{announcement.id}@foo.com"
     )
 
     conn = post(conn, "/email_replies", email_reply_webhook)
@@ -29,14 +29,15 @@ defmodule Constable.EmailReplyTest do
 
     Sure looks like it!!
     """
-    body_text = """
-    #{user_text}\n> On Oct 16, 2015, at 5:05 PM, Paul Smith (Constable) <constable-40@staging.constable.io> wrote:\n> \n> \t\n> my text\t\n\n\n
+    whole_email_with_quoted_text = """
+    #{user_text}\n> On Oct 16, 2015, at 5:05 PM, Paul Smith (Constable) <constable-40@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}> wrote:\n> \n> \t\n> my text\t\n\n\n
     """
+    comment_author = create(:user)
     announcement = create(:announcement)
     email_reply_webhook = create_email_reply_webhook(
-      from_email: announcement.user.email,
-      text: body_text,
-      email: "constable-#{announcement.id}@thoughtbot.com"
+      from_email: comment_author.email,
+      text: whole_email_with_quoted_text,
+      email: "announcement-#{announcement.id}@foo.com"
     )
 
     post(conn, "/email_replies", email_reply_webhook)

--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -10,6 +10,7 @@ defmodule Constable.Mailers.AnnouncementTest do
       send self, {:subject, message_params.subject}
       send self, {:from_email, message_params.from_email}
       send self, {:from_name, message_params.from_name}
+      send self, {:headers, message_params.headers}
       send self, {:html, message_params.html}
       send self, {:text, message_params.text}
     end
@@ -28,11 +29,15 @@ defmodule Constable.Mailers.AnnouncementTest do
     users = Mandrill.format_users(interested_users)
     subject = "#{announcement.title}"
     from_name = "#{author.name} (Constable)"
-    from_email = "constable-#{announcement.id}@#{System.get_env("EMAIL_DOMAIN")}"
+    from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
+    headers = %{
+      "Reply-To": "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+    }
     assert_received {:to, ^users}
     assert_received {:subject, ^subject}
     assert_received {:from_email, ^from_email}
     assert_received {:from_name, ^from_name}
+    assert_received {:headers, ^headers}
     assert_received {:html, email_html_body}
     assert_received {:text, email_text_body}
     html_announcement_body = Earmark.to_html(announcement.body)

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -9,6 +9,7 @@ defmodule Constable.Mailers.CommentMailerTest do
       send self, {:to, message_params.to}
       send self, {:subject, message_params.subject}
       send self, {:from_email, message_params.from_email}
+      send self, {:headers, message_params.headers}
       send self, {:from_name, message_params.from_name}
       send self, {:html, message_params.html}
       send self, {:text, message_params.text}
@@ -25,7 +26,10 @@ defmodule Constable.Mailers.CommentMailerTest do
     comment_body = "Bar is cool"
     from_name = "#{author.name} (Constable)"
     announcement = create(:announcement, title: title, user: author)
-    from_email = "constable-#{announcement.id}@#{System.get_env("EMAIL_DOMAIN")}"
+    from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
+    headers = %{
+      "Reply-To": "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+    }
     create(:subscription, user: author, announcement: announcement)
     comment = create(:comment,
       body: comment_body,
@@ -40,6 +44,7 @@ defmodule Constable.Mailers.CommentMailerTest do
     assert_received {:subject, ^subject}
     assert_received {:from_name, ^from_name}
     assert_received {:from_email, ^from_email}
+    assert_received {:headers, ^headers}
     assert_received {:html, email_html_body}
     assert_received {:text, email_text_body}
     html_comment_body = Earmark.to_html(comment.body)

--- a/test/services/daily_digest_test.exs
+++ b/test/services/daily_digest_test.exs
@@ -37,7 +37,7 @@ defmodule Constable.DailyDigestTest do
 
     subject = "Daily Digest"
     from_name = "Constable (thoughtbot)"
-    from_email = "constable@#{System.get_env("EMAIL_DOMAIN")}"
+    from_email = "constable@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     users = Mandrill.format_users(users)
     assert_receive {:to, ^users}
     assert_receive {:subject, ^subject}

--- a/web/controllers/email_reply_controller.ex
+++ b/web/controllers/email_reply_controller.ex
@@ -12,9 +12,9 @@ defmodule Constable.EmailReplyController do
   end
 
   defp create_comments(messages) do
-    Enum.each(messages, fn(message) ->
+    for message <- messages do
       Comment.changeset(:create, comment_params(message)) |> Repo.insert!
-    end)
+    end
   end
 
   defp comment_params(
@@ -30,7 +30,7 @@ defmodule Constable.EmailReplyController do
     Queries.User.with_email(email_address) |> Repo.one
   end
 
-  defp announcement_id_from_email("constable-" <> key_and_domain) do
+  defp announcement_id_from_email("announcement-" <> key_and_domain) do
     key_and_domain |> String.split("@") |> List.first
   end
 
@@ -42,6 +42,6 @@ defmodule Constable.EmailReplyController do
   end
 
   defp is_from_new_email?(line) do
-    !String.contains?(line, "@#{System.get_env("EMAIL_DOMAIN")}")
+    !String.contains?(line, "@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}")
   end
 end

--- a/web/mailers/announcement.ex
+++ b/web/mailers/announcement.ex
@@ -8,7 +8,7 @@ defmodule Constable.Mailers.Announcement do
 
   def created(announcement, users) do
     announcement = announcement |> Repo.preload([:user, :interests])
-    default_attributes(announcement: announcement, author: announcement.user)
+    default_attributes(author: announcement.user)
     |> Map.merge(%{
       to: Mandrill.format_users(users),
       subject: announcement.title,
@@ -16,6 +16,7 @@ defmodule Constable.Mailers.Announcement do
       html: email_html(announcement),
       text: email_text(announcement)
     })
+    |> reply_to(announcement_email_address(announcement))
     |> Pact.get(:mailer).message_send
   end
 

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -1,7 +1,7 @@
 defmodule Constable.Mailers.Base do
-  def default_attributes(announcement: announcement, author: author) do
+  def default_attributes(author: author) do
     %{
-      from_email: "constable-#{announcement.id}@#{email_domain}",
+      from_email: "announcements@#{outbound_domain}",
       from_name: "#{author.name} (Constable)"
     }
   end
@@ -11,8 +11,20 @@ defmodule Constable.Mailers.Base do
      back_end_uri: "http://#{back_end_host}"]
   end
 
-  def email_domain do
-    System.get_env("EMAIL_DOMAIN")
+  def reply_to(message, email) do
+    message |> Dict.put(:headers, %{ "Reply-To": email })
+  end
+
+  def announcement_email_address(announcement) do
+    "announcement-#{announcement.id}@#{inbound_domain}"
+  end
+
+  def outbound_domain do
+    Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")
+  end
+
+  def inbound_domain do
+    Constable.Env.get("INBOUND_EMAIL_DOMAIN")
   end
 
   def back_end_host do

--- a/web/mailers/comment.ex
+++ b/web/mailers/comment.ex
@@ -10,7 +10,7 @@ defmodule Constable.Mailers.Comment do
   def created(_comment, []), do: nil
   def created(comment, users) do
     comment = comment |> Repo.preload([:announcement, :user])
-    default_attributes(announcement: comment.announcement, author: comment.user)
+    default_attributes(author: comment.user)
     |> Map.merge(%{
       html: created_html(comment),
       text: created_text(comment),
@@ -20,6 +20,7 @@ defmodule Constable.Mailers.Comment do
       tags: ["new-comment"],
       merge_vars: generate_merge_vars(users, comment)
     })
+    |> reply_to(announcement_email_address(comment.announcement))
     |> Pact.get(:mailer).message_send
   end
 

--- a/web/services/daily_digest.ex
+++ b/web/services/daily_digest.ex
@@ -11,7 +11,7 @@ defmodule Constable.DailyDigest do
   def send_email(users, time) do
     if new_items_since?(time) do
       %{
-        from_email: "constable@#{email_domain}",
+        from_email: "constable@#{outbound_domain}",
         from_name: "Constable (thoughtbot)",
         html: email_html(time),
         text: email_text(time),


### PR DESCRIPTION
This will allow us to use Mandrill to handle inbound emails from email
replies, while still leaving open the ability to set up account like
"support@constable.io" if we ever need to do that.

This is necessary because Mandrill will handle _all_ incoming email for
a given domain.
