### PR TITLE
Store user_id as a cookie

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule AuthControllerTest do
   use Constable.ConnCase, async: true
-  alias Constable.User
-  alias Constable.UserInterest
+  alias Constable.{User, UserIdentifier, UserInterest}
 
   @google_authorize_url "https://accounts.google.com/o/oauth2/auth"
   @oauth_email_address "fake@thoughtbot.com"
@@ -147,7 +146,14 @@ defmodule AuthControllerTest do
       |> get("/auth/browser_callback", code: "foo")
 
     user = Repo.one(User)
-    assert get_session(conn, :user_id) == user.id
+    assert user_id_cookie_is_saved?(conn, user)
+  end
+
+  defp user_id_cookie_is_saved?(conn, user) do
+    case UserIdentifier.verify_signed_user_id(conn) do
+      {:ok, user_id} -> user_id == user.id
+      {:error, _} -> false
+    end
   end
 
   defp create_everyone_interest do

--- a/web/models/user_identifier.ex
+++ b/web/models/user_identifier.ex
@@ -1,0 +1,9 @@
+defmodule Constable.UserIdentifier do
+  def sign_user_id(conn, user_id) do
+    Phoenix.Token.sign(conn, "user_id", user_id)
+  end
+
+  def verify_signed_user_id(conn) do
+    Phoenix.Token.verify(conn, "user_id", conn.cookies["user_id"])
+  end
+end

--- a/web/plugs/fetch_current_user.ex
+++ b/web/plugs/fetch_current_user.ex
@@ -1,23 +1,22 @@
 defmodule Constable.Plugs.FetchCurrentUser do
   import Plug.Conn
 
-  alias Constable.{Repo, User}
+  alias Constable.{Repo, User, UserIdentifier}
 
   def init(opts), do: opts
 
   def call(conn, _) do
     case find_user(conn) do
-      nil -> conn
+      :not_signed_in -> conn
       user ->
         conn |> assign(:current_user, user)
     end
   end
 
   def find_user(conn) do
-    user_id = get_session(conn, :user_id)
-
-    if user_id do
-      Repo.get(User, user_id)
+    case UserIdentifier.verify_signed_user_id(conn) do
+      {:ok, user_id} -> Repo.get(User, user_id)
+      {:error, _} -> :not_signed_in
     end
   end
 end

--- a/web/plugs/set_user_id_from_params.ex
+++ b/web/plugs/set_user_id_from_params.ex
@@ -1,11 +1,18 @@
 defmodule Constable.Plugs.SetUserIdFromParams do
+  alias Constable.UserIdentifier
+
   def init(opts), do: opts
 
   def call(conn, _opts) do
     if user_id = conn.params["as"] do
-      Plug.Conn.put_session(conn, :user_id, user_id)
+      set_user_id_cookie(conn, user_id)
     else
       conn
     end
+  end
+
+  defp set_user_id_cookie(conn, user_id) do
+    signed_user_id = UserIdentifier.sign_user_id(conn, user_id)
+    conn |> Plug.Conn.put_resp_cookie("user_id", signed_user_id)
   end
 end


### PR DESCRIPTION
This allows us to store the user_id for a longer time. Currently it is
stored on the session which is cleared frequently.

closes https://github.com/thoughtbot/constable/issues/257
