### PR TITLE
Add mousetrap to comments

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -52,6 +52,7 @@ exports.config = {
     whitelist: [
       "jquery",
       "marked",
+      "mousetrap",
       "phoenix",
       "phoenix_html",
       "selectize",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bourbon-neat": "^1.7.2",
     "jquery": "^2.2.0",
     "marked": "^0.3.5",
+    "mousetrap": "^1.5.3",
     "phoenix": "file:deps/phoenix",
     "phoenix_html": "file:deps/phoenix_html",
     "selectize": "^0.12.1",

--- a/web/static/css/_announcement.scss
+++ b/web/static/css/_announcement.scss
@@ -84,7 +84,7 @@
 }
 
 .announcement-body,
-.comment-body {
+.comment-form {
   h1,
   h2,
   h3,

--- a/web/static/js/comment-form.js
+++ b/web/static/js/comment-form.js
@@ -1,17 +1,19 @@
-import $ from "jquery"
-import socket from "./socket"
+import $ from 'jquery'
+import Mousetrap from 'mousetrap';
+
+import socket from './socket'
 
 const resetForm = (form) => form.reset();
-const disableForm = (form) => form.children(":input").attr("disabled", "disabled");
-const enableForm = (form) => form.children(":input").removeAttr("disabled");
+const disableForm = (form) => form.children(':input').attr('disabled', 'disabled');
+const enableForm = (form) => form.children(':input').removeAttr('disabled');
 
-$(".comment-form").on("submit", function submitForm(event) {
+$('.comment-form').on('submit', function submitForm(event) {
   event.preventDefault();
-  var form = $(this);
+  const form = $(this);
 
   $.ajax({
-    type: "POST",
-    url: form.attr("action"),
+    type: 'POST',
+    url: form.attr('action'),
     data: form.serialize(),
     beforeSend: () => disableForm(form),
   })
@@ -21,13 +23,24 @@ $(".comment-form").on("submit", function submitForm(event) {
   });
 });
 
-var channel = socket.channel("live-html", {});
+const channel = socket.channel('live-html', {});
 
 channel.join()
-  .receive("ok", function(resp) { console.log("Joined successfully", resp) })
-  .receive("error", function(resp) { console.log("Unable to join", resp) })
+  .receive('ok', function(resp) { console.log('Joined successfully', resp) })
+  .receive('error', function(resp) { console.log('Unable to join', resp) })
 
-channel.on("new-comment", payload => {
-  $(`[data-announcement-id="${payload.announcement_id}"] .comments-list`)
+channel.on('new-comment', payload => {
+  $(`[data-announcement-id='${payload.announcement_id}'] .comments-list`)
     .append(payload.comment_html)
 })
+
+const SAVE_SHORTCUT = ['mod+enter'];
+
+const $form = $('.comment-form');
+const $body = $form.find('textarea');
+
+Mousetrap.bind(SAVE_SHORTCUT, function() {
+  if ($body.val() !== '') {
+    $form.submit();
+  }
+});

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -46,11 +46,10 @@
   </ul>
 
   <div class="comment-new">
-    <div class="comment-body">
       <%= form_for @comment, announcement_comment_path(@conn, :create, @announcement), [class: "comment-form"], fn(f) -> %>
         <%= textarea f,
           :body,
-          class: "new-comment-textarea moustrap",
+          class: "new-comment-textarea mousetrap",
           placeholder: gettext("Your markdown formatted comment here"),
           required: true
         %>


### PR DESCRIPTION
When adding a comment, this allows cmd+enter or ctrl+enter to submit the
comment for you.

Closes #184 
