### PR TITLE
Link directly to comment in emails

### DIFF
--- a/web/static/css/_announcement.scss
+++ b/web/static/css/_announcement.scss
@@ -34,10 +34,18 @@
   section {
     margin-bottom: $base-spacing;
   }
+}
 
-  .comment-time {
-    font-size: $small-font-size - 2px;
-    margin-bottom: 0;
+.comment-time {
+  font-size: $small-font-size - 2px;
+  margin-bottom: 0;
+
+  a {
+    color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/web/templates/announcement/_comment.html.eex
+++ b/web/templates/announcement/_comment.html.eex
@@ -1,4 +1,4 @@
-<li class="comment">
+<li class="comment" id="comment-<%= @comment.id %>">
   <div class="comment-information">
     <div class="author-information">
       <img class="avatar-rounded" src="<%= gravatar @comment.user %>">
@@ -6,7 +6,9 @@
     </div>
 
     <time class="comment-time">
-      <%= time_ago_in_words @comment.inserted_at %>
+      <a href="#comment-<%= @comment.id %>">
+        <%= time_ago_in_words @comment.inserted_at %>
+      </a>
     </time>
   </div>
 

--- a/web/templates/email/author_footer.html.eex
+++ b/web/templates/email/author_footer.html.eex
@@ -12,7 +12,7 @@
     </table>
   </td>
   <td align="right">
-    <%= link to: announcement_url(Constable.Endpoint, :show, @announcement),
+    <%= link to: announcement_url_for_footer(@announcement, @comment),
       style: "color: #{red}; font-size: 14px;" do %>
       <%= gettext("View on #Constable") %>
     <% end %>

--- a/web/templates/email/new_announcement.html.eex
+++ b/web/templates/email/new_announcement.html.eex
@@ -31,7 +31,7 @@
         <tr>
           <td colspan="2" height="35"></td>
         </tr>
-        <%= render "author_footer.html", author: @author, announcement: @announcement %>
+        <%= render "author_footer.html", author: @author, announcement: @announcement, comment: nil %>
         <%= render "unsubscribe_footer.html" %>
         <tr>
           <td colspan="2" height="45"></td>

--- a/web/templates/email/new_announcement.text.eex
+++ b/web/templates/email/new_announcement.text.eex
@@ -2,6 +2,7 @@ Announced to <%= interest_names(@announcement) %>
 
 <%= @announcement.body %>
 
-<%= announcement_url(Constable.Endpoint, :show, @announcement) %>
+<%= announcement_url_for_footer(@announcement, nil) %>
 
 <%= render "unsubscribe_footer.text" %>
+

--- a/web/templates/email/new_comment.html.eex
+++ b/web/templates/email/new_comment.html.eex
@@ -23,7 +23,7 @@
         <tr>
           <td colspan="2" height="35"></td>
         </tr>
-        <%= render "author_footer.html", author: @author, announcement: @announcement %>
+        <%= render "author_footer.html", author: @author, announcement: @announcement, comment: @comment %>
         <%= render "unsubscribe_footer.html" %>
         <tr>
           <td colspan="2" height="45"></td>

--- a/web/templates/email/new_comment.text.eex
+++ b/web/templates/email/new_comment.text.eex
@@ -1,5 +1,5 @@
 <%= @comment.body %>
 
-<%= announcement_url(Constable.Endpoint, :show, @comment.announcement) %>
+<%= announcement_url_for_footer(@announcement, @comment) %>
 
 <%= render "unsubscribe_footer.text" %>

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -77,6 +77,13 @@ defmodule Constable.EmailView do
     |> Enum.join(", ")
   end
 
+  def announcement_url_for_footer(announcement, nil) do
+    Constable.Router.Helpers.announcement_url(Constable.Endpoint, :show, announcement)
+  end
+  def announcement_url_for_footer(announcement, comment) do
+    announcement_url_for_footer(announcement, nil) <> "#comment-#{comment.id}"
+  end
+
   defp new_comments(comments, announcement) do
     Enum.filter(comments, fn(c) -> c.announcement_id == announcement.id end)
   end


### PR DESCRIPTION
When clicking "View on Constable" we currently link to the announcement.

This change makes the "View on Constable" link take you directly to the
comment you were looking at in the email. This also updates the comment
times to be clickable so you can link directly to individual comments.
