### PR TITLE
Add Message-Id and In-Reply-To email headers

### DIFF
--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -31,7 +31,8 @@ defmodule Constable.Mailers.AnnouncementTest do
     from_name = "#{author.name} (Constable)"
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
-      "Reply-To": "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+      "Message-ID" => "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}",
+      "Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
     }
     assert_received {:to, ^users}
     assert_received {:subject, ^subject}

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -28,7 +28,8 @@ defmodule Constable.Mailers.CommentMailerTest do
     announcement = create(:announcement, title: title, user: author)
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
-      "Reply-To": "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+      "In-Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}",
+      "Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
     }
     create(:subscription, user: author, announcement: announcement)
     comment = create(:comment,

--- a/web/mailers/announcement.ex
+++ b/web/mailers/announcement.ex
@@ -14,11 +14,15 @@ defmodule Constable.Mailers.Announcement do
       subject: announcement.title,
       tags: @tags,
       html: email_html(announcement),
-      text: email_text(announcement)
+      text: email_text(announcement),
+      headers: %{
+        "Message-ID" => announcement_message_id(announcement)
+      }
     })
     |> reply_to(announcement_email_address(announcement))
     |> Pact.get(:mailer).message_send
   end
+
 
   defp email_text(announcement) do
     render_template("new.text",

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -12,7 +12,9 @@ defmodule Constable.Mailers.Base do
   end
 
   def reply_to(message, email) do
-    message |> Dict.put(:headers, %{ "Reply-To": email })
+    message
+    |> Map.put_new(:headers, %{})
+    |> put_in [:headers, "Reply-To"], email
   end
 
   def announcement_email_address(announcement) do
@@ -29,5 +31,9 @@ defmodule Constable.Mailers.Base do
 
   def back_end_host do
     Application.get_env(:constable, Constable.Endpoint) |> get_in([:url, :host])
+  end
+
+  def announcement_message_id(announcement) do
+    "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
   end
 end

--- a/web/mailers/comment.ex
+++ b/web/mailers/comment.ex
@@ -18,7 +18,10 @@ defmodule Constable.Mailers.Comment do
       subject: "Re: #{comment.announcement.title}",
       to: Mandrill.format_users(users),
       tags: ["new-comment"],
-      merge_vars: generate_merge_vars(users, comment)
+      merge_vars: generate_merge_vars(users, comment),
+      headers: %{
+        "In-Reply-To" => announcement_message_id(comment.announcement)
+      }
     })
     |> reply_to(announcement_email_address(comment.announcement))
     |> Pact.get(:mailer).message_send


### PR DESCRIPTION
This adds headers that will help email clients determine if follow-up
emails are part of the same thread or not without having to parse email
subjects.

This should fix Mutt, and iPhone email threading.
