### PR TITLE
Make sample.env language consistent with readme

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,5 +1,5 @@
-CLIENT_ID=GetFromGoogleDeveloperConsole
-CLIENT_SECRET=GetFromGoogleDeveloperConsole
+CLIENT_ID=GetFromStagingHerokuConfig
+CLIENT_SECRET=GetFromStagingHerokuConfig
 MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io


### PR DESCRIPTION
The readme tells you to get the CLIENT_ID and CLIENT_SECRET from the
staging heroku app, but the .sample.env file was saying to get these
from the google developer console.

This commit changes the sample env language to be consistent with the
readme.
