### PR TITLE
Display flash messages in login layout

### DIFF
--- a/test/acceptance/user_unsubscribes_test.exs
+++ b/test/acceptance/user_unsubscribes_test.exs
@@ -1,0 +1,38 @@
+defmodule Constable.UserUnsubscribesTest do
+  use Constable.AcceptanceCase
+
+  test "shows unsubscribe message when logged in", %{session: session} do
+    announcement = insert(:announcement)
+    subscription = insert(:subscription, announcement: announcement)
+    user = insert(:user)
+
+    session
+    |> visit(unsubscribe_path(Endpoint, :show, subscription.token, as: user))
+
+    assert has_unsubscribed_flash_message?(session)
+    assert has_announcement_title?(session, announcement.title)
+  end
+
+  test "shows unsubscribed message when logged out", %{session: session} do
+    subscription = insert(:subscription)
+    session
+    |> visit(unsubscribe_path(Endpoint, :show, subscription.token))
+
+    assert has_unsubscribed_flash_message?(session)
+    assert has_login_button?(session)
+  end
+
+  defp has_unsubscribed_flash_message?(session) do
+    session
+    |> find(".flash")
+    |> has_text?("You've been unsubscribed")
+  end
+
+  defp has_announcement_title?(session, text) do
+    session |> find("h1[data-role=title]") |> has_text?(text)
+  end
+
+  defp has_login_button?(session) do
+    session |> find("a.sign-in-link") |> has_text?("Sign in")
+  end
+end

--- a/web/templates/layout/_flashes.html.eex
+++ b/web/templates/layout/_flashes.html.eex
@@ -1,0 +1,11 @@
+<%= if get_flash(@conn, :info) do %>
+  <div class="flash flash-info">
+    <%= get_flash(@conn, :info) %>
+  </div>
+<% end %>
+
+<%= if get_flash(@conn, :error) do %>
+  <div class="flash flash-error">
+    <%= get_flash(@conn, :error) %>
+  </div>
+<% end %>

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -40,17 +40,7 @@
           </li>
         </ul>
       </header>
-      <%= if get_flash(@conn, :info) do %>
-        <div class="flash flash-info">
-          <%= get_flash(@conn, :info) %>
-        </div>
-      <% end %>
-
-      <%= if get_flash(@conn, :error) do %>
-        <div class="flash flash-error">
-          <%= get_flash(@conn, :error) %>
-        </div>
-      <% end %>
+      <%= render "_flashes.html", conn: @conn %>
 
       <%= render @view_module, @view_template, assigns %>
     </div>

--- a/web/templates/layout/login.html.eex
+++ b/web/templates/layout/login.html.eex
@@ -12,6 +12,8 @@
   </head>
 
   <body>
+    <%= render "_flashes.html", conn: @conn %>
+
     <div class="login-page">
       <%= render @view_module, @view_template, assigns %>
     </div>


### PR DESCRIPTION
Resolves issue that when unsubscribing while logged out, it was not obvious that
the unsubscribe was successful because the confirmation flash message was not
displayed on the page.
