### PR TITLE
Change prod to use port 80 for URL helpers

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,8 +12,8 @@ use Mix.Config
 # disk for the key and cert.
 
 config :constable, Constable.Endpoint,
-  url: [host: System.get_env("HOST")],
-  http: [port: 80, compress: true],
+  url: [host: System.get_env("HOST"), port: 80],
+  http: [port: {:system, "PORT"}, compress: true],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :constable, Constable.Repo,


### PR DESCRIPTION
This should not affect the React front end. We need to eventually change this to port 443, but we need to add SSL to staging first.

Since the Phoenix front end is not ready for production it should not be an issue if this is deployed
