### PR TITLE
Use Phoenix.Controller.redirect instead of custom handling

### DIFF
--- a/web/plugs/require_login.ex
+++ b/web/plugs/require_login.ex
@@ -13,8 +13,7 @@ defmodule Constable.Plugs.RequireLogin do
 
   defp redirect_to_login(conn) do
     conn
-    |> put_resp_header("location", "/")
-    |> send_resp(302, "")
+    |> Phoenix.Controller.redirect(to: "/")
     |> halt
   end
 end


### PR DESCRIPTION
# Why?

Phoenix.Controller.redirect handles setting location header and response
code. This leverages that functionality instead of doing it ourselves.
