### PR TITLE
Subscribe and Unsubscribe from interest page

### DIFF
--- a/test/acceptance/user_manages_interests_test.exs
+++ b/test/acceptance/user_manages_interests_test.exs
@@ -18,6 +18,17 @@ defmodule Constable.UserManagesInterestsTest do
     assert not_subscribed_to_interest?(session)
   end
 
+  test "user subscribes to an interest from interest page", %{session: session} do
+    user = insert(:user)
+    interest = insert(:interest)
+    session |> visit(interest_path(Endpoint, :show, interest, as: user.id))
+
+    assert not_subscribed_to_interest?(session)
+    session |> subscribe_to_interest
+
+    assert subscribed_to_interest?(session)
+  end
+
   defp view_interests(session) do
     user = insert(:user)
 

--- a/web/controllers/interest_controller.ex
+++ b/web/controllers/interest_controller.ex
@@ -14,6 +14,7 @@ defmodule Constable.InterestController do
     interest = get_interest_by_id_or_name(param)
 
     conn
+    |> assign(:current_user, preload_interests(conn.assigns.current_user))
     |> assign(:announcements, sorted_announcements(interest))
     |> assign(:interest, interest)
     |> render("show.html")

--- a/web/static/css/_interest.scss
+++ b/web/static/css/_interest.scss
@@ -34,6 +34,10 @@
   margin: $base-spacing*.5 0 0;
   padding: 0;
 
+  .interest.container & {
+    border-bottom: 0;
+  }
+
   h3 {
     line-height: inherit;
     margin: 0;

--- a/web/templates/interest/index.html.eex
+++ b/web/templates/interest/index.html.eex
@@ -5,21 +5,7 @@
     <%= for interest <- @interests do %>
       <li class="interest-list-item">
         <h3><%= link interest.name, to: interest_path(@conn, :show, interest) %></h3>
-        <%= if interested_in?(@current_user, interest) do %>
-          <%= link to: interest_user_interest_path(@conn, :delete, interest),
-                method: :delete,
-                class: "unsubscribe",
-                data: [turbolinks: "refresh", role: "unsubscribe-from-interest"] do %>
-                <span><%= gettext("Unsubscribe") %></span>
-          <% end %>
-        <% else %>
-          <%= link to: interest_user_interest_path(@conn, :create, interest),
-                method: :post,
-                class: "subscribe",
-                data: [turbolinks: "refresh", role: "subscribe-to-interest"] do %>
-                <span><%= gettext("Subscribe") %></span>
-          <% end %>
-        <% end %>
+        <%= render Constable.InterestView, "subscription.html", conn: @conn, interest: interest, current_user: @current_user %>
       </li>
     <% end %>
   </ul>

--- a/web/templates/interest/show.html.eex
+++ b/web/templates/interest/show.html.eex
@@ -1,6 +1,9 @@
 <div class="page-interest">
   <div class="interest container">
-    <h1><%= @interest.name %></h1>
+    <div class="interest-list-item">
+      <h1><%= @interest.name %></h1>
+      <%= render Constable.InterestView, "subscription.html", conn: @conn, interest: @interest, current_user: @current_user %>
+    </div>
 
     <div class="current-channel">
       <%= link to: interest_slack_channel_path(@conn, :edit, @interest), data: [role: "edit-interest"] do %>

--- a/web/templates/interest/subscription.html.eex
+++ b/web/templates/interest/subscription.html.eex
@@ -1,0 +1,15 @@
+<%= if interested_in?(@current_user, @interest) do %>
+  <%= link to: interest_user_interest_path(@conn, :delete, @interest),
+        method: :delete,
+        class: "unsubscribe",
+        data: [turbolinks: "refresh", role: "unsubscribe-from-interest"] do %>
+    <span><%= gettext("Unsubscribe") %></span>
+  <% end %>
+<% else %>
+  <%= link to: interest_user_interest_path(@conn, :create, @interest),
+        method: :post,
+        class: "subscribe",
+        data: [turbolinks: "refresh", role: "subscribe-to-interest"] do %>
+    <span><%= gettext("Subscribe") %></span>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This allows users to subscribe and unsubscribe to an interest directly
from the interest show page.

closes https://github.com/thoughtbot/constable/issues/163

![2016-05-16-154035-animated](https://cloud.githubusercontent.com/assets/4008677/15301629/acf3733a-1b7c-11e6-8b2f-0d7531f2091e.gif)
![screenshot_20160516-161917](https://cloud.githubusercontent.com/assets/4008677/15302679/37aca410-1b82-11e6-9702-b6fe416975e6.png)
![screenshot_20160516-161949](https://cloud.githubusercontent.com/assets/4008677/15302680/37b1e11e-1b82-11e6-908a-21ee5e082669.png)
