### PR TITLE
Fix hover colors on remove slack button

### DIFF
--- a/web/static/css/_interest.scss
+++ b/web/static/css/_interest.scss
@@ -14,6 +14,11 @@
 
   color: $dark-gray;
   background-color: $light-gray;
+
+  &:hover {
+    background-color: $light-gray-shade;
+    color: $dark-gray;
+  }
 }
 
 .interests.container {


### PR DESCRIPTION
This changes the hover color to a more subtle gray from the bright red
used on other button hover states.

CURRENT:

![2016-04-29-104500-animated](https://cloud.githubusercontent.com/assets/4008677/14919587/8468e32e-0df7-11e6-80ee-990ffc89f161.gif)

NEW:

![2016-04-29-103946-animated](https://cloud.githubusercontent.com/assets/4008677/14919520/38eb59f4-0df7-11e6-92be-97ce2d2ea824.gif)
