### PR TITLE
Interest Page (in Phoenix)

### DIFF
--- a/test/acceptance/user_views_interest_page_test.exs
+++ b/test/acceptance/user_views_interest_page_test.exs
@@ -1,0 +1,72 @@
+defmodule Constable.UserViewsInterestPageTest do
+  use Constable.AcceptanceCase
+
+  test "user views interest page", %{session: session} do
+    matching_interest = create(:interest, name: "foobar1s")
+    matching_announcement = create(:announcement, title: "foobar1")
+      |> tag_with_interest(matching_interest)
+    _non_matching_announcement = create(:announcement, title: "foobar2")
+    user = create(:user)
+
+    session
+    |> visit(interest_path(Endpoint, :show, matching_interest, as: user.id))
+
+    assert has_announcement_text?(session, matching_announcement.title)
+    assert find(session, ".announcement-list", count: 1)
+  end
+
+  test "user adds the slack channel for an interest", %{session: session} do
+    interest = create(:interest, name: "interest")
+    user = create(:user)
+
+    session
+    |> visit(interest_path(Endpoint, :show, interest.id, as: user.id))
+    |> click_edit_interest
+    |> fill_in("interest_slack_channel", with: "#channel-name")
+    |> click_submit
+
+    assert has_channel_text?(session, "#channel-name")
+  end
+
+  test "user edits an existing slack channel for an interest", %{session: session} do
+    interest = create(:interest, name: "interest", slack_channel: "#channel-name")
+    user = create(:user)
+
+    visit(session, interest_path(Endpoint, :show, interest, as: user.id))
+
+    assert has_channel_text?(session, "#channel-name")
+
+    session
+    |> click_edit_interest
+    |> fill_in("interest_slack_channel", with: "#new-channel-name")
+    |> click_submit
+
+    assert has_channel_text?(session, "#new-channel-name")
+  end
+
+  defp has_announcement_text?(session, announcment_title) do
+    session
+    |> find("h1[data-role=title]")
+    |> has_text?(announcment_title)
+  end
+
+  defp click_edit_interest(session) do
+    session
+    |> find("a[data-role=edit-interest]")
+    |> click
+
+    session
+  end
+
+  defp has_channel_text?(session, channel_name) do
+    session
+    |> find("p[data-role=current-channel]")
+    |> has_text?(channel_name)
+  end
+
+  defp click_submit(session) do
+    session
+    |> find("#submit-channel-name")
+    |> click
+  end
+end

--- a/web/controllers/interest_controller.ex
+++ b/web/controllers/interest_controller.ex
@@ -1,0 +1,10 @@
+defmodule Constable.InterestController do
+  use Constable.Web, :controller
+
+  alias Constable.Interest
+
+  def show(conn, %{"id" => id}) do
+    interest = Repo.get!(Interest.with_announcements, id)
+    render conn, "show.html", interest: interest
+  end
+end

--- a/web/controllers/slack_channel_controller.ex
+++ b/web/controllers/slack_channel_controller.ex
@@ -1,0 +1,23 @@
+defmodule Constable.SlackChannelController do
+  use Constable.Web, :controller
+
+  alias Constable.Interest
+
+  def edit(conn, %{"interest_id" => id}) do
+    interest = Repo.get!(Interest.with_announcements, id)
+    changeset = Interest.update_channel_changeset(interest, interest.slack_channel)
+    render conn, "edit.html", interest: interest, changeset: changeset
+  end
+
+  def update(conn, %{"interest_id" => id, "interest" => %{"slack_channel" => channel}}) do
+    interest = Repo.get!(Interest.with_announcements, id)
+    case Repo.update(Interest.update_channel_changeset(interest, channel)) do
+      {:ok, interest} ->
+        redirect conn, to: interest_path(conn, :show, interest)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Constable.ChangesetView, "edit.html", changeset: changeset)
+    end
+  end
+end

--- a/web/models/interest.ex
+++ b/web/models/interest.ex
@@ -1,7 +1,6 @@
 defmodule Constable.Interest do
   use Constable.Web, :model
-  alias Constable.UserInterest
-  alias Constable.AnnouncementInterest
+  alias Constable.{Announcement, AnnouncementInterest, UserInterest}
 
   schema "interests" do
     field :name
@@ -21,6 +20,11 @@ defmodule Constable.Interest do
     |> update_change(:name, &String.replace(&1, "#", ""))
     |> update_change(:name, &String.downcase/1)
     |> unique_constraint(:name)
+  end
+
+  def with_announcements(query \\ __MODULE__) do
+    from interest in query,
+      preload: [announcements: ^Announcement.with_announcement_list_assocs]
   end
 
   def update_channel_changeset(interest, channel_name) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -31,6 +31,9 @@ defmodule Constable.Router do
     end
     resources "/settings", SettingsController, singleton: true, only: [:show, :update]
     resources "/unsubscribe", UnsubscribeController, only: [:show]
+    resources "/interests", InterestController, only: [:show] do
+      resources "/slack_channel", SlackChannelController, singleton: true, only: [:edit, :update]
+    end
     get "/search", SearchController, :new
 
     if Mix.env == :dev do

--- a/web/static/css/_interest.scss
+++ b/web/static/css/_interest.scss
@@ -1,0 +1,6 @@
+.page-interest,
+.page-slack-channel {
+  .interest {
+    margin-top: $base-spacing;
+  }
+}

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -12,4 +12,6 @@
 @import 'announcement';
 @import 'comments';
 
+@import 'interest';
+
 @import 'settings';

--- a/web/templates/announcement_list/index.html.eex
+++ b/web/templates/announcement_list/index.html.eex
@@ -1,4 +1,4 @@
-<ul class="container">
+<ul class="container announcement-list">
   <%= for announcement <- @announcements do %>
     <li class="announcement-list-item">
       <%= link to: announcement_path(@conn, :show, announcement.id) do %>

--- a/web/templates/interest/show.html.eex
+++ b/web/templates/interest/show.html.eex
@@ -1,0 +1,28 @@
+<div class="page-interest">
+  <div class="interest container">
+    <h1><%= @interest.name %></h1>
+
+    <div class="current-channel">
+      <%= link to: interest_slack_channel_path(@conn, :edit, @interest), data: [role: "edit-interest"] do %>
+        <%= if @interest.slack_channel do %>
+          <p data-role="current-channel">
+            <%=
+              gettext(
+                "New announcements are posted to the %{channel} channel in Slack. Click to edit.",
+                channel: @interest.slack_channel
+              )
+            %>
+          </p>
+        <% else %>
+          <p>Click here to add a slack channel webhook to this interest.</p>
+        <% end %>
+      <% end %>
+    </div>
+
+    <hr/>
+
+    <div class="announcements">
+      <%= render Constable.AnnouncementListView, "index.html", conn: @conn, announcements: @interest.announcements %>
+    </div>
+  </div>
+</div>

--- a/web/templates/slack_channel/edit.html.eex
+++ b/web/templates/slack_channel/edit.html.eex
@@ -1,0 +1,16 @@
+<div class="page-slack-channel">
+  <div class="interest container">
+    <h1><%= @interest.name %></h1>
+
+    <div>
+      <%= gettext("Here you can enter the slack channel to be notified when an announcement is created for this interest.") %>
+    </div>
+
+    <div class="current-channel">
+      <%= form_for @changeset, interest_slack_channel_path(@conn, :update, @interest), fn f -> %>
+        <%= text_input f, :slack_channel %>
+        <%= submit gettext("Save"), id: "submit-channel-name" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/web/views/interest_view.ex
+++ b/web/views/interest_view.ex
@@ -1,0 +1,3 @@
+defmodule Constable.InterestView do
+  use Constable.Web, :view
+end

--- a/web/views/slack_channel_view.ex
+++ b/web/views/slack_channel_view.ex
@@ -1,0 +1,3 @@
+defmodule Constable.SlackChannelView do
+  use Constable.Web, :view
+end


### PR DESCRIPTION
This brings the interest's announcements page over to Phoenix as well as the `slack_channel` edit/updating.

![2016-04-25-143217-scrot-targeted](https://cloud.githubusercontent.com/assets/4008677/14794525/9a61310c-0af2-11e6-9d8c-70ea7366b841.png)
![2016-04-25-143221-scrot-targeted](https://cloud.githubusercontent.com/assets/4008677/14794524/9a6062c2-0af2-11e6-8007-6ea810f3c909.png)
