### PR TITLE
Link new interests in daily digest

### DIFF
--- a/web/templates/email/daily_digest.html.eex
+++ b/web/templates/email/daily_digest.html.eex
@@ -116,7 +116,11 @@
 
                 <ul>
                   <%= for interest <- @interests do %>
-                    <li>#<%= interest.name %></li>
+                    <li>
+                      <a href="<%= front_end_uri %>/interests/<%= interest.id %>" style="color: #c32f34;">
+                        #<%= interest.name %>
+                      </a>
+                    </li>
                   <% end %>
                 </ul>
 

--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -4,9 +4,8 @@ New Interests
 -------------
 
 <%= for interest <- @interests do %>
-#<%= interest.name %>
+  #<%= interest.name %> - <%= front_end_uri %>/interests/<%= interest.id %>
 <% end %>
-
 
 New Announcements
 -----------------
@@ -16,7 +15,6 @@ New Announcements
   posted by <%= announcement.user.name %>
 
 <% end %>
-
 
 View Interests and Announcements on Constable
 <%= front_end_uri %>/announcements


### PR DESCRIPTION
The daily digest contains new interests and new announcements. The
announcements are linked but the interests are not. Most of the time the
post that triggered the new interest is in the list of new
announcements, but it doesn't have to be.

Linking the interests as well keeps the mail consistent.
