### PR TITLE
Allow interests to have associated slack channel

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -5,3 +5,4 @@ MANDRILL_KEY=GetFromMandrillSettings
 FRONT_END_URI=http://localhost:8000
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
+SLACK_WEBHOOK_URL=https://fakeslack/webhook

--- a/priv/repo/migrations/20151218210106_add_slack_channel_to_interest.exs
+++ b/priv/repo/migrations/20151218210106_add_slack_channel_to_interest.exs
@@ -1,0 +1,9 @@
+defmodule Constable.Repo.Migrations.AddSlackWebhookToInterest do
+  use Ecto.Migration
+
+  def change do
+    alter table(:interests) do
+      add :slack_channel, :string
+    end
+  end
+end

--- a/test/controllers/api/interest_controller_test.exs
+++ b/test/controllers/api/interest_controller_test.exs
@@ -22,4 +22,12 @@ defmodule Constable.Api.InterestControllerTest do
 
     assert json_response(conn, 200)["interest"]["id"] == interest.id
   end
+
+  test "#update changes the slack channel and adds leading #", %{conn: conn} do
+    interest = create(:interest)
+
+    conn = put conn, interest_path(conn, :update, interest.id), channel: "boston"
+
+    assert json_response(conn, 200)["interest"]["slack_channel"] == "#boston"
+  end
 end

--- a/test/views/api/interest_view_test.exs
+++ b/test/views/api/interest_view_test.exs
@@ -11,6 +11,7 @@ defmodule Constable.Api.InterestViewTest do
       interest: %{
         id: interest.id,
         name: interest.name,
+        slack_channel: interest.slack_channel,
       }
     }
   end

--- a/web/models/interest.ex
+++ b/web/models/interest.ex
@@ -5,6 +5,7 @@ defmodule Constable.Interest do
 
   schema "interests" do
     field :name
+    field :slack_channel
     timestamps
 
     has_many :announcements_interests, AnnouncementInterest, on_delete: :fetch_and_delete
@@ -20,5 +21,11 @@ defmodule Constable.Interest do
     |> update_change(:name, &String.replace(&1, "#", ""))
     |> update_change(:name, &String.downcase/1)
     |> unique_constraint(:name)
+  end
+
+  def update_channel_changeset(interest, channel_name) do
+    interest
+    |> cast(%{slack_channel: channel_name}, ~w(slack_channel))
+    |> update_change(:slack_channel, &Regex.replace(~r/^#*/, &1, "#"))
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -48,7 +48,7 @@ defmodule Constable.Router do
 
     resources "/announcements", AnnouncementController
     resources "/comments", CommentController, only: [:create]
-    resources "/interests", InterestController, only: [:index, :show]
+    resources "/interests", InterestController, only: [:index, :show, :update]
     resources "/searches", SearchController, only: [:create]
     resources "/subscriptions", SubscriptionController, only: [:index, :create, :delete]
     resources "/user_interests", UserInterestController, only: [:index, :show, :create, :delete]

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -7,6 +7,7 @@ defmodule Constable.Services.AnnouncementCreator do
 
   alias Constable.Services.AnnouncementInterestAssociator
   alias Constable.Services.MentionFinder
+  alias Constable.Services.SlackHook
 
   def create(params, interest_names) do
     changeset = Announcement.changeset(%Announcement{}, :create, params)
@@ -17,6 +18,7 @@ defmodule Constable.Services.AnnouncementCreator do
         |> Repo.preload(:user)
         |> subscribe_author
         |> email_and_subscribe_users
+        |> SlackHook.new_announcement
 
         {:ok, announcement}
       error -> error

--- a/web/services/slack_hook.ex
+++ b/web/services/slack_hook.ex
@@ -1,0 +1,34 @@
+defmodule Constable.Services.SlackHook do
+  alias Constable.Repo
+
+  def new_announcement(announcement) do
+    announcement = announcement |> Repo.preload([:interests, :user])
+
+    Enum.each(announcement.interests, fn(interest) ->
+      if interest.slack_channel do
+        payload = %{
+          text: "#{announcement.user.name} posted <#{front_end_uri}/announcements/#{announcement.id}|#{announcement.title}> on Constable",
+          channel: interest.slack_channel,
+        }
+
+        post(payload)
+      end
+    end)
+  end
+
+  defp post(payload) do
+    if slack_webhook_url do
+      spawn fn ->
+        HTTPoison.post(slack_webhook_url, Poison.encode!(payload))
+      end
+    end
+  end
+
+  defp front_end_uri do
+    System.get_env("FRONT_END_URI")
+  end
+
+  defp slack_webhook_url do
+    System.get_env("SLACK_WEBHOOK_URL")
+  end
+end

--- a/web/views/api/interest_view.ex
+++ b/web/views/api/interest_view.ex
@@ -13,6 +13,7 @@ defmodule Constable.Api.InterestView do
     %{
       id: interest.id,
       name: interest.name,
+      slack_channel: interest.slack_channel,
     }
   end
 end


### PR DESCRIPTION
When an announcement is created all interests that have an associated
slack channel have that announcement posted to that channel.
