### PR TITLE
Fix mobile auth endpoint calling non-existent method

### DIFF
--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -40,7 +40,7 @@ defmodule AuthControllerTest do
   defmodule FakeTokenInfoGoogleStrategy do
     @oauth_email_address "fake@thoughtbot.com"
 
-    def get_tokeninfo!(_id_token) do
+    def get_tokeninfo!(_redirect_uri, _id_token) do
       %{"email" => @oauth_email_address, "name" => "John Doe"}
     end
   end
@@ -48,7 +48,7 @@ defmodule AuthControllerTest do
   defmodule NonThoughtbotTokenInfoGoogleStrategy do
     @oauth_email_address "fake@example.com"
 
-    def get_tokeninfo!(_id_token) do
+    def get_tokeninfo!(_redirect_uri, _id_token) do
       %{"email" => @oauth_email_address, "name" => "John Doe"}
     end
   end

--- a/web/controllers/auth_controller.ex
+++ b/web/controllers/auth_controller.ex
@@ -93,7 +93,7 @@ defmodule Constable.AuthController do
   end
 
   defp get_tokeninfo!(id_token) do
-    google_strategy.get_tokeninfo!(id_token)
+    google_strategy.get_tokeninfo!(nil, id_token)
   end
 
   defp find_or_insert_user(email, name) do


### PR DESCRIPTION
At some point the method this was initially calling was removed. This updates it
to pass in the missing redirect URI variable.

It's an empty string because it doesn't matter what it is, it works either way.

Also updated the tests to match.
