### PR TITLE
Fix announcements url in plaintext emails

### DIFF
--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -17,4 +17,4 @@
 <% end %>
 
 <%= gettext("View Interests and Announcements on Constable") %>
-<%= announcement_path(Constable.Endpoint, :index) %>
+<%= announcement_url(Constable.Endpoint, :index) %>


### PR DESCRIPTION
Previously, we were just printing out the path to the announcement index in the
daily digest. This resulted in this less-than-helpful output:

```
View Interests and Announcements on Constable
/announcements
```

We should instead be using the `announcement_url` so that we get the _full_ url
to the announcement index:

```
View Interests and Announcements on Constable
https://constable.io/announcements
```
