### PR TITLE
Cache erlang in circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,7 @@ dependencies:
     - "~/erlang"
   pre:
     - mkdir -p ~/erlang
-    - wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -P ~/erlang
-    - sudo dpkg -i ~/erlang/erlang-solutions_1.0_all.deb
+    - if [[ ! -e ~/erlang/erlang-solutions_1.0_all.deb ]]; then wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb -P ~/erlang && sudo dpkg -i ~/erlang/erlang-solutions_1.0_all.deb; fi
     - sudo apt-get update
     - sudo apt-get install elixir=1.0.5-2
     - yes | mix deps.get


### PR DESCRIPTION
Builds are often slow because we have to fetch Erlang and install it
along with Elixir each build. This caches the Erlang download so we can
go straight to installing it and Elixir.
