### PR TITLE
Add autocomplete to comments/announcements

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -41,6 +41,7 @@ exports.config = {
           bourbonPath,
           "./node_modules/bourbon-neat/app/assets/stylesheets",
           "./node_modules/normalize-css",
+          "./node_modules/jquery-textcomplete/dist/",
         ],
       }
     }
@@ -56,6 +57,7 @@ exports.config = {
     enabled: true,
     whitelist: [
       "jquery",
+      "jquery-textcomplete",
       "marked",
       "mousetrap",
       "normalize.css",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bourbon": "^4.2.6",
     "bourbon-neat": "^1.7.2",
     "jquery": "^2.2.0",
+    "jquery-textcomplete": "^0.8.0",
     "marked": "^0.3.5",
     "mousetrap": "^1.5.3",
     "normalize.css": "^4.1.1",

--- a/test/views/shared_view_test.exs
+++ b/test/views/shared_view_test.exs
@@ -1,0 +1,14 @@
+defmodule Constable.SharedViewTest do
+  use Constable.ConnCase
+  alias Constable.SharedView
+
+  test "markdown_with_users/1 bolds existing users" do
+    create(:user, username: "joedirt")
+    markdown = "Hello @joedirt not @forestgump!"
+
+    rendered = SharedView.markdown_with_users(markdown)
+
+    assert rendered =~ "<strong>@joedirt</strong>"
+    refute rendered =~ "<strong>@forestgump</strong>"
+  end
+end

--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -1,6 +1,8 @@
 defmodule Constable.AnnouncementController do
   use Constable.Web, :controller
 
+  alias Constable.User
+
   plug :scrub_params, "announcement" when action == :create
 
   alias Constable.{Announcement, Comment, Interest, Subscription}
@@ -31,14 +33,19 @@ defmodule Constable.AnnouncementController do
     |> render("show.html",
       announcement: announcement,
       comment: comment,
-      subscription: subscription
+      subscription: subscription,
+      users: Repo.all(User),
     )
   end
 
   def new(conn, _params) do
     changeset = Announcement.changeset(%Announcement{}, :create)
     interests = Repo.all(Interest)
-    render(conn, "new.html", changeset: changeset, interests: interests)
+    render(conn, "new.html", %{
+      changeset: changeset,
+      interests: interests,
+      users: Repo.all(User),
+    })
   end
 
   def create(conn, %{"announcement" => announcement_params}) do
@@ -53,7 +60,11 @@ defmodule Constable.AnnouncementController do
         redirect(conn, to: announcement_path(conn, :show, announcement.id))
       {:error, changeset} ->
         interests = Repo.all(Interest)
-        render(conn, "new.html", changeset: changeset, interests: interests)
+        render(conn, "new.html", %{
+          changeset: changeset,
+          interests: interests,
+          user_json: Repo.all(User),
+        })
     end
   end
 

--- a/web/static/css/_at-mention.scss
+++ b/web/static/css/_at-mention.scss
@@ -1,0 +1,51 @@
+@import "jquery.textcomplete";
+
+.at-mention-menu .active,
+.at-mention-menu li:hover {
+  @include linear-gradient(to right, tint($dark-blue, 15%), $dark-blue);
+
+  a {
+    color: white;
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.at-mention-menu {
+  border-radius: $base-border-radius;
+  box-shadow: $base-box-shadow;
+
+  li {
+    border-top: $base-border;
+    cursor: pointer;
+    padding: $small-spacing;
+
+    &.active {
+      border-top: 1px solid shade($dark-blue, 95%);
+    }
+  }
+}
+
+.textcomplete-item {
+  transition: background-color $base-transition-time;
+
+  &.active {
+    &:first-of-type {
+      @include border-top-radius($base-border-radius);
+    }
+
+    &:last-of-type {
+      @include border-bottom-radius($base-border-radius);
+    }
+  }
+
+  a {
+    @include display(flex);
+    @include align-items(center);
+    color: $base-font-color;
+    font-size: $small-font-size;
+  }
+
+  .avatar-rounded {
+    margin-bottom: 0;
+  }
+}

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -8,12 +8,13 @@
 @import 'header';
 @import 'login';
 
+@import 'announcement';
+@import 'announcement-create';
+@import 'announcement-form';
 @import 'announcements';
 @import 'announcements-interests-nav';
-@import 'announcement';
+@import 'at-mention';
 @import 'comments';
 @import 'interest';
 @import 'search';
 @import 'settings';
-@import 'announcement-create';
-@import 'announcement-form';

--- a/web/static/js/user-autocomplete.js
+++ b/web/static/js/user-autocomplete.js
@@ -1,0 +1,35 @@
+import $ from 'jquery';
+import 'jquery-textcomplete';
+
+const AT_REGEX = /(^|\s)@(\w*)$/;
+
+export function autocompleteUsers(selector, users) {
+  $(selector).textcomplete([{
+    match: AT_REGEX,
+    search: (term, callback) => {
+      term = term.toLowerCase();
+
+      if (term === '') {
+        callback(users);
+      } else {
+        const matches = users.filter((user) => {
+          const name = user.name;
+          const username = user.username;
+          const matchesName = name.toLowerCase().startsWith(term);
+          const matchesUsername = username.toLowerCase().startsWith(term);
+
+          return matchesName || matchesUsername;
+        });
+        callback(matches);
+      }
+    },
+
+    template: function(user, _term) {
+      return `<img class="avatar-rounded" src="${user.gravatar_url}"/> ${user.username}`;
+    },
+
+    replace: function(user) {
+      return `$1@${user.username} `;
+    },
+  }], { className: 'at-mention-menu' });
+}

--- a/web/templates/announcement/_comment.html.eex
+++ b/web/templates/announcement/_comment.html.eex
@@ -11,6 +11,6 @@
   </div>
 
   <div class="comment-body">
-    <%= raw Earmark.to_html(@comment.body) %>
+    <%= raw markdown_with_users(@comment.body) %>
   </div>
 </li>

--- a/web/templates/announcement/new.html.eex
+++ b/web/templates/announcement/new.html.eex
@@ -37,5 +37,9 @@
     window.INTERESTS_NAMES = <%= raw json_interests(@interests) %>;
     require('web/static/js/announcement-form').setupForm();
     require('web/static/js/announcement-form-mobile').setupForm();
+    require("web/static/js/user-autocomplete").autocompleteUsers(
+      '#announcement_body',
+      <%= raw user_autocomplete_json(@users) %>
+    );
   })()
 </script>

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -38,7 +38,7 @@
   </div>
 
   <div class="announcement-body" data-role="body">
-    <%= raw Earmark.to_html(@announcement.body) %>
+    <%= raw markdown_with_users(@announcement.body) %>
   </div>
 
   <ul class="comments-list">
@@ -65,5 +65,9 @@
 <script>
   (function() {
     require("web/static/js/comment-form").setupForm();
+    require("web/static/js/user-autocomplete").autocompleteUsers(
+      '.new-comment-textarea',
+      <%= raw user_autocomplete_json(@users) %>
+    );
   })()
 </script>

--- a/web/views/announcement_view.ex
+++ b/web/views/announcement_view.ex
@@ -19,4 +19,14 @@ defmodule Constable.AnnouncementView do
   def interest_count_for(user) do
     length user.interests
   end
+
+  def user_autocomplete_json(users) do
+    users
+    |> Enum.map(&format_user_json/1)
+    |> Poison.encode!
+  end
+
+  defp format_user_json(user) do
+    %{name: user.name, username: user.username, gravatar_url: gravatar(user)}
+  end
 end

--- a/web/views/shared_view.ex
+++ b/web/views/shared_view.ex
@@ -1,4 +1,8 @@
 defmodule Constable.SharedView do
+  require Ecto.Query
+
+  alias Constable.Services.MentionFinder
+
   def gravatar(user) do
     Exgravatar.generate(user.email, %{}, true)
   end
@@ -8,5 +12,18 @@ defmodule Constable.SharedView do
     |> Ecto.DateTime.to_erl
     |> Timex.DateTime.from_erl
     |> Timex.format!("{relative}", Timex.Format.DateTime.Formatters.Relative)
+  end
+
+  def markdown_with_users(markdown) do
+    markdown
+    |> MentionFinder.find_users
+    |> bold_usernames(markdown)
+    |> Earmark.to_html
+  end
+
+  defp bold_usernames(users, text) do
+    Enum.reduce(users, text, fn(user, text) ->
+      String.replace(text, "@#{user.username}", "**@#{user.username}**")
+    end)
   end
 end


### PR DESCRIPTION
This adds autocompletion of usernames in comments and announcements.

This also bolds @mentioned usernames in comments and announcements when
that user exists.

![gif](https://cloud.githubusercontent.com/assets/342554/14968419/b1602c3a-108a-11e6-957b-2204e4577bef.gif)
