### PR TITLE
Add angle brackets to header emails

### DIFF
--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -31,8 +31,8 @@ defmodule Constable.Mailers.AnnouncementTest do
     from_name = "#{author.name} (Constable)"
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
-      "Message-ID" => "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}",
-      "Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+      "Message-ID" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
+      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>"
     }
     assert_received {:to, ^users}
     assert_received {:subject, ^subject}

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -28,8 +28,8 @@ defmodule Constable.Mailers.CommentMailerTest do
     announcement = create(:announcement, title: title, user: author)
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
-      "In-Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}",
-      "Reply-To" => "announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}"
+      "In-Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
+      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>"
     }
     create(:subscription, user: author, announcement: announcement)
     comment = create(:comment,

--- a/web/mailers/base.ex
+++ b/web/mailers/base.ex
@@ -14,7 +14,7 @@ defmodule Constable.Mailers.Base do
   def reply_to(message, email) do
     message
     |> Map.put_new(:headers, %{})
-    |> put_in [:headers, "Reply-To"], email
+    |> put_in [:headers, "Reply-To"], "<#{email}>"
   end
 
   def announcement_email_address(announcement) do
@@ -34,6 +34,6 @@ defmodule Constable.Mailers.Base do
   end
 
   def announcement_message_id(announcement) do
-    "announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
+    "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>"
   end
 end


### PR DESCRIPTION
The current format without angle brackets is being re-written by GMail
due to lack of angle brackets. Malformed headers can also cause Google
to mark messages as spam.
