### PR TITLE
Add default to announcement list query

### DIFF
--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -11,10 +11,7 @@ defmodule Constable.AnnouncementController do
   end
 
   def show(conn, %{"id" => id}) do
-    announcement =
-      Announcement
-      |> Announcement.with_announcement_list_assocs
-      |> Repo.get!(id)
+    announcement = Repo.get!(Announcement.with_announcement_list_assocs, id)
     comment = Comment.changeset(:create, %{})
     subscription = Repo.get_by(Subscription,
       announcement_id: announcement.id,
@@ -38,8 +35,7 @@ defmodule Constable.AnnouncementController do
   end
 
   defp all_announcements do
-    Announcement
-    |> Announcement.with_announcement_list_assocs
+    Announcement.with_announcement_list_assocs
     |> Repo.all
     |> sort_announcements
   end

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -29,7 +29,7 @@ defmodule Constable.Announcement do
     |> cast(params, ~w(title body user_id), [])
   end
 
-  def with_announcement_list_assocs(query) do
+  def with_announcement_list_assocs(query \\ __MODULE__) do
     from q in query, preload: [
       :interests,
       :user,


### PR DESCRIPTION
This allows for the removal of boiler plate code, which has also been
removed in this commit.
