### PR TITLE
Review apps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ folder has a few the best examples.
 
 1. If you have not run `bin/setup` yet, run it to add the correct git remotes.
 2. Run `bin/deploy (staging|production)`
+
+## Review Apps
+
+Constable is setup with support for [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps).
+
+Google enforce a whitelist of OAuth redirect URLs, so for review apps we redirect the OAuth flow through [thoughtbot/constable-oauth-redirector](https://github.com/thoughtbot/constable-oauth-redirector) which then redirects back to the correct review app. This is configured with the `OAUTH_REDIRECT_OVERRIDE` environment variable.

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name": "constable",
   "description": "Constable Heroku review app config",
   "scripts": {
+    "postdeploy": "mix ecto.migrate"
   },
   "env": {
     "ADMIN_EMAILS": {
@@ -14,7 +15,10 @@
       "required": true
     },
     "CLIENT_SECRET": {
-      "generator": "secret"
+      "required": true
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
     },
     "INBOUND_EMAIL_DOMAIN": {
       "required": true
@@ -25,11 +29,12 @@
     "MIX_ENV": {
       "required": true
     },
+    "OAUTH_REDIRECT_OVERRIDE": "https://constable-oauth-redirector.herokuapp.com/auth",
     "OUTBOUND_EMAIL_DOMAIN": {
       "required": true
     },
     "SECRET_KEY_BASE": {
-      "required": true
+      "generator": "secret"
     },
     "SLACK_WEBHOOK_URL": {
       "required": true

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,11 @@ use Mix.Config
 # Where those two env variables point to a file on
 # disk for the key and cert.
 
+heroku_app_name = System.get_env("HEROKU_APP_NAME")
+if heroku_app_name && heroku_app_name =~ ~r/\Aconstable-api-staging-pr/ do
+  System.put_env("HOST", "#{heroku_app_name}.herokuapp.com")
+end
+
 config :constable, Constable.Endpoint,
   url: [scheme: "https", host: System.get_env("HOST"), port: System.get_env("URL_PORT")],
   http: [port: {:system, "PORT"}, compress: true],

--- a/lib/constable.ex
+++ b/lib/constable.ex
@@ -34,6 +34,7 @@ defmodule Constable do
     Pact.put(:token_retriever, OAuth2.Strategy.AuthCode)
     Pact.put(:daily_digest, Constable.DailyDigest)
     Pact.put(:google_strategy, GoogleStrategy)
+    Pact.put(:oauth_redirect_strategy, OAuthRedirectStrategy)
   end
 
   # Tell Phoenix to update the endpoint configuration

--- a/web/services/oauth_redirect_strategy.ex
+++ b/web/services/oauth_redirect_strategy.ex
@@ -1,0 +1,17 @@
+defmodule OAuthRedirectStrategy do
+  def redirect_uri(original_redirect_uri) do
+    oauth_redirect_override || original_redirect_uri
+  end
+
+  def state_param(original_redirect_uri) do
+    if oauth_redirect_override do
+      original_redirect_uri
+    else
+      nil
+    end
+  end
+
+  defp oauth_redirect_override do
+    System.get_env("OAUTH_REDIRECT_OVERRIDE")
+  end
+end


### PR DESCRIPTION
Changes to support Heroku review apps for Constable.

These are mostly fixes to get OAuth working correctly with review apps. Google will only redirect back to a given URI if it's been explicitly whitelisted. It's not practical for us to add every review app URL to the whitelist. Instead we use a tiny app which sits between Constable and Google to act as a proxy redirector.

For review apps, the `redirect_uri` is always set to the proxy app (`https://constable-oauth-redirector.herokuapp.com/auth`) and the actual redirect URI (e.g. `https://constable-api-staging-pr-293.herokuapp.com/auth/browser_callback`) is passed as the `state` param to Google. We then use this state param to know where to redirect to.

Fixes #267 

See also related PR for the OAuth redirector: thoughtbot/constable-oauth-redirector#1.
