### PR TITLE
Use slug for interests

### DIFF
--- a/test/acceptance/user_sets_slack_channel_for_interest_test.exs
+++ b/test/acceptance/user_sets_slack_channel_for_interest_test.exs
@@ -6,7 +6,7 @@ defmodule Constable.UserSetsSlackChannelForInterestTest do
     user = insert(:user)
 
     session
-    |> visit(interest_path(Endpoint, :show, interest.id, as: user.id))
+    |> visit(interest_path(Endpoint, :show, interest, as: user.id))
     |> click_edit_interest
     |> fill_in("interest_slack_channel", with: "#channel-name")
     |> click_submit

--- a/test/controllers/interest_controller_test.exs
+++ b/test/controllers/interest_controller_test.exs
@@ -15,4 +15,13 @@ defmodule Constable.InterestControllerTest do
     assert html_response(conn, :ok) =~ "Awesome"
     refute html_response(conn, :ok) =~ "Nope"
   end
+
+  test "works with legacy ids for the param", %{conn: conn} do
+    interest = insert(:interest)
+    insert(:announcement, title: "Awesome") |> tag_with_interest(interest)
+
+    conn = get conn, interest_path(conn, :show, interest.id)
+
+    assert html_response(conn, :ok) =~ "Awesome"
+  end
 end

--- a/test/models/interest_test.exs
+++ b/test/models/interest_test.exs
@@ -7,4 +7,10 @@ defmodule Constable.InterestTest do
     assert changeset.valid?
     assert changeset.changes.name == "everyone"
   end
+
+  test "replaces spaces in the interest name with dashes" do
+    changeset = Interest.changeset(%{name: "this is an interest"})
+    assert changeset.valid?
+    assert changeset.changes.name == "this-is-an-interest"
+  end
 end

--- a/web/controllers/interest_controller.ex
+++ b/web/controllers/interest_controller.ex
@@ -10,13 +10,20 @@ defmodule Constable.InterestController do
     |> render("index.html")
   end
 
-  def show(conn, %{"id" => id}) do
-    interest = Repo.get!(Interest, id)
+  def show(conn, %{"param" => param}) do
+    interest = get_interest_by_id_or_name(param)
 
     conn
     |> assign(:announcements, sorted_announcements(interest))
     |> assign(:interest, interest)
     |> render("show.html")
+  end
+
+  defp get_interest_by_id_or_name(param) do
+    case Integer.parse(param) do
+      :error -> Repo.get_by!(Interest, name: param)
+      {id, _} -> Repo.get!(Interest, id)
+    end
   end
 
   defp preload_interests(user) do

--- a/web/controllers/slack_channel_controller.ex
+++ b/web/controllers/slack_channel_controller.ex
@@ -3,14 +3,14 @@ defmodule Constable.SlackChannelController do
 
   alias Constable.Interest
 
-  def edit(conn, %{"interest_id" => id}) do
-    interest = Repo.get!(Interest, id)
+  def edit(conn, %{"interest_param" => name}) do
+    interest = find_interest(name)
     changeset = Interest.update_channel_changeset(interest, interest.slack_channel)
     render conn, "edit.html", interest: interest, changeset: changeset
   end
 
-  def update(conn, %{"interest_id" => id, "interest" => %{"slack_channel" => channel}}) do
-    interest = Repo.get!(Interest, id)
+  def update(conn, %{"interest_param" => name, "interest" => %{"slack_channel" => channel}}) do
+    interest = find_interest(name)
     case Repo.update(Interest.update_channel_changeset(interest, channel)) do
       {:ok, interest} ->
         redirect conn, to: interest_path(conn, :show, interest)
@@ -21,9 +21,13 @@ defmodule Constable.SlackChannelController do
     end
   end
 
-  def delete(conn, %{"interest_id" => id}) do
-    interest = Repo.get!(Interest, id)
+  def delete(conn, %{"interest_param" => name}) do
+    interest = find_interest(name)
     Repo.update!(Interest.changeset(interest, %{slack_channel: nil}))
     redirect conn, to: interest_path(conn, :show, interest)
+  end
+
+  defp find_interest(interest_name) do
+    Repo.get_by!(Interest, name: interest_name)
   end
 end

--- a/web/controllers/user_interest_controller.ex
+++ b/web/controllers/user_interest_controller.ex
@@ -1,22 +1,29 @@
 defmodule Constable.UserInterestController do
   use Constable.Web, :controller
 
-  alias Constable.UserInterest
+  alias Constable.{Interest, UserInterest}
 
-  def create(conn, %{"interest_id" => interest_id}) do
+  def create(conn, %{"interest_param" => interest_name}) do
+    interest = find_interest(interest_name)
     current_user = current_user(conn)
 
-    UserInterest.changeset(%{user_id: current_user.id, interest_id: interest_id})
+    UserInterest.changeset(%{user_id: current_user.id, interest_id: interest.id})
     |> Repo.insert!
 
     send_resp(conn, :no_content, "")
   end
 
-  def delete(conn, %{"interest_id" => interest_id}) do
+  def delete(conn, %{"interest_param" => interest_name}) do
+    interest = find_interest(interest_name)
+
     UserInterest
-    |> Repo.get_by!(interest_id: interest_id, user_id: current_user(conn).id)
+    |> Repo.get_by!(interest_id: interest.id, user_id: current_user(conn).id)
     |> Repo.delete!
 
     send_resp(conn, :no_content, "")
+  end
+
+  defp find_interest(interest_name) do
+    Interest |> Repo.get_by!(name: interest_name)
   end
 end

--- a/web/models/interest.ex
+++ b/web/models/interest.ex
@@ -1,4 +1,10 @@
 defmodule Constable.Interest do
+  defimpl Phoenix.Param do
+    def to_param(%{name: name}) do
+      "#{name}"
+    end
+  end
+
   use Constable.Web, :model
   alias Constable.{Announcement, AnnouncementInterest, UserInterest}
 
@@ -18,6 +24,7 @@ defmodule Constable.Interest do
     |> cast(params, ~w(name), ~w(slack_channel))
     |> validate_presence(:name)
     |> update_change(:name, &String.replace(&1, "#", ""))
+    |> update_change(:name, &String.replace(&1, " ", "-"))
     |> update_change(:name, &String.downcase/1)
     |> unique_constraint(:name)
   end

--- a/web/router.ex
+++ b/web/router.ex
@@ -40,7 +40,7 @@ defmodule Constable.Router do
       resources "/subscriptions", SubscriptionController, singleton: true, only: [:create, :delete]
     end
     resources "/settings", SettingsController, singleton: true, only: [:show, :update]
-    resources "/interests", InterestController, only: [:index, :show] do
+    resources "/interests", InterestController, only: [:index, :show], param: "param" do
       resources "/slack_channel", SlackChannelController, singleton: true, only: [:edit, :update, :delete]
       resources "/user_interest", UserInterestController, singleton: true, only: [:create, :delete]
     end


### PR DESCRIPTION
This allows for users to browse to interest pages using the interest
name instead of the id. For example: `/interests/everyone` instead of
`/interests/1`

closes https://github.com/thoughtbot/constable/issues/164
