### PR TITLE
Remove box around pagination

### DIFF
--- a/web/static/css/_pagination.scss
+++ b/web/static/css/_pagination.scss
@@ -1,17 +1,5 @@
 .pagination {
-  $base-border-color: gainsboro !default;
-  $base-border-radius: 3px !default;
-  $base-spacing: 1.5em !default;
-  $action-color: #477DCA !default;
-  $dark-gray: #333 !default;
-  $large-screen: 53.75em !default;
-  $base-font-color: $dark-gray !default;
-  $pagination-border-color: $base-border-color;
-  $pagination-border: 1px solid $pagination-border-color;
-  $pagination-background: lighten($pagination-border-color, 10);
-  $pagination-hover-background: lighten($pagination-background, 5);
-  $pagination-color: $base-font-color;
-
+  overflow: hidden;
   text-align: center;
   margin-top: 30px;
   margin-bottom: 40px;
@@ -36,24 +24,18 @@
     }
 
     li a {
-      background: $pagination-background;
-      border-radius: $base-border-radius;
-      border: $pagination-border;
-      color: $pagination-color;
       outline: none;
-      padding: ($base-spacing / 4) ($gutter / 2);
+      padding: $base-spacing / 4 0;
       text-decoration: none;
-      transition: all 0.2s ease-in-out;
-
-      &:hover,
-      &:focus {
-        background: $pagination-hover-background;
-        color: $action-color;
-      }
-
-      &:active {
-        background: $pagination-background;
-      }
+      width: auto;
     }
+  }
+
+  .page-prev {
+    float: right;
+  }
+
+  .page-next {
+    float: left;
   }
 }

--- a/web/templates/announcement/index.html.eex
+++ b/web/templates/announcement/index.html.eex
@@ -25,17 +25,21 @@
 
   <%= render Constable.AnnouncementListView, "index.html", conn: @conn, announcements: @announcements %>
 
-  <div class="pagination">
+  <div class="pagination container">
     <ul>
       <%= if !on_first_page?(@index_page) do %>
-        <li class="page-next">
-          <%= link gettext("NEWER"), to: announcement_path(@conn, :index, all: @show_all, page: (@index_page.page_number - 1)) %>
+        <li class="page-next page-button">
+          <%= link to: announcement_path(@conn, :index, all: @show_all, page: (@index_page.page_number - 1)) do %>
+            &laquo; <%= gettext("Newer") %>
+          <% end %>
         </li>
       <% end %>
 
       <%= if !on_last_page?(@index_page) do %>
-        <li class="page-prev">
-          <%= link gettext("OLDER"), to: announcement_path(@conn, :index, all: @show_all, page: (@index_page.page_number + 1)) %>
+        <li class="page-prev page-button">
+          <%= link to: announcement_path(@conn, :index, all: @show_all, page: (@index_page.page_number + 1)) do %>
+            <%= gettext("Older") %> &raquo;
+          <% end %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Paginations styles wrap the textbox like it's a button but our chosen
font has issues with line heights making it look off-center.

This removes the button styling and turns the links into standard
looking pagination links with double arrows and no box.

Current:
![screen shot 2016-05-27 at 3 08 55 pm](https://cloud.githubusercontent.com/assets/342554/15618608/f5983668-241c-11e6-804c-dc6f52a70bc9.png)

New:
![screen shot 2016-05-27 at 3 10 31 pm](https://cloud.githubusercontent.com/assets/342554/15618631/2b29376e-241d-11e6-88c8-eb0b4b17838e.png)
