### PR TITLE
Fallback to username if name is not set

### DIFF
--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -29,4 +29,13 @@ defmodule Constable.UserTest do
     refute changeset.valid?
     assert changeset.errors[:email] == "must be a member of thoughtbot"
   end
+
+  test "create_changeset sets name from username only if the name is blank" do
+    changeset = User.create_changeset(%User{}, %{email: "foo@bar.com", name: "Real Name"})
+    assert changeset.changes.name == "Real Name"
+
+    username = "foobar"
+    changeset = User.create_changeset(%User{}, %{email: username <> "@foo.com"})
+    assert changeset.changes.name == username
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -31,10 +31,11 @@ defmodule Constable.User do
 
   def create_changeset(user \\ %__MODULE__{}, params) do
     user
-    |> cast(params, ~w(email name), [])
+    |> cast(params, ~w(email), ~w(name))
     |> require_thoughtbot_email
     |> generate_token
     |> generate_username
+    |> ensure_name_is_set
   end
 
   defp require_thoughtbot_email(changeset) do
@@ -59,6 +60,23 @@ defmodule Constable.User do
       put_change changeset, :username, username
     else
       changeset
+    end
+  end
+
+  defp ensure_name_is_set(changeset) do
+    username = changeset |> get_change(:username)
+    if get_change(changeset, :name) |> is_blank? do
+      changeset |> put_change(:name, username)
+    else
+      changeset
+    end
+  end
+
+  defp is_blank?(nil), do: true
+  defp is_blank?(string) when is_binary(string) do
+    case String.strip(string) do
+      "" -> true
+      _ -> false
     end
   end
 end


### PR DESCRIPTION
Closes #148

Sometimes user's don't have their name set up in Gmail so it was blank in the database. This makes it so that the changeset uses the username if the name if not there.
