### PR TITLE
Disable editing functionality temporarily

### DIFF
--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -16,6 +16,7 @@ defmodule Constable.UserAnnouncementTest do
     assert has_announcement_interest?(session, "everyone")
   end
 
+  @tag :pending
   test "user updates an announcement", %{session: session} do
     user = insert(:user)
     announcement = insert(:announcement, user: user)

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -27,11 +27,6 @@
 
   <h1 data-role="title">
     <%= @announcement.title %>
-    <%= if @announcement.user_id == @current_user.id do %>
-      <small>
-        <%= link "edit", to: announcement_path(@conn, :edit, @announcement), data: [role: "edit"] %>
-      </small>
-    <% end %>
   </h1>
 
   <div class="announcement-posted-by">


### PR DESCRIPTION
The edit functionality currently has a few gotcha's that users would not
expect.

To get past that, we'll disable the feature until it's resolved.
