### PR TITLE
Allow user to update name

### DIFF
--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -56,10 +56,12 @@ defmodule Constable.Api.UserControllerTest do
   test "#update updates the current user", %{conn: conn, user: user} do
     conn = put conn, user_path(conn, :update), user: %{
       daily_digest: false,
-      auto_subscribe: false
+      auto_subscribe: false,
+      name: "Ian Justin"
     }
 
     assert json_response(conn, 200)["user"]["id"] == user.id
+    assert json_response(conn, 200)["user"]["name"] == "Ian Justin"
     assert json_response(conn, 200)["user"]["daily_digest"] == false
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -26,7 +26,7 @@ defmodule Constable.User do
   end
 
   def changeset(user, params) do
-    user |> cast(params, ~w(), ~w(daily_digest auto_subscribe))
+    user |> cast(params, ~w(), ~w(auto_subscribe daily_digest name))
   end
 
   def create_changeset(user \\ %__MODULE__{}, params) do


### PR DESCRIPTION
This adds the name field to the whitelist of attributes that are allowed
to be updated through the update api endpoint for `User`, as well as a
test.
