### PR TITLE
Force SSL

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,8 +12,9 @@ use Mix.Config
 # disk for the key and cert.
 
 config :constable, Constable.Endpoint,
-  url: [host: System.get_env("HOST"), port: System.get_env("URL_PORT")],
+  url: [scheme: "https", host: System.get_env("HOST"), port: System.get_env("URL_PORT")],
   http: [port: {:system, "PORT"}, compress: true],
+  force_ssl: [rewrite_on: [:x_forwarded_proto], host: System.get_env("HOST")],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :constable, Constable.Repo,


### PR DESCRIPTION
The docs at http://www.phoenixframework.org/docs/heroku set the `scheme` to `"https"`. I believe that made a difference. I also added the necessary URLs to the whitelist. This should work on staging.constable.io and constable-api-staging.herokuapp.com
