### PR TITLE
Split interests when creating

### DIFF
--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule Constable.AnnouncementControllerTest do
   use Constable.ConnCase
 
+  alias Constable.Announcement
+
   setup do
     {:ok, browser_authenticate}
   end
@@ -42,5 +44,21 @@ defmodule Constable.AnnouncementControllerTest do
     conn = get conn, announcement_path(conn, :show, announcement.id)
 
     assert html_response(conn, :ok) =~ "<h1>Comment</h1>"
+  end
+
+  test "#create splits interests by ,", %{conn: conn} do
+    post conn, announcement_path(conn, :create), announcement: %{
+      title: "Hello world",
+      interests: "everyone, boston",
+      body: "# Hello"
+    }
+
+    interest_names = Repo.one!(Announcement)
+      |> Ecto.assoc(:interests)
+      |> Ecto.Query.select([a], a.name)
+      |> Ecto.Query.order_by([a], a.name)
+      |> Repo.all
+
+    assert interest_names == ["boston", "everyone"]
   end
 end

--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -43,6 +43,7 @@ defmodule Constable.AnnouncementController do
 
   def create(conn, %{"announcement" => announcement_params}) do
     interest_names = Map.get(announcement_params, "interests")
+      |> String.split(",")
     announcement_params = announcement_params
       |> Map.delete("interests")
       |> Map.put("user_id", conn.assigns.current_user.id)


### PR DESCRIPTION
When creating interests we currently don't split the string by `,` which
causes a single interest to be created.

This splits the interests by a `,` before trying to create the
announcement.
