### PR TITLE
Ajax links

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -54,7 +54,6 @@ exports.config = {
       "marked",
       "mousetrap",
       "phoenix",
-      "phoenix_html",
       "selectize",
       "textarea-autogrow",
       "turbolinks",

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,4 +15,4 @@ config :constable, Constable.Mailer,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-config :wallaby, :max_wait_time, 50
+config :wallaby, :max_wait_time, 250

--- a/mix.exs
+++ b/mix.exs
@@ -48,27 +48,27 @@ defmodule Constable.Mixfile do
   # Type `mix help deps` for examples and options
   defp deps do
     [
-      {:bamboo, "~> 0.4.0"},
-      {:cors_plug, "~> 0.1.3"},
+      {:bamboo, "~> 0.4"},
+      {:cors_plug, "~> 0.1"},
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.3", only: [:dev]},
       {:earmark, "~> 0.1.17"},
       {:ecto, "~> 1.1"},
       {:envy, "~> 0.0.1"},
-      {:ex_machina, "~> 0.6.1"},
-      {:exgravatar, "~> 0.2.0"},
-      {:gettext, "~> 0.11.0"},
+      {:ex_machina, "~> 0.6"},
+      {:exgravatar, "~> 0.2"},
+      {:gettext, "~> 0.11"},
       {:good_times, "~> 1.1"},
       {:httpoison, github: "edgurgel/httpoison", override: true},
-      {:oauth2, "~> 0.5.0"},
-      {:pact, "~> 0.1.0"},
-      {:phoenix_ecto, "~> 1.2.0"},
+      {:oauth2, "~> 0.5"},
+      {:pact, "0.1.0"},
+      {:phoenix_ecto, "~> 1.2"},
       {:phoenix_html, "~> 2.4"},
-      {:phoenix, "~> 1.1.4"},
+      {:phoenix, "~> 1.1"},
       {:postgrex, ">= 0.0.0"},
       {:secure_random, "~> 0.1"},
-      {:timex, "~> 2.1.4"},
-      {:wallaby, "~> 0.4.0", only: :test},
+      {:timex, "~> 2.1"},
+      {:wallaby, "~> 0.5", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "cowboy": {:hex, :cowboy, "1.0.4"},
   "cowlib": {:hex, :cowlib, "1.0.2"},
   "db_connection": {:hex, :db_connection, "0.2.5"},
-  "decimal": {:hex, :decimal, "1.1.1"},
+  "decimal": {:hex, :decimal, "1.1.2"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "dialyze": {:hex, :dialyze, "0.2.1"},
   "earmark": {:hex, :earmark, "0.1.19"},
@@ -22,7 +22,7 @@
   "metrics": {:hex, :metrics, "1.0.1"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mimetype_parser": {:hex, :mimetype_parser, "0.1.2"},
-  "oauth2": {:hex, :oauth2, "0.5.0"},
+  "oauth2": {:hex, :oauth2, "0.6.0"},
   "pact": {:hex, :pact, "0.1.0"},
   "phoenix": {:hex, :phoenix, "1.1.4"},
   "phoenix_ecto": {:hex, :phoenix_ecto, "1.2.0"},
@@ -36,4 +36,4 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
   "timex": {:hex, :timex, "2.1.4"},
   "tzdata": {:hex, :tzdata, "0.5.7"},
-  "wallaby": {:hex, :wallaby, "0.4.0"}}
+  "wallaby": {:hex, :wallaby, "0.5.0"}}

--- a/test/acceptance/user_manages_interests_test.exs
+++ b/test/acceptance/user_manages_interests_test.exs
@@ -1,58 +1,44 @@
 defmodule Constable.UserManagesInterestsTest do
   use Constable.AcceptanceCase
 
+  @unsubscribe_link_css "[data-role=unsubscribe-from-interest]"
+  @subscribe_link_css "[data-role=subscribe-to-interest]"
+  @view_all_interests_css "[data-role=view-all-interests]"
+
   test "user manages interests", %{session: session} do
-    interest_everyone = create(:interest, name: "Everyone")
-    interest_design = create(:interest, name: "Design")
+    create(:interest)
 
     session |> view_interests
+    assert not_subscribed_to_interest?(session)
 
-    assert not_subscribed_to?(session, interest_everyone)
-    assert not_subscribed_to?(session, interest_design)
+    session |> subscribe_to_interest
+    assert subscribed_to_interest?(session)
 
-    session |> subscribe_to(interest_everyone)
-
-    assert subscribed_to?(session, interest_everyone)
-    assert not_subscribed_to?(session, interest_design)
-
-    session |> unsubscribe_from(interest_everyone)
-
-    assert not_subscribed_to?(session, interest_everyone)
-    assert not_subscribed_to?(session, interest_design)
+    session |> unsubscribe_from_interest
+    assert not_subscribed_to_interest?(session)
   end
 
-  defp view_interests(session, user \\ create(:user)) do
+  defp view_interests(session) do
+    user = create(:user)
+
     session
     |> visit(announcement_path(Endpoint, :index, as: user.id))
-    |> click("[data-role=view-all-interests]")
+    |> click(@view_all_interests_css)
   end
 
-  defp subscribed_to?(session, interest) do
-    session
-    |> find_interest(interest)
-    |> has_css?("[data-role=unsubscribe-from-interest]")
+  defp subscribed_to_interest?(session) do
+    session |> has_css?(@unsubscribe_link_css)
   end
 
-  defp not_subscribed_to?(session, interest) do
-    session
-    |> find_interest(interest)
-    |> has_css?("[data-role=subscribe-to-interest]")
+  defp not_subscribed_to_interest?(session) do
+    session |> has_css?(@subscribe_link_css)
   end
 
-  defp subscribe_to(session, interest) do
-    session
-    |> find_interest(interest)
-    |> click("[data-role='subscribe-to-interest']")
+  defp subscribe_to_interest(session) do
+    session |> click(@subscribe_link_css)
   end
 
-  defp unsubscribe_from(session, interest) do
-    session
-    |> find_interest(interest)
-    |> click("[data-role='unsubscribe-from-interest']")
-  end
-
-  defp find_interest(session, interest) do
-    session
-    |> find(".interest-list-item[data-id='#{interest.id}']")
+  defp unsubscribe_from_interest(session) do
+    session |> click(@unsubscribe_link_css)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,9 +1,8 @@
 :erlang.system_flag :backtrace_depth, 50
 ExUnit.configure exclude: [pending: true]
-{:ok, _} = Application.ensure_all_started(:wallaby)
-ExUnit.start
 {:ok, _} = Application.ensure_all_started(:bamboo)
 {:ok, _} = Application.ensure_all_started(:wallaby)
+ExUnit.start
 Pact.put(:google_strategy, FakeGoogleStrategy)
 
 # Create the database, run migrations, and start the test transaction.

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1,3 +1,2 @@
 import './custom_phoenix_html';
 import 'turbolinks';
-// import './socket';

--- a/web/static/js/custom_phoenix_html.js
+++ b/web/static/js/custom_phoenix_html.js
@@ -1,10 +1,16 @@
 import $ from "jquery";
+import refreshWithTurbolinks from "./turbolinks-refresh";
 
-$(document).on("click", "a[data-submit=parent]", function(event) {
+$(document).on("click", "a[data-submit=parent], a[data-turbolinks=refresh]", function(event) {
   event.preventDefault();
+  const link = $(this);
 
   const message = event.target.getAttribute("data-confirm");
   if (message === null || confirm(message)) {
-    event.target.parentNode.submit();
+    if (link.attr("data-turbolinks") === "refresh") {
+      refreshWithTurbolinks(link);
+    } else {
+      event.target.parentNode.submit();
+    }
   };
 });

--- a/web/static/js/turbolinks-refresh.js
+++ b/web/static/js/turbolinks-refresh.js
@@ -1,0 +1,41 @@
+import $ from "jquery";
+
+const refreshWithTurbolinks = function(link) {
+  saveScrollPosition()
+  sendLinkWithAjax(link)
+};
+
+const shouldRestoreScrollPosition = function() {
+  return window.turbolinksPreviousScrollPosition !== null;
+}
+
+const saveScrollPosition = function() {
+  window.turbolinksPreviousScrollPosition = $(window).scrollTop();
+}
+
+const sendLinkWithAjax = function(link) {
+  var form = $(link.parent());
+
+  $.ajax({
+    type: "POST",
+    url: form.attr("action"),
+    data: form.serialize()
+  })
+  .done(refreshPageWithTurbolinks)
+}
+
+const refreshPageWithTurbolinks = function() {
+  var path = window.location.pathname + window.location.search;
+  Turbolinks.visit(path);
+}
+
+const maybeRestoreScrollPosition = function() {
+  if (shouldRestoreScrollPosition()) {
+    window.scrollTo(0, window.turbolinksPreviousScrollPosition);
+    window.turbolinksPreviousScrollPosition = null;
+  }
+}
+
+$(document).on("turbolinks:render", maybeRestoreScrollPosition)
+
+export default refreshWithTurbolinks;

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -10,13 +10,15 @@
       <%= if @subscription do %>
         <%= link to: announcement_subscription_path(@conn, :delete, @announcement.id),
           method: :delete,
-          class: "button button-unsubscribe" do %>
+          class: "button button-unsubscribe",
+          data: [turbolinks: "refresh"] do %>
           <%= gettext("Unsubscribe") %>
         <% end %>
       <% else %>
         <%= link to: announcement_subscription_path(@conn, :create, @announcement.id),
           method: :post,
-          class: "button button-subscribe" do %>
+          class: "button button-subscribe",
+          data: [turbolinks: "refresh"] do %>
           <%= gettext("Subscribe") %>
         <% end %>
       <% end %>

--- a/web/templates/interest/index.html.eex
+++ b/web/templates/interest/index.html.eex
@@ -3,20 +3,20 @@
 
   <ul class="interests-list">
     <%= for interest <- @interests do %>
-      <li class="interest-list-item" data-id="<%= interest.id %>">
+      <li class="interest-list-item">
         <h3><%= interest.name %></h3>
         <%= if interested_in?(@current_user, interest) do %>
           <%= link to: interest_user_interest_path(@conn, :delete, interest),
                 method: :delete,
                 class: "unsubscribe",
-                data: [role: "unsubscribe-from-interest"] do %>
+                data: [turbolinks: "refresh", role: "unsubscribe-from-interest"] do %>
                 <span><%= gettext("Unsubscribe") %></span>
           <% end %>
         <% else %>
           <%= link to: interest_user_interest_path(@conn, :create, interest),
                 method: :post,
                 class: "subscribe",
-                data: [role: "subscribe-to-interest"] do %>
+                data: [turbolinks: "refresh", role: "subscribe-to-interest"] do %>
                 <span><%= gettext("Subscribe") %></span>
           <% end %>
         <% end %>


### PR DESCRIPTION
This adds a data attribute that can be used post/delete links to send an AJAX request and then refresh the page with turbolinks with the scroll state restored. This gives the impression that the page never changed.
### First you need to know:
- When you use `method: :delete` or `method: :post` with Phoenix link helpers, it wraps the link in a form and adds `data-submit=parent` to the link
- The phoenix_html.js would add a handler to the window so that whenever a link with that data attribute is pressed, it gets it's parent (the form) and submits the parent instead of clicking the link. This is because links can only be GET requests, but forms can be POST
### What `data-turbolinnks=refresh` does:
- If that attribute is present it does not submit the parent form as phoenix_html.js does
- Instead it uses refreshPageWithTurbolinks
- This function saves the current scroll position
- Then it uses the link's parent form action, serializes the form and makes an AJAX request. This is basically submitting the form as we did before, but doing it with AJAX instead.
- When the AJAX response is done, we refresh the current page with Turbolinks. This is faster and will make sure there is no "flicker" in the browser
- There is an event listener added to `document` that checks if the scroll position was saved, if it is, it restores the scroll position after turbolinks renders the page. This makes it seem as if everything the page was never replaced (no jumping back to the top after the page loads)
