### PR TITLE
Use mix phoenix.server to start in Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yes | mix compile.protocols && elixir -pa _build/prod/consolidated -S mix phoenix.server
+web: mix phoenix.server


### PR DESCRIPTION
We no longer need all that extra stuff since protocols are consolidated by default now. Also piping to `yes` could sometimes cause memory leaks
