### PR TITLE
Remove unused code and fix warnings for 1.2

### DIFF
--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -28,37 +28,6 @@ defmodule Constable.ChannelCase do
 
       # The default endpoint for testing
       @endpoint Constable.Endpoint
-
-      defmacro join!(topic, payload \\ Macro.escape(%{})) do
-        quote do
-          join!(@channel, unquote(topic), unquote(payload))
-        end
-      end
-      def join!(channel, topic, as: user) do
-        join!(channel, topic, %{"token" => user.token})
-      end
-      def join!(channel, topic, payload) when is_binary(topic) do
-        {:ok, _, socket} = subscribe_and_join(channel, topic, payload)
-        socket
-      end
-
-      def wait_for_reply(ref, status) do
-        assert_reply(ref, ^status)
-      end
-
-      def payload_from_reply(ref, status) do
-        assert_reply ref, status, payload
-        payload
-      end
-
-      defmacro refute_broadcast(event, payload, timeout \\ 100) do
-        quote do
-          refute_receive %Phoenix.Socket.Broadcast{
-            event: unquote(event),
-            payload: unquote(payload)},
-            unquote(timeout)
-        end
-      end
     end
   end
 

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -35,7 +35,7 @@ defmodule Constable.AuthController do
 
   def callback(conn, %{"error" => error_message}) do
     Logger.warn("Auth error: #{error_message}")
-    conn |> redirect external: "/"
+    conn |> redirect(external: "/")
   end
 
   @doc """
@@ -47,7 +47,7 @@ defmodule Constable.AuthController do
     %{"email" => email, "name" => name} = get_tokeninfo!(id_token)
 
     case find_or_insert_user(email, name) do
-      nil -> conn |> put_status(403) |> json %{error: "Non-thoughtbot email"}
+      nil -> conn |> put_status(403) |> json(%{error: "Non-thoughtbot email"})
       user -> conn |> put_status(201) |>  render("show.json", user: user)
     end
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -39,12 +39,12 @@ defmodule Constable.User do
 
   defp require_thoughtbot_email(changeset) do
     changeset
-    |> validate_change :email, fn(:email, value) ->
+    |> validate_change(:email, fn(:email, value) ->
       case String.split(value, "@") do
         [_, "thoughtbot.com"] -> []
         _ -> [email: "must be a member of thoughtbot"]
       end
-    end
+    end)
   end
 
   defp generate_token(changeset) do


### PR DESCRIPTION
Elixir 1.2 adds new warnings for ambiguous pipelines. This fixes those
warnings and removes unused code.
