### PR TITLE
Fix Auth for newest version of OAuth

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -16,9 +16,11 @@ defmodule AuthControllerTest do
     @oauth_email_address "fake@thoughtbot.com"
 
     def get!(_token, _path) do
-      %{
-        "email" => @oauth_email_address,
-        "name" => "Gumbo McGee"
+      %OAuth2.Response{
+        body: %{
+          "email" => @oauth_email_address,
+          "name" => "Gumbo McGee"
+        }
       }
     end
   end
@@ -27,9 +29,11 @@ defmodule AuthControllerTest do
     @oauth_email_address "fake@example.com"
 
     def get!(_token, _path) do
-      %{
-        "email" => @oauth_email_address,
-        "name" => "Gumbo McGee"
+      %OAuth2.Response{
+        body: %{
+          "email" => @oauth_email_address,
+          "name" => "Gumbo McGee"
+        }
       }
     end
   end

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -58,6 +58,7 @@ defmodule Constable.AuthController do
 
   defp get_userinfo(token) do
     Pact.get("request_with_access_token").get!(token, "/oauth2/v1/userinfo?alt=json")
+    |> Map.get(:body)
   end
 
   defp get_tokeninfo!(id_token) do


### PR DESCRIPTION
When we updated the OAuth client we did not realize the response
changed. I've updated the tests to the new response format, and the
controller to match against the latest response type.
