### PR TITLE
Fix announcement creation acceptance test

### DIFF
--- a/test/acceptance/user_creates_announcement_test.exs
+++ b/test/acceptance/user_creates_announcement_test.exs
@@ -1,20 +1,31 @@
 defmodule Constable.UserCreatesAnnouncementTest do
   use Constable.AcceptanceCase, async: true
 
-  @tag :pending
   test "user creates an announcement", %{session: session} do
     user = create(:user)
 
     session
     |> visit(announcement_path(Endpoint, :new, as: user.id))
     |> fill_in("announcement_title", with: "Hello World")
-    |> fill_in("announcement_interests", with: "everyone")
+    |> fill_in_interests("everyone")
     |> fill_in("announcement_body", with: "# Hello!")
     |> click_create_announcement
 
     assert has_announcement_title?(session, "Hello World")
     assert has_announcement_body?(session, "Hello")
     assert has_announcement_interest?(session, "everyone")
+  end
+
+  defp fill_in_interests(session, interests) do
+    session
+    |> find(".selectize-input input")
+    |> fill_in(with: interests)
+
+    session
+    |> find(".selectize-dropdown-content .create")
+    |> click
+
+    session
   end
 
   defp click_create_announcement(session) do


### PR DESCRIPTION
This test was originally passing because JavaScript seemingly wasn't
being run during the switch to Wallaby.

Now that JavaScript is run this changes the way we insert interests to
work with selectize.
