### PR TITLE
Replace email links with helpers

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,7 +2,6 @@ CLIENT_ID=GetFromGoogleDeveloperConsole
 CLIENT_SECRET=GetFromGoogleDeveloperConsole
 REDIRECT_URI=http://localhost:4000/auth/callback
 MANDRILL_KEY=GetFromMandrillSettings
-FRONT_END_URI=http://localhost:8000
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook

--- a/web/services/slack_hook.ex
+++ b/web/services/slack_hook.ex
@@ -1,4 +1,6 @@
 defmodule Constable.Services.SlackHook do
+  import Constable.Router.Helpers
+
   alias Constable.Repo
 
   def new_announcement(announcement) do
@@ -7,7 +9,7 @@ defmodule Constable.Services.SlackHook do
     Enum.each(announcement.interests, fn(interest) ->
       if interest.slack_channel do
         payload = %{
-          text: "#{announcement.user.name} posted <#{front_end_uri}/announcements/#{announcement.id}|#{announcement.title}>",
+          text: "#{announcement.user.name} posted <#{announcement_url(Constable.Endpoint, :show, announcement)}|#{announcement.title}>",
           channel: interest.slack_channel,
         }
 
@@ -22,10 +24,6 @@ defmodule Constable.Services.SlackHook do
         HTTPoison.post(slack_webhook_url, Poison.encode!(payload))
       end
     end
-  end
-
-  defp front_end_uri do
-    System.get_env("FRONT_END_URI")
   end
 
   defp slack_webhook_url do

--- a/web/templates/email/author_footer.html.eex
+++ b/web/templates/email/author_footer.html.eex
@@ -12,8 +12,10 @@
     </table>
   </td>
   <td align="right">
-    <a href="<%= front_end_uri %>/announcements/<%= @announcement.id  %>" style="color: <%= red %>; font-size: 14px;">
-      View on #Constable
-    </a>
+    <%= link to: announcement_url(Constable.Endpoint, :show, @announcement) do %>
+      <span style="color: <%= red %>; font-size: 14px;">
+        <%= gettext("View on #Constable") %>
+      </span>
+    <% end %>
   </td>
 </tr>

--- a/web/templates/email/daily_digest.html.eex
+++ b/web/templates/email/daily_digest.html.eex
@@ -112,14 +112,12 @@
             <tr>
               <td width='40'></td>
               <td align='left'>
-                <h4>Recently added interests</h4>
+                <h4><%= gettext("Recently added interests") %></h4>
 
                 <ul>
                   <%= for interest <- @interests do %>
                     <li>
-                      <a href="<%= front_end_uri %>/interests/<%= interest.id %>" style="color: #c32f34;">
-                        #<%= interest.name %>
-                      </a>
+                      <%= link "##{interest.name}", to: interest_url(Constable.Endpoint, :show, interest), style: "color: #{red}" %>
                     </li>
                   <% end %>
                 </ul>
@@ -128,10 +126,8 @@
                 <ul>
                   <%= for announcement <- @announcements do %>
                     <li>
-                      <a href="<%= front_end_uri %>/announcements/<%= announcement.id %>" style='color: #c32f34;'>
-                        <%= announcement.title %>
-                      </a>
-                      posted by <strong><%= announcement.user.name %></strong>
+                      <%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %>
+                      <%= gettext("posted by") %> <strong><%= announcement.user.name %></strong>
                     </li>
                   <% end %>
                 </ul>
@@ -149,11 +145,11 @@
             <tr>
               <td width='40'></td>
               <td align='center'>
-                <a href="<%= front_end_uri %>/announcements" style='color: #c32f34;'>
-                  <h4 style='#c32f34 font-size: 18px; margin: 0; padding-bottom: 5px;'>
-                    View Interests and Announcements on Constable
+                <%= link to: announcement_url(Constable.Endpoint, :index) do %>
+                  <h4 style='color: <%= red %>; font-size: 18px; margin: 0; padding-bottom: 5px;'>
+                    <%= gettext("View Interests and Announcements on Constable") %>
                   </h4>
-                </a>
+                <% end %>
               </td>
               <td width='40'></td>
             </tr>

--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -1,20 +1,20 @@
-# Daily digest of new Interests and Announcements
+<%= gettext("# Daily digest of new Interests and Announcements") %>
 
-New Interests
+<%= gettext("New Interests") %>
 -------------
 
 <%= for interest <- @interests do %>
-  #<%= interest.name %> - <%= front_end_uri %>/interests/<%= interest.id %>
+  #<%= interest.name %> - <%= interest_url(Constable.Endpoint, :show, interest) %>
 <% end %>
 
-New Announcements
+<%= gettext("New Announcements") %>
 -----------------
 
 <%= for announcement <- @announcements do %>
-  <%= announcement.title %> - <%= front_end_uri %>/announcements/<%= announcement.id %>
-  posted by <%= announcement.user.name %>
+  <%= announcement.title %> - <%= announcement_url(Constable.Endpoint, :show, announcement) %>
+  <%= gettext("posted by") %> <%= announcement.user.name %>
 
 <% end %>
 
-View Interests and Announcements on Constable
-<%= front_end_uri %>/announcements
+<%= gettext("View Interests and Announcements on Constable") %>
+<%= announcement_path(Constable.Endpoint, :index) %>

--- a/web/templates/email/new_announcement.text.eex
+++ b/web/templates/email/new_announcement.text.eex
@@ -1,3 +1,3 @@
 <%= @announcement.body %>
 
-<%= front_end_uri %>/announcements/<%= @announcement.id  %>
+<%= announcement_url(Constable.Endpoint, :show, @announcement) %>

--- a/web/templates/email/new_comment.text.eex
+++ b/web/templates/email/new_comment.text.eex
@@ -1,5 +1,5 @@
 <%= @comment.body %>
 
-<%= front_end_uri %>/announcements/<%= @comment.announcement.id %>
+<%= announcement_url(Constable.Endpoint, :show, @comment.announcement) %>
 
-Unsubscribe: <%= unsubscribe_link %>
+<%= gettext("Unsubscribe:") %> <%= unsubscribe_link %>

--- a/web/templates/email/unsubscribe_footer.html.eex
+++ b/web/templates/email/unsubscribe_footer.html.eex
@@ -1,5 +1,9 @@
 <tr>
   <td colspan="2" height="125" align="center">
-    <a href="<%= unsubscribe_link %>" style="font-size: 13px; color: <%= light_gray %>;">Unsubscribe from emails</a>
+    <%= link to: unsubscribe_link do %>
+      <span style="color: <%= light_gray %>; font-size: 13px;">
+        <%= gettext("Unsubscribe from emails") %>
+      </span>
+    <% end %>
   </td>
 </tr>

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -10,22 +10,14 @@ defmodule Constable.EmailView do
   end
 
   def unsubscribe_link do
-    back_end_uri <> "/unsubscribe/{{subscription_id}}"
-  end
-
-  def front_end_uri do
-    System.get_env("FRONT_END_URI")
+    unsubscribe_url(Constable.Endpoint, :show, subscription_id_merge_variable)
   end
 
   def author_avatar_url(user) do
     Exgravatar.generate(user.email)
   end
 
-  defp back_end_uri do
-    "http://#{back_end_host}"
-  end
-
-  defp back_end_host do
-    Application.get_env(:constable, Constable.Endpoint) |> get_in([:url, :host])
+  defp subscription_id_merge_variable do
+    "{{subscription_id}}"
   end
 end


### PR DESCRIPTION
remove all the raw html links and replace them with helpers
Also, removes the reliance on `FRONT_END_URI` for the slack hook service
