### PR TITLE
Allow URL_PORT to be configured in production

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,7 +12,7 @@ use Mix.Config
 # disk for the key and cert.
 
 config :constable, Constable.Endpoint,
-  url: [host: System.get_env("HOST"), port: 80],
+  url: [host: System.get_env("HOST"), port: System.get_env("URL_PORT")],
   http: [port: {:system, "PORT"}, compress: true],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
 erlang_version=18.0.2
 elixir_version=1.2.1
 always_rebuild=true
-config_vars_to_export=(DATABASE_URL MANDRILL_KEY)
+config_vars_to_export=(DATABASE_URL MANDRILL_KEY URL_PORT)


### PR DESCRIPTION
This allows a developer to configure URL ports in production for http:
vs https: (port 80 vs 443, respectively).
