### PR TITLE
Remove unused entry from sample.env

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,5 @@
 CLIENT_ID=GetFromGoogleDeveloperConsole
 CLIENT_SECRET=GetFromGoogleDeveloperConsole
-REDIRECT_URI=http://localhost:4000/auth/callback
 MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io


### PR DESCRIPTION
It looks like `REDIRECT_URI` is not used. Instead the app uses the path helper (specifically `auth_url`).

If this looks good, I'll also go ahead and also remove from the Heroku env. There are a couple of other env vars set in Heroku which I believe are also not used: `REDIRECT_AFTER_SUCCESS_URI` and `FRONT_END_URI`.
