### PR TITLE
Add search announcements endpoint

### DIFF
--- a/test/controllers/api/search_controller_test.exs
+++ b/test/controllers/api/search_controller_test.exs
@@ -1,0 +1,31 @@
+defmodule Constable.Api.SearchesControllerTest do
+  use Constable.ConnCase
+
+  @view Constable.Api.AnnouncementView
+
+  setup do
+    {:ok, authenticate}
+  end
+
+  test "returns matching announcements", %{conn: conn} do
+    announcement_1 = create(:announcement, title: "foobar1")
+    announcement_2 = create(:announcement, body: "announcement body cool")
+    announcement_3 = create(:announcement, title: "awesome title", body: "cool body")
+
+    assert results_for(conn, query: "foobar1") == json_for(announcement_1)
+    assert results_for(conn, query: "announcement body") == json_for(announcement_2)
+    assert results_for(conn, query: "awesome title cool body") == json_for(announcement_3)
+    assert results_for(conn, query: "cool") == json_for([announcement_2, announcement_3])
+    query_with_extra_spaces = "announcement     body"
+    assert results_for(conn, query: query_with_extra_spaces) == json_for(announcement_2)
+  end
+
+  defp results_for(conn, query: search_term) do
+    response = post conn, search_path(conn, :create), query: search_term
+    json_response(response, 200)
+  end
+
+  defp json_for(announcements) do
+    render_json("index.json", announcements: List.wrap(announcements))
+  end
+end

--- a/web/controllers/api/search_controller.ex
+++ b/web/controllers/api/search_controller.ex
@@ -1,0 +1,12 @@
+defmodule Constable.Api.SearchController do
+  use Constable.Web, :controller
+
+  plug :put_view, Constable.Api.AnnouncementView
+
+  alias Constable.Announcement
+
+  def create(conn, %{"query" => search_terms}) do
+    announcements = Announcement.search(search_terms) |> Repo.all
+    render(conn, "index.json", announcements: announcements)
+  end
+end

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -28,4 +28,23 @@ defmodule Constable.Announcement do
     announcement
     |> cast(params, ~w(title body user_id))
   end
+
+  def search(query \\ __MODULE__, search_term) do
+    search_term = search_term |> prepare_for_tsquery
+
+    from(a in query,
+      where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ to_tsquery('english', ?)",
+        a.title,
+        a.body,
+        ^search_term
+      )
+    )
+  end
+
+  defp prepare_for_tsquery(search_term) do
+    search_term
+    |> String.split(" ", trim: true)
+    |> Enum.intersperse(" & ")
+    |> Enum.join("")
+  end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -46,6 +46,7 @@ defmodule Constable.Router do
     resources "/announcements", AnnouncementController
     resources "/comments", CommentController, only: [:create]
     resources "/interests", InterestController, only: [:index, :show]
+    resources "/searches", SearchController, only: [:create]
     resources "/subscriptions", SubscriptionController, only: [:index, :create, :delete]
     resources "/user_interests", UserInterestController, only: [:index, :show, :create, :delete]
     resources "/users", UserController, only: [:index, :show]


### PR DESCRIPTION
For now this is just searching the announcement title and body. If the
queries start to get too slow we can add some indexes, but for now I
think this should be fine.

Resources used:
- http://rachbelaid.com/postgres-full-text-search-is-good-enough/
- https://robots.thoughtbot.com/optimizing-full-text-search-with-postgres-tsvector-columns-and-triggers
- http://blog.rokkincat.com/postgres-full-text-search-in-ecto/
