### PR TITLE
[resolves #242] add syntax highlighting to code sections in markdown output

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -40,7 +40,6 @@ exports.config = {
         includePaths: [
           bourbonPath,
           "./node_modules/bourbon-neat/app/assets/stylesheets",
-          "./node_modules/normalize-css",
           "./node_modules/jquery-textcomplete/dist/",
         ],
       }
@@ -55,7 +54,11 @@ exports.config = {
 
   npm: {
     enabled: true,
+    styles: {
+      "normalize.css": ['normalize.css']
+    },
     whitelist: [
+      "highlight.js",
       "jquery",
       "jquery-textcomplete",
       "marked",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "autoprefixer": "^6.3.6",
     "bourbon": "^4.2.6",
     "bourbon-neat": "^1.7.2",
+    "highlight.js": "^9.3.0",
     "jquery": "^2.2.0",
     "jquery-textcomplete": "^0.8.0",
     "marked": "^0.3.5",

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -1,7 +1,7 @@
 @import 'bourbon';
-@import 'normalize.css';
 @import 'neat';
 @import 'base/base';
+@import 'node_modules/highlight.js/styles/github';
 
 @import 'fonts';
 @import 'layout';

--- a/web/static/js/announcement-form.js
+++ b/web/static/js/announcement-form.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import marked from 'marked';
+import { markedWithSyntax } from './syntax-highlighting';
 import 'selectize';
 
 const DELIMITER = ',';
@@ -65,8 +65,7 @@ const updateMarkdown = function(e) {
     $('[data-role=markdown-preview]').html('Your rendered markdown goes here');
   } else {
     $('[data-role=markdown-preview]').removeClass('preview');
-
-    const markdown = marked(value);
+    const markdown = markedWithSyntax(value);
     $('[data-role=markdown-preview]').html(markdown);
   }
 };

--- a/web/static/js/syntax-highlighting.js
+++ b/web/static/js/syntax-highlighting.js
@@ -1,0 +1,34 @@
+import $ from 'jquery';
+import marked from 'marked';
+import hljs from 'highlight.js';
+
+marked.setOptions({
+  highlight: (code) => {
+    return hljs.highlightAuto(code).value;
+  }
+});
+
+const observer = new MutationObserver( mutations => {
+  mutations.forEach((mutation) => {
+    highlightCodeBlocks();
+  });
+});
+
+const initializeSyntaxHighlighting = container => {
+  highlightCodeBlocks();
+}
+
+const highlightCodeBlocks = function() {
+  $('pre code').each(function(index, block) {
+    hljs.highlightBlock(block);
+  });
+};
+
+export function markedWithSyntax(value) {
+  return marked(value);
+}
+
+export function highlightSyntax(container) {
+  observer.observe(document.querySelector(container), { childList: true });
+  initializeSyntaxHighlighting(container);
+}

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -68,6 +68,7 @@
     require("web/static/js/user-autocomplete").autocompleteUsers(
       '.new-comment-textarea',
       <%= raw user_autocomplete_json(@users) %>
-    );
+      );
+    require("web/static/js/syntax-highlighting").highlightSyntax('.comments-list');
   })()
 </script>


### PR DESCRIPTION
Take a look at this and see the gif below.

I can show that the css file is included in the build (changes from 174 files processed to 175), however I do not see the styles being reflected in app.css.

I DO see the hljs- prefixes being added to the code sections, and if you manually copy in the css styling from node_modules for highlight.js, and include it in app.scss it works wonderfully.

Im a little stumped on what is going on inside of brunch... Another set of eyes would be nice.

![brunch_includes](https://cloud.githubusercontent.com/assets/43513/15160001/2c0190ea-16bd-11e6-90c9-3619013f9130.gif)
