### PR TITLE
Fixes listing of announcement interests in digest

### DIFF
--- a/test/emails_test.exs
+++ b/test/emails_test.exs
@@ -5,7 +5,7 @@ defmodule Constable.EmailsTest do
   test "daily_digest" do
     users = insert_pair(:user)
     interests = insert_pair(:interest)
-    announcements = insert_pair(:announcement) |> Repo.preload(:interests)
+    announcements = [insert_announcement_with_interests, insert_announcement_with_interests]
 
     email = Constable.Emails.daily_digest(interests, announcements, users)
 
@@ -22,11 +22,30 @@ defmodule Constable.EmailsTest do
     for announcement <- announcements do
       assert email.html_body =~ announcement.title
       assert email.text_body =~ announcement.title
-
-      for interest <- announcement.interests do
-        assert email.html_body =~ interest.name
-        assert email.text_body =~ interest.name
-      end
+      assert email.html_body =~ posted_by_html(announcement.user.name, announcement)
+      assert email.text_body =~ posted_by_text(announcement.user.name, announcement)
     end
+  end
+
+  defp insert_announcement_with_interests do
+    insert(:announcement)
+    |> tag_with_interest(insert(:interest))
+    |> tag_with_interest(insert(:interest))
+    |> Repo.preload(:interests)
+  end
+
+  defp posted_by_html(username, announcement) do
+    "posted by <strong>#{username}</strong> in #{interest_names(announcement)}"
+  end
+
+  defp posted_by_text(username, announcement) do
+    "posted by #{username} in #{interest_names(announcement)}"
+  end
+
+  defp interest_names(announcement) do
+    announcement
+    |> Map.get(:interests)
+    |> Enum.map(&("##{&1.name}"))
+    |> Enum.join(", ")
   end
 end

--- a/web/controllers/email_preview_controller.ex
+++ b/web/controllers/email_preview_controller.ex
@@ -17,7 +17,7 @@ defmodule Constable.EmailPreviewController do
   end
 
   defp email_for(:new_announcement) do
-    Emails.new_announcement(announcement, [])
+    Emails.new_announcement(insert_announcement_with_interests, [])
   end
 
   defp email_for(:new_comment) do
@@ -29,14 +29,13 @@ defmodule Constable.EmailPreviewController do
   end
 
   defp email_for(:new_announcement_mention) do
-    Emails.new_announcement_mention(announcement, [])
+    Emails.new_announcement_mention(insert_announcement_with_interests, [])
   end
 
   defp email_for(:daily_digest) do
     Emails.daily_digest(
       insert_pair(:interest),
-      insert_pair(:announcement)
-       |> Repo.preload(:interests),
+      [insert_announcement_with_interests, insert_announcement_with_interests],
       []
     )
   end
@@ -52,9 +51,10 @@ defmodule Constable.EmailPreviewController do
     }
   end
 
-  defp announcement do
+  defp insert_announcement_with_interests do
     insert(:announcement)
     |> tag_with_interest(insert(:interest))
     |> tag_with_interest(insert(:interest))
+    |> Repo.preload(:interests)
   end
 end

--- a/web/templates/email/daily_digest.html.eex
+++ b/web/templates/email/daily_digest.html.eex
@@ -127,7 +127,7 @@
                   <%= for announcement <- @announcements do %>
                     <li>
                       <%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %>
-                      <%= gettext("posted by") %> <strong><%= announcement.user.name %></strong> <%= gettext("in") %> #<%= Enum.join(announcement.interests, ", #") %>
+                      <%= gettext("posted by") %> <strong><%= announcement.user.name %></strong> <%= gettext("in") %> <%= interest_names(announcement) %>
                     </li>
                   <% end %>
                 </ul>

--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -12,7 +12,7 @@
 
 <%= for announcement <- @announcements do %>
   <%= announcement.title %> - <%= announcement_url(Constable.Endpoint, :show, announcement) %>
-  <%= gettext("posted by") %> <%= announcement.user.name %> <%= gettext("in") %> #<%= Enum.join(announcement.interests, ", #") %>
+  <%= gettext("posted by") %> <%= announcement.user.name %> <%= gettext("in") %> <%= interest_names(announcement) %>
 <% end %>
 
 <%= gettext("View Interests and Announcements on Constable") %>


### PR DESCRIPTION
This fixes an issue where we were passing in a full struct rather than
just the names of the interests to the daily digest.

Closes https://github.com/thoughtbot/constable/issues/301

![](http://i.imgur.com/9biWE1K.png)
