### PR TITLE
Sort announcements on interest and search pages

### DIFF
--- a/test/controllers/interest_controller_test.exs
+++ b/test/controllers/interest_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule Constable.InterestControllerTest do
+  use Constable.ConnCase, async: true
+
+  setup do
+    {:ok, browser_authenticate}
+  end
+
+  test "#show all announcements that are associated with this interest", %{conn: conn} do
+    interest = insert(:interest)
+    insert(:announcement, title: "Awesome") |> tag_with_interest(interest)
+    insert(:announcement, title: "Nope") |> tag_with_interest(insert(:interest))
+
+    conn = get conn, interest_path(conn, :show, interest)
+
+    assert html_response(conn, :ok) =~ "Awesome"
+    refute html_response(conn, :ok) =~ "Nope"
+  end
+end

--- a/web/controllers/interest_controller.ex
+++ b/web/controllers/interest_controller.ex
@@ -1,7 +1,7 @@
 defmodule Constable.InterestController do
   use Constable.Web, :controller
 
-  alias Constable.Interest
+  alias Constable.{Announcement, Interest}
 
   def index(conn, _params) do
     conn
@@ -11,8 +11,12 @@ defmodule Constable.InterestController do
   end
 
   def show(conn, %{"id" => id}) do
-    interest = Repo.get!(Interest.with_announcements, id)
-    render conn, "show.html", interest: interest
+    interest = Repo.get!(Interest, id)
+
+    conn
+    |> assign(:announcements, sorted_announcements(interest))
+    |> assign(:interest, interest)
+    |> render("show.html")
   end
 
   defp preload_interests(user) do
@@ -21,5 +25,12 @@ defmodule Constable.InterestController do
 
   defp all_interests do
     Repo.all Interest.ordered_by_name
+  end
+
+  defp sorted_announcements(interest) do
+    Ecto.assoc(interest, :announcements)
+    |> Announcement.last_discussed_first
+    |> Announcement.with_announcement_list_assocs
+    |> Repo.all
   end
 end

--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -5,6 +5,7 @@ defmodule Constable.SearchController do
 
   def new(conn, %{"query" => search_terms}) do
     announcements = Announcement.search(search_terms)
+      |> Announcement.last_discussed_first
       |> Announcement.with_announcement_list_assocs
       |> Repo.all
     render conn, "new.html", announcements: announcements

--- a/web/controllers/slack_channel_controller.ex
+++ b/web/controllers/slack_channel_controller.ex
@@ -4,13 +4,13 @@ defmodule Constable.SlackChannelController do
   alias Constable.Interest
 
   def edit(conn, %{"interest_id" => id}) do
-    interest = Repo.get!(Interest.with_announcements, id)
+    interest = Repo.get!(Interest, id)
     changeset = Interest.update_channel_changeset(interest, interest.slack_channel)
     render conn, "edit.html", interest: interest, changeset: changeset
   end
 
   def update(conn, %{"interest_id" => id, "interest" => %{"slack_channel" => channel}}) do
-    interest = Repo.get!(Interest.with_announcements, id)
+    interest = Repo.get!(Interest, id)
     case Repo.update(Interest.update_channel_changeset(interest, channel)) do
       {:ok, interest} ->
         redirect conn, to: interest_path(conn, :show, interest)

--- a/web/models/interest.ex
+++ b/web/models/interest.ex
@@ -22,11 +22,6 @@ defmodule Constable.Interest do
     |> unique_constraint(:name)
   end
 
-  def with_announcements(query \\ __MODULE__) do
-    from interest in query,
-      preload: [announcements: ^Announcement.with_announcement_list_assocs]
-  end
-
   def update_channel_changeset(interest, channel_name) do
     interest
     |> cast(%{slack_channel: channel_name}, ~w(slack_channel), [])

--- a/web/templates/interest/show.html.eex
+++ b/web/templates/interest/show.html.eex
@@ -25,5 +25,5 @@
 
   </div>
 
-  <%= render Constable.AnnouncementListView, "index.html", conn: @conn, announcements: @interest.announcements %>
+  <%= render Constable.AnnouncementListView, "index.html", conn: @conn, announcements: @announcements %>
 </div>


### PR DESCRIPTION
This sorts the announcements on the interest pages and search results pages to match the sorting on the main announcements index (ordered by last discussed at)

closes https://github.com/thoughtbot/constable/issues/261
