### PR TITLE
Check for phantomjs

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,6 +9,20 @@ if [ ! -f .env ]; then
   cp .sample.env .env
 fi
 
+# check if phantomjs is installed
+if ! command -v phantomjs >/dev/null; then
+  echo "You must install PhantomJS 2.x before continuing."
+  exit 1
+else
+  phantomjs_version=$(phantomjs -v)
+  major_version="${phantomjs_version%.*.*}"
+
+  if ((major_version < 2)); then
+    echo "Please update your PhantomJS to 2.x before continuing."
+    exit 1
+  fi
+fi
+
 echo "Removing previous build artifacts"
 rm -rf deps _build
 


### PR DESCRIPTION
This checks to see if phantomJS is installed and if not, exits
`bin/setup` with message to install it before continuing.
