### PR TITLE
Rename unused variable

### DIFF
--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -76,7 +76,7 @@ defmodule Constable.AnnouncementController do
       case AnnouncementUpdater.update(announcement, announcement_params, interest_names) do
         {:ok, announcement} ->
           redirect(conn, to: announcement_path(conn, :show, announcement.id))
-        {:error, changeset} ->
+        {:error, _changeset} ->
           render_form(conn, "edit", announcement)
       end
     else


### PR DESCRIPTION
This:
- renames an unused variable from `changeset` to `_changeset`

Why:
- I kept seeing a warning when running tests and wanted to get rid of
  it.
