### PR TITLE
Upgrade to fixed version of Bamboo

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -13,7 +13,7 @@ config :constable, Constable.Repo,
 
 config :constable, Constable.Mailer,
   adapter: Bamboo.MandrillAdapter,
-  api_key: ""
+  api_key: System.get_env("MANDRILL_KEY")
 
 # Enables code reloading for development
 config :phoenix, :code_reloader, true

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Constable.Mixfile do
   # Type `mix help deps` for examples and options
   defp deps do
     [
-      {:bamboo, "~> 0.0.1", github: "paulcsmith/bamboo"},
+      {:bamboo, "~> 0.1.0", github: "paulcsmith/bamboo"},
       {:cowboy, "~> 1.0"},
       {:envy, "~> 0.0.1"},
       {:earmark, "~> 0.1.17"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"bamboo": {:git, "https://github.com/paulcsmith/bamboo.git", "b0a4b8d031696642595ea224b4bc9ee1f2a2d31e", []},
+%{"bamboo": {:git, "https://github.com/paulcsmith/bamboo.git", "86e0b998267ac24cb1ef4e877268446978640e41", []},
   "certifi": {:hex, :certifi, "0.3.0"},
   "combine": {:hex, :combine, "0.6.0"},
   "cors_plug": {:hex, :cors_plug, "0.1.4"},


### PR DESCRIPTION
Bamboo incorrectly set the params as `api_key` when it should be just
`key`. Version 0.1.0 fixes that. This also uses the mandrill key from
your .env file in development
