### PR TITLE
Add List-Unsubscribe headers to emails

### DIFF
--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -15,7 +15,8 @@ defmodule Constable.Mailers.AnnouncementTest do
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
       "Message-ID" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
-      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>"
+      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>",
+      "List-Unsubscribe" => Constable.EmailView.unsubscribe_link
     }
     html_announcement_body = Earmark.to_html(announcement.body)
     assert email.to == interested_users

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -17,7 +17,8 @@ defmodule Constable.Mailers.CommentMailerTest do
     from_email = "announcements@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
     headers = %{
       "In-Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
-      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>"
+      "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>",
+      "List-Unsubscribe" => Constable.EmailView.unsubscribe_link
     }
     assert email.to == users
     assert email.subject == subject

--- a/web/emails.ex
+++ b/web/emails.ex
@@ -41,6 +41,7 @@ defmodule Constable.Emails do
     |> from_author(announcement.user)
     |> put_header("Reply-To", announcement_email_address(announcement))
     |> put_header("Message-ID", announcement_message_id(announcement))
+    |> put_header("List-Unsubscribe", Constable.EmailView.unsubscribe_link)
     |> tag("new-announcement")
     |> render(:new_announcement, %{
       announcement: announcement,
@@ -55,6 +56,7 @@ defmodule Constable.Emails do
     |> subject("Re: #{announcement.title}")
     |> from_author(comment.user)
     |> put_reply_headers(announcement)
+    |> put_header("List-Unsubscribe", Constable.EmailView.unsubscribe_link)
     |> tag("new-comment")
     |> add_unsubscribe_vars(comment)
     |> render(:new_comment, %{


### PR DESCRIPTION
Adding an unsubscribe link to the emails is great, but what's _really_
great is to add a List-Unsubscribe header. That allows tools that know
to look for this header to do Neat Things like display unsubscribe
buttons in the UI and other cool things. For example, adding this header
makes Constable emails work with https://github.com/pbrisbin/ghu
