### PR TITLE
Replace dotenv with envy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ dependencies:
     - sudo apt-get install elixir=1.0.5-2
     - yes | mix deps.get
     - mix local.rebar
+    - cp .sample.env .env
 test:
   override:
     - MIX_ENV=prod mix compile --warnings-as-errors

--- a/lib/constable.ex
+++ b/lib/constable.ex
@@ -5,6 +5,11 @@ defmodule Constable do
   # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
+
+    unless Mix.env == "production" do
+      Envy.auto_load
+    end
+
     setup_dependencies
 
     children = [

--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,8 @@ defmodule Constable.Mixfile do
      applications: app_list(Mix.env)]
   end
 
-  defp app_list(:dev), do: [:dotenv | app_list]
-  defp app_list(:test), do: [:ex_machina, :dotenv | app_list]
+  defp app_list(:dev), do: app_list
+  defp app_list(:test), do: [:ex_machina | app_list]
   defp app_list(_), do: app_list
   defp app_list, do: [:phoenix, :cowboy, :logger, :postgrex, :ecto, :httpoison]
 
@@ -31,7 +31,7 @@ defmodule Constable.Mixfile do
   defp deps do
     [
       {:cowboy, "~> 1.0"},
-      {:dotenv, "~> 0.0.4"},
+      {:envy, "~> 0.0.1"},
       {:earmark, "~> 0.1.17"},
       {:exgravatar, "~> 0.2.0"},
       {:ex_machina, "~> 0.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "dotenv": {:hex, :dotenv, "0.0.4"},
   "earmark": {:hex, :earmark, "0.1.17"},
   "ecto": {:hex, :ecto, "0.15.0"},
+  "envy": {:hex, :envy, "0.0.1"},
   "ex_machina": {:hex, :ex_machina, "0.3.0"},
   "exgravatar": {:hex, :exgravatar, "0.2.0"},
   "faker": {:hex, :faker, "0.5.1"},


### PR DESCRIPTION
Dotenv has a few quirks that we've run into in the past and is somewhat of
a more heavyweight approach using genservers.

This replaces dotenv with envy which just loads your .env files without
needing to start up an application. This also allows us to define env files
for specific environments. eg: `.env.dev`, `.env.test`, etc.
