### PR TITLE
Preview how many users are interested in an announcement

### DIFF
--- a/lib/constable/repo.ex
+++ b/lib/constable/repo.ex
@@ -7,7 +7,10 @@ defmodule Constable.Repo do
   use Scrivener, page_size: 30
 
   def count(query) do
-    __MODULE__.all(from record in query, select: count(record.id))
-    |> List.first
+    one!(from record in query, select: count(record.id))
+  end
+
+  def count_distinct(query) do
+    one!(from record in query, select: count(record.id, :distinct))
   end
 end

--- a/test/controllers/recipients_preview_controller_test.exs
+++ b/test/controllers/recipients_preview_controller_test.exs
@@ -1,0 +1,31 @@
+defmodule Constable.RecipientsPreviewControllerTest do
+  use Constable.ConnCase, async: true
+
+  setup do
+    {:ok, browser_authenticate}
+  end
+
+  test "shows how many users are subscribed to the interests", %{conn: conn} do
+    interests = insert_pair(:interest)
+    _interested_user = insert(:user)
+      |> with_interest(interests |> List.first)
+      |> with_interest(interests |> List.last)
+    _uninterested_user = insert(:user)
+
+    html_result = recipient_preview_html_for(conn, interests: interests)
+
+    assert html_result =~ "1 person is subscribed to these interests."
+  end
+
+  defp recipient_preview_html_for(conn, interests: interests) do
+    json_result_for(conn, interests: interests)
+    |> Map.fetch! "recipients_preview_html"
+  end
+
+  defp json_result_for(conn, interests: interests) do
+    comma_separated_interests = interests |> Enum.map(&(&1.name)) |> Enum.join(",")
+
+    get(conn, recipients_preview_path(conn, :show), interests: comma_separated_interests)
+    |> json_response(200)
+  end
+end

--- a/web/controllers/recipients_preview_controller.ex
+++ b/web/controllers/recipients_preview_controller.ex
@@ -1,0 +1,27 @@
+defmodule Constable.RecipientsPreviewController do
+  use Constable.Web, :controller
+
+  alias Constable.Interest
+  alias Constable.User
+
+  def show(conn, params) do
+    recipient_count = interested_user_count(params["interests"])
+
+    conn
+    |> put_status(200)
+    |> render("show.json", recipient_count: recipient_count)
+  end
+
+  defp interested_user_count(comma_separated_interest_names) do
+    comma_separated_interest_names
+    |> String.split(",")
+    |> count_interested_users
+  end
+
+  defp count_interested_users(interest_names) do
+    query = from u in User,
+              join: i in assoc(u, :interests),
+              where: i.name in ^interest_names
+    Repo.count_distinct(query)
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -49,6 +49,7 @@ defmodule Constable.Router do
       resources "/user_interest", UserInterestController, singleton: true, only: [:create, :delete]
     end
     resources "/search", SearchController, singleton: true, only: [:show, :new]
+    resources "/recipients_preview", RecipientsPreviewController, singleton: true, only: [:show]
   end
 
   if Mix.env == :dev do

--- a/web/static/js/announcement-form.js
+++ b/web/static/js/announcement-form.js
@@ -1,4 +1,5 @@
 import { markedWithSyntax } from './syntax-highlighting';
+import { updateRecipientsPreview } from './recipients-preview';
 import 'selectize';
 
 const DELIMITER = ',';
@@ -27,9 +28,11 @@ const watchBody = function() {
 const setupInterestsSelect = function() {
   const interests = $('#announcement_interests');
 
-  if (interests.lenth !== 0) {
+  if (interests.length !== 0) {
     if (interests.val() === '') {
-      interests.val(localStorage.getItem('interests'));
+      const localStorageValue = localStorage.getItem('interests');
+      interests.val(localStorageValue);
+      updateRecipientsPreview(localStorageValue);
     }
 
     interests.selectize({
@@ -44,6 +47,7 @@ const setupInterestsSelect = function() {
       options: window.INTERESTS_NAMES,
       onChange: function(value) {
         localStorage.setItem('interests', value);
+        updateRecipientsPreview(value);
       },
     });
   }

--- a/web/static/js/recipients-preview.js
+++ b/web/static/js/recipients-preview.js
@@ -1,0 +1,7 @@
+export function updateRecipientsPreview(interests) {
+  const previewSelector = '.recipients-preview';
+  $.getJSON('/recipients_preview', { interests })
+    .done((data) => {
+      $(previewSelector).html(data.recipients_preview_html);
+    });
+}

--- a/web/templates/announcement/_form.html.eex
+++ b/web/templates/announcement/_form.html.eex
@@ -15,6 +15,9 @@
     <div class="announcement-form">
       <%= text_input f, :title, placeholder: gettext("What are you announcing?") %>
 
+      <section class="recipients-preview">
+        Please select interests:
+      </section>
       <%= text_input :announcement, :interests, placeholder: gettext("Interests") %>
 
       <%= textarea f, :body, placeholder: gettext("Write markdown here. You can @mention specific people to notify them") %>
@@ -45,7 +48,7 @@
     require('web/static/js/announcement-form').setupForm();
     require('web/static/js/announcement-form-mobile').setupForm();
     require('web/static/js/textarea-image-uploader').setupImageUploader('#announcement_body');
-    require("web/static/js/user-autocomplete").autocompleteUsers(
+    require('web/static/js/user-autocomplete').autocompleteUsers(
       '#announcement_body',
       <%= raw user_autocomplete_json(@users) %>
     );

--- a/web/templates/recipients_preview/recipients_preview.html.eex
+++ b/web/templates/recipients_preview/recipients_preview.html.eex
@@ -1,0 +1,1 @@
+<%= ngettext("1 person is", "%{count} people are", @recipient_count) %> subscribed to these interests.

--- a/web/views/recipients_preview_view.ex
+++ b/web/views/recipients_preview_view.ex
@@ -1,0 +1,15 @@
+defmodule Constable.RecipientsPreviewView do
+  use Constable.Web, :view
+
+  def render("show.json", %{recipient_count: recipient_count}) do
+    %{ recipients_preview_html: recipients_preview_html(recipient_count) }
+  end
+
+  defp recipients_preview_html(recipient_count) do
+    Phoenix.View.render_to_string(
+      Constable.RecipientsPreviewView,
+      "recipients_preview.html",
+      recipient_count: recipient_count
+    )
+  end
+end


### PR DESCRIPTION
Why?

When writing an announcement, it can be useful to know how many people
it will reach.

How?

This PR adds a preview to the announcement form page that shows how
many users are subscribed to the selected interests. The preview is
updated when interests are added/removed on the announcement form.

Closes https://github.com/thoughtbot/constable/issues/135

![constable_recipient_count](https://cloud.githubusercontent.com/assets/180798/15835016/21093bee-2bfc-11e6-8b27-20456abc0b1f.gif)
