### PR TITLE
Add alias for test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,9 +21,6 @@ dependencies:
     - mix local.rebar
     - cp .sample.env .env
 
-  post:
-    - node_modules/brunch/bin/brunch build
-
 test:
   override:
     - mix test --warnings-as-errors

--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,8 @@ defmodule Constable.Mixfile do
 
   defp aliases do
     [
-      "ecto.reset": ["ecto.drop", "ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"]
+      "ecto.reset": ["ecto.drop", "ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "test": ["cmd node_modules/brunch/bin/brunch build", "test"]
     ]
   end
 end


### PR DESCRIPTION
This builds the static assets with `brunch build` before running `test`
so that our acceptance tests can run javascript.
