### PR TITLE
Clear cache when refreshing with Turbolinks

### DIFF
--- a/web/static/js/turbolinks-refresh.js
+++ b/web/static/js/turbolinks-refresh.js
@@ -26,6 +26,7 @@ const sendLinkWithAjax = function(link) {
 
 const refreshPageWithTurbolinks = function() {
   var path = window.location.pathname + window.location.search;
+  Turbolinks.clearCache();
   Turbolinks.visit(path);
 }
 


### PR DESCRIPTION
This will remove a slight flicker when subscribing/unsubscribing to many
interests.

It fixes this:

![2016-04-29-133926-animated](https://cloud.githubusercontent.com/assets/22394/14924606/5f9a142c-0e11-11e6-8d96-3e79476a75e4.gif)
