### PR TITLE
Fix daily digest commenter list

### DIFF
--- a/test/emails_test.exs
+++ b/test/emails_test.exs
@@ -5,9 +5,12 @@ defmodule Constable.EmailsTest do
   test "daily_digest" do
     users = insert_pair(:user)
     interests = insert_pair(:interest)
+    [comment_1, comment_2] = insert_pair(:comment, announcement: insert(:announcement))
+    comment_3 = insert(:comment, announcement: insert(:announcement))
+    comments = [comment_1, comment_2, comment_3]
     announcements = [insert_announcement_with_interests, insert_announcement_with_interests]
 
-    email = Constable.Emails.daily_digest(interests, announcements, [], users)
+    email = Constable.Emails.daily_digest(interests, announcements, comments, users)
 
     assert email.subject == "Daily Digest"
     assert email.to == users
@@ -25,6 +28,10 @@ defmodule Constable.EmailsTest do
       assert email.html_body =~ posted_by_html(announcement.user.name, announcement)
       assert email.text_body =~ posted_by_text(announcement.user.name, announcement)
     end
+    assert email.html_body =~ "2 comments by #{comment_1.user.name}, #{comment_2.user.name}"
+    assert email.text_body =~ "2 comments by #{comment_1.user.name}, #{comment_2.user.name}"
+    assert email.html_body =~ "1 comment by #{comment_3.user.name}"
+    assert email.text_body =~ "1 comment by #{comment_3.user.name}"
   end
 
   defp insert_announcement_with_interests do

--- a/web/templates/email/daily_digest.html.eex
+++ b/web/templates/email/daily_digest.html.eex
@@ -159,7 +159,7 @@
                 <%= for announcement <- discussed_announcements(@comments) do %>
                   <div class="left-padded">
                     <h4><%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %></h4>
-                    <%= new_comment_count_text(@comments, announcement) %> <%= unique_commenters_list(@comments) %>
+                    <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
                   </div>
                 <% end %>
 

--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -20,7 +20,7 @@
 
 <%= for announcement <- discussed_announcements(@comments) do %>
   <%= announcement.title %> - <%= announcement_url(Constable.Endpoint, :show, announcement) %>
-  <%= new_comment_count_text(@comments, announcement) %> <%= unique_commenters_list(@comments) %>
+  <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
 <% end %>
 
 <%= gettext("View Interests and Announcements on Constable") %>

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -40,9 +40,14 @@ defmodule Constable.EmailView do
     |> Enum.uniq
   end
 
-  def unique_commenter_names(users) do
-    users
+  def unique_commenters(announcement, comments) do
+    Enum.filter(comments, fn(c) -> c.announcement_id == announcement.id end)
+    |> Enum.map(fn(c) -> c.user end)
     |> Enum.uniq
+  end
+
+  def commenter_names(users) do
+    users
     |> Enum.map(fn(user) -> user.name end)
   end
 
@@ -59,10 +64,17 @@ defmodule Constable.EmailView do
     )
   end
 
-  def unique_commenters_list(comments) do
-    gettext(" by ")
+  def commenters_list_text(announcement, comments) do
+    gettext("by ")
     <>
-    Enum.join(unique_commenter_names(unique_commenters(comments)), ", ")
+    comma_separated_commenter_list(announcement, comments)
+  end
+
+  defp comma_separated_commenter_list(announcement, comments) do
+    announcement
+    |> unique_commenters(comments)
+    |> commenter_names
+    |> Enum.join(", ")
   end
 
   defp new_comments(comments, announcement) do


### PR DESCRIPTION
This fixes the issue where the digest would list all the unique
commenters for all of the discussed announcements rather than the
specific one that it is iterating over.
