### PR TITLE
Fix comment rendering

### DIFF
--- a/web/static/css/_announcement.scss
+++ b/web/static/css/_announcement.scss
@@ -84,7 +84,7 @@
 }
 
 .announcement-body,
-.comment-form {
+.comment-body {
   h1,
   h2,
   h3,


### PR DESCRIPTION
This PR:
- Adds the `comment-body` class to the styles that render the markdown
  correctly

Why?
- The comments were not being render with the correct styling.

BEFORE:
![2016-05-02-142423-scrot-targeted](https://cloud.githubusercontent.com/assets/4008677/14963464/bfe016b2-1071-11e6-9440-a65a1f5c13b3.png)

AFTER:
![2016-05-02-142449-scrot-targeted](https://cloud.githubusercontent.com/assets/4008677/14963466/c363540c-1071-11e6-9031-d4710f40887b.png)
