### PR TITLE
Speed things up

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,13 +1,10 @@
 use Mix.Config
 
-# Longer stacktraces in development
-:erlang.system_flag :backtrace_depth, 25
-
 config :constable, Constable.Endpoint,
   http: [port: System.get_env("PORT") || 4000],
   debug_errors: true,
-  cache_static_lookup: false,
   code_reloader: true,
+  check_origin: false,
   watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]
 
 config :constable, Constable.Repo,
@@ -23,3 +20,7 @@ config :phoenix, :code_reloader, true
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
+
+# Set a higher stacktrace during development. Avoid configuring such
+# in production as building large stacktraces may be expensive.
+config :phoenix, :stacktrace_depth, 20

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,7 +15,8 @@ config :constable, Constable.Endpoint,
   url: [scheme: "https", host: System.get_env("HOST"), port: System.get_env("URL_PORT")],
   http: [port: {:system, "PORT"}, compress: true],
   force_ssl: [rewrite_on: [:x_forwarded_proto], host: System.get_env("HOST")],
-  secret_key_base: System.get_env("SECRET_KEY_BASE")
+  secret_key_base: System.get_env("SECRET_KEY_BASE"),
+  cache_static_manifest: "priv/static/manifest.json"
 
 config :constable, Constable.Repo,
   url: System.get_env("DATABASE_URL")

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,3 +18,6 @@ config :constable, Constable.Mailer,
 config :logger, level: :warn
 
 config :wallaby, :max_wait_time, 250
+
+# Set a higher stacktrace during test.
+config :phoenix, :stacktrace_depth, 35

--- a/lib/constable/endpoint.ex
+++ b/lib/constable/endpoint.ex
@@ -8,7 +8,9 @@ defmodule Constable.Endpoint do
   end
 
   plug Plug.Static,
-    at: "/", from: :constable
+    at: "/", from: :constable,
+    gzip: true,
+    only: ~w(css fonts images js favicon.ico)
 
   plug Plug.Logger
 
@@ -29,9 +31,7 @@ defmodule Constable.Endpoint do
   plug Plug.Session,
     store: :cookie,
     key: "_constable_key",
-    signing_salt: "/CEisxlR",
-    encryption_salt: "W5B5Vc1E"
+    signing_salt: "/CEisxlR"
 
-  plug CORSPlug
   plug Constable.Router
 end

--- a/lib/constable/time.ex
+++ b/lib/constable/time.ex
@@ -1,8 +1,6 @@
 defmodule Constable.Time do
-  alias Timex.Date
-
   def now do
-    Date.now |> to_ecto
+    Ecto.DateTime.utc
   end
 
   def yesterday do
@@ -10,10 +8,11 @@ defmodule Constable.Time do
   end
 
   def days_ago(count) do
-    Date.now |> Date.shift(days: -count) |> to_ecto
+    # Date.now |> Date.shift(days: -count) |> to_ecto
+    GoodTimes.days_ago(count) |> to_ecto
   end
 
   def to_ecto(date) do
-    date |> Timex.to_erlang_datetime |> Ecto.DateTime.from_erl
+    date |> Ecto.DateTime.cast!
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -39,8 +39,7 @@ defmodule Constable.Mixfile do
     :httpoison,
     :logger,
     :phoenix,
-    :postgrex,
-    :timex,
+    :postgrex
   ]
 
   # Specifies your project dependencies
@@ -67,7 +66,6 @@ defmodule Constable.Mixfile do
       {:phoenix, "~> 1.1"},
       {:postgrex, ">= 0.0.0"},
       {:secure_random, "~> 0.1"},
-      {:timex, "~> 2.1"},
       {:wallaby, "~> 0.5", only: :test},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -34,6 +34,5 @@
   "ranch": {:hex, :ranch, "1.2.1"},
   "secure_random": {:hex, :secure_random, "0.2.0"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
-  "timex": {:hex, :timex, "2.1.4"},
   "tzdata": {:hex, :tzdata, "0.5.7"},
   "wallaby": {:hex, :wallaby, "0.5.0"}}

--- a/test/lib/constable/time_test.exs
+++ b/test/lib/constable/time_test.exs
@@ -2,16 +2,16 @@ defmodule Constable.TimeTest do
   use ExUnit.Case, async: true
 
   test "today returns todays date in Ecto.DateTime format" do
-    assert Constable.Time.now == Constable.Time.to_ecto(Timex.Date.now)
+    assert Constable.Time.now == Ecto.DateTime.utc
   end
 
   test "today returns yesterdays date in Ecto.DateTime format" do
-    yesterday = Timex.Date.now |> Timex.Date.shift(days: -1) |> Constable.Time.to_ecto
+    yesterday = GoodTimes.a_day_ago |> Constable.Time.to_ecto
     assert Constable.Time.yesterday == yesterday
   end
 
-  test "to_ecto turns Timex dates into ecto dates" do
-    converted_time = Timex.Date.now |> Constable.Time.to_ecto
+  test "to_ecto turns erlang dates into ecto dates" do
+    converted_time = {{2015, 10, 10}, {10, 10, 10}} |> Constable.Time.to_ecto
     assert converted_time.__struct__ == Ecto.DateTime
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,3 @@
-:erlang.system_flag :backtrace_depth, 50
 ExUnit.configure exclude: [pending: true], max_cases: 10
 {:ok, _} = Application.ensure_all_started(:bamboo)
 {:ok, _} = Application.ensure_all_started(:wallaby)

--- a/web/views/shared_view.ex
+++ b/web/views/shared_view.ex
@@ -8,11 +8,27 @@ defmodule Constable.SharedView do
   end
 
   def time_ago_in_words(time) do
-    time
-    |> Ecto.DateTime.to_erl
-    |> Timex.DateTime.from_erl
-    |> Timex.format!("{relative}", Timex.Format.DateTime.Formatters.Relative)
+    ts = Ecto.DateTime.to_erl(time) |> :calendar.datetime_to_gregorian_seconds
+    diff = :calendar.datetime_to_gregorian_seconds(:calendar.universal_time) - ts
+    rel_from_now(:calendar.seconds_to_daystime(diff))
   end
+
+  defp rel_from_now({0, {0, 0, sec}}) when sec < 30,
+    do: "about now"
+  defp rel_from_now({0, {0, min, _}}) when min < 2,
+    do: "1 minute ago"
+  defp rel_from_now({0, {0, min, _}}),
+    do: "#{min} minutes ago"
+  defp rel_from_now({0, {1, _, _}}),
+    do: "1 hour ago"
+  defp rel_from_now({0, {hour, _, _}}) when hour < 24,
+    do: "#{hour} hours ago"
+  defp rel_from_now({1, {_, _, _}}),
+    do: "1 day ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 0,
+    do: "about now"
+  defp rel_from_now({day, {_, _, _}}),
+    do: "#{day} days ago"
 
   def markdown_with_users(markdown) do
     markdown


### PR DESCRIPTION
Turns out Timex is _ridiculously_ slow: https://github.com/benwilson512/time-bench

By removing the Timex relative time helper and using on used by hex.pm, we shaved off ~30% from total test suite time and about 60% from response times on some endpoints.

I think there still may be a couple other things lurking around somewhere, but this is substantial speed boost!
