### PR TITLE
Add service to disable login for inactive users

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -4,3 +4,4 @@ MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook
+HUB_API_TOKEN=getFromHubIfNeeded

--- a/lib/mix/tasks/disable_inactive_people.ex
+++ b/lib/mix/tasks/disable_inactive_people.ex
@@ -1,0 +1,12 @@
+defmodule Mix.Tasks.Constable.DisableInactivePeople do
+  use Mix.Task
+
+  alias Constable.{Hub, HubUserValidator}
+
+  def run(_opts) do
+    Mix.Task.run "app.start"
+
+    active_people_emails = Hub.active_people_emails
+    HubUserValidator.disable_users_not_in(active_people_emails)
+  end
+end

--- a/lib/mix/tasks/send_daily_digest.ex
+++ b/lib/mix/tasks/send_daily_digest.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Constable.SendDailyDigest do
 
   def run(_) do
     Mix.Task.run "app.start"
-    users = Repo.all(from u in User, where: u.daily_digest == true)
+    users = Repo.all(from u in User.active, where: u.daily_digest == true)
     user_emails = for user <- users do
       user.email
     end

--- a/priv/repo/migrations/20160610142434_add_active_to_user.exs
+++ b/priv/repo/migrations/20160610142434_add_active_to_user.exs
@@ -1,0 +1,11 @@
+defmodule Elixir.Constable.Repo.Migrations.AddActiveToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :active, :boolean, default: true, null: false
+    end
+
+    create index(:users, [:id, :active])
+  end
+end

--- a/test/plugs/api_auth_test.exs
+++ b/test/plugs/api_auth_test.exs
@@ -1,0 +1,27 @@
+defmodule Constable.Plugs.ApiAuthTest do
+  use Constable.ConnCase
+
+  test "active user is assigned to current_user assigns on conn" do
+    user = insert(:user, active: true)
+    conn = conn()
+      |> bypass_through
+      |> put_req_header("authorization", user.token)
+      |> run_plug
+
+    assert conn.assigns[:current_user]
+  end
+
+  test "inactive user is not assigned to current_user assigns on conn" do
+    user = insert(:user, active: false)
+    conn = conn()
+      |> bypass_through
+      |> put_req_header("authorization", user.token)
+      |> run_plug
+
+    refute conn.assigns[:current_user]
+  end
+
+  defp run_plug(conn) do
+    conn |> Constable.Plugs.ApiAuth.call(%{})
+  end
+end

--- a/test/plugs/fetch_current_user_test.ex
+++ b/test/plugs/fetch_current_user_test.ex
@@ -1,0 +1,33 @@
+defmodule Constable.Plugs.FetchCurrentUserTest do
+  use Constable.ConnCase
+
+  test "active user is assigned to current_user assigns on conn" do
+    user = insert(:user, active: true)
+    token = Constable.UserIdentifier.sign_user_id(Constable.Endpoint, user.id)
+    conn = conn()
+      |> bypass_through
+      |> Phoenix.ConnTest.put_req_cookie("user_id", token)
+      |> with_session
+      |> get("/")
+      |> run_plug
+
+    assert conn.assigns[:current_user]
+  end
+
+  test "inactive user is not assigned to current_user assigns on conn" do
+    user = insert(:user, active: false)
+    token = Constable.UserIdentifier.sign_user_id(Constable.Endpoint, user.id)
+    conn = conn()
+      |> bypass_through
+      |> Phoenix.ConnTest.put_req_cookie("user_id", token)
+      |> with_session
+      |> get("/")
+      |> run_plug
+
+    refute conn.assigns[:current_user]
+  end
+
+  defp run_plug(conn) do
+    conn |> Constable.Plugs.FetchCurrentUser.call(%{})
+  end
+end

--- a/test/services/hub_user_validator_test.exs
+++ b/test/services/hub_user_validator_test.exs
@@ -1,0 +1,31 @@
+defmodule Constable.HubValidatorTest do
+  use Constable.TestWithEcto
+
+  alias Constable.{HubUserValidator, User}
+
+  test "disable_invalid_users deactivates all users who don't match active people" do
+    insert(:user, email: "joe@dirt.com")
+    insert(:user, email: "invalid@dirt.com")
+    valid_emails = ["joe@dirt.com", "foo@bar.net"]
+
+    HubUserValidator.disable_users_not_in(valid_emails)
+
+    active_user = Repo.get_by(User, email: "joe@dirt.com")
+    inactive_user = Repo.get_by(User, email: "invalid@dirt.com")
+    ralph = Repo.get_by(User, email: "ralph@thoughtbot.com")
+
+    assert active_user.active
+    refute inactive_user.active
+  end
+
+  test "does not deactivate users in @ignored_users" do
+    insert(:user, email: "ralph@thoughtbot.com")
+    valid_emails = ["joe@dirt.com", "foo@bar.net"]
+
+    HubUserValidator.disable_users_not_in(valid_emails)
+
+    ralph = Repo.get_by(User, email: "ralph@thoughtbot.com")
+
+    assert ralph.active
+  end
+end

--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -49,7 +49,7 @@ defmodule Constable.AnnouncementController do
       announcement: announcement,
       comment: comment,
       subscription: subscription,
-      users: Repo.all(User),
+      users: Repo.all(User.active),
     )
   end
 
@@ -103,7 +103,7 @@ defmodule Constable.AnnouncementController do
   defp render_form(conn, action, announcement) do
     changeset = Announcement.changeset(announcement, :create)
     interests = Repo.all(Interest)
-    users = Repo.all(User)
+    users = Repo.all(User.active)
 
     render(conn, action, %{
       changeset: changeset,

--- a/web/models/queries/subscription.ex
+++ b/web/models/queries/subscription.ex
@@ -1,9 +1,11 @@
 defmodule Constable.Queries.Subscription do
-  alias Constable.Subscription
+  alias Constable.{Subscription, User}
   import Ecto.Query
 
   def for_announcement(announcement_id) do
     from s in Subscription,
+      join: u in assoc(s, :user),
+      where: u.active,
       where: s.announcement_id == ^announcement_id,
       preload: [:user]
   end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -16,6 +16,7 @@ defmodule Constable.User do
     field :username
     field :auto_subscribe, :boolean, default: true
     field :daily_digest, :boolean, default: true
+    field :active, :boolean, default: true
 
     has_many :user_interests, UserInterest, on_delete: :delete_all
     has_many :interests, through: [:user_interests, :interest]
@@ -46,6 +47,10 @@ defmodule Constable.User do
 
   def ordered_by_name(query \\ __MODULE__) do
     query |> order_by(asc: :name)
+  end
+
+  def active(query \\ __MODULE__) do
+    query |> where(active: true)
   end
 
   defp require_thoughtbot_email(changeset) do

--- a/web/plugs/api_auth.ex
+++ b/web/plugs/api_auth.ex
@@ -26,7 +26,7 @@ defmodule Constable.Plugs.ApiAuth do
 
   def find_user_from_token(nil), do: nil
   def find_user_from_token(token) do
-    Repo.get_by(User, token: token)
+    Repo.get_by(User.active, token: token)
   end
 
   def unauthorized(conn) do

--- a/web/plugs/fetch_current_user.ex
+++ b/web/plugs/fetch_current_user.ex
@@ -15,7 +15,7 @@ defmodule Constable.Plugs.FetchCurrentUser do
 
   def find_user(conn) do
     case UserIdentifier.verify_signed_user_id(conn) do
-      {:ok, user_id} -> Repo.get(User, user_id)
+      {:ok, user_id} -> Repo.get(User.active, user_id)
       {:error, _} -> :not_signed_in
     end
   end

--- a/web/services/announcement_creator.ex
+++ b/web/services/announcement_creator.ex
@@ -1,4 +1,6 @@
 defmodule Constable.Services.AnnouncementCreator do
+  import Ecto.Query
+
   alias Constable.Repo
   alias Constable.Announcement
   alias Constable.Subscription
@@ -75,9 +77,9 @@ defmodule Constable.Services.AnnouncementCreator do
   end
 
   defp find_interested_users(announcement) do
-    announcement
-    |> Repo.preload(:interested_users)
-    |> Map.get(:interested_users)
+    Ecto.assoc(announcement, :interested_users)
+    |> where([u1], u1.active == true)
+    |> Repo.all
   end
 
   def find_mentioned_users(announcement) do

--- a/web/services/hub.ex
+++ b/web/services/hub.ex
@@ -1,0 +1,25 @@
+defmodule Constable.Hub do
+  @hub_people_endpoint "https://hub.thoughtbot.com/api/people"
+
+  def active_people_emails do
+    fetch_active_people |> Enum.map(&(&1["email"]))
+  end
+
+  def fetch_active_people do
+    {:ok, response} = HTTPoison.get(
+      @hub_people_endpoint,
+      headers
+    )
+
+    response.body |> Poison.decode! |> Map.get("people")
+  end
+
+  defp headers do
+    token = System.get_env("HUB_API_TOKEN")
+    %{
+      "Content-Type" => "application/json",
+      "Accept" => "application/vnd.hub+json; version=1",
+      "AUTHORIZATION" => "Token token=#{token}"
+    }
+  end
+end

--- a/web/services/hub_user_validator.ex
+++ b/web/services/hub_user_validator.ex
@@ -1,0 +1,28 @@
+defmodule Constable.HubUserValidator do
+  import Ecto.Query
+  alias Constable.{Repo, User}
+
+  @ignore_users ["ralph@thoughtbot.com"]
+
+  def disable_users_not_in(active_emails) do
+    Repo.all(User.active)
+    |> diff(active_emails)
+    |> disable_users
+  end
+
+  defp diff(users, active_emails) do
+    Enum.reject(users, fn(user) ->
+      is_active = Enum.member?(active_emails, user.email)
+      is_ignored = Enum.member?(@ignore_users, user.email)
+
+      is_active || is_ignored
+    end)
+  end
+
+  defp disable_users(users) do
+    user_ids = users |> Enum.map(&(&1.id))
+
+    from(u in User, where: u.id in ^user_ids)
+    |> Repo.update_all(set: [active: false])
+  end
+end

--- a/web/services/mention_finder.ex
+++ b/web/services/mention_finder.ex
@@ -7,7 +7,7 @@ defmodule Constable.Services.MentionFinder do
   def find_users(text) do
     Regex.scan(@mention_regex, text)
     |> Enum.map(fn ([_, username]) -> username end)
-    |> Enum.map(&(Repo.get_by(User, username: &1)))
+    |> Enum.map(&(Repo.get_by(User.active, username: &1)))
     |> Enum.reject(&is_nil/1)
   end
 end


### PR DESCRIPTION
Currently there is no validation if a user is still an employee or not
which means if they save the session or API token they could potentially
still have access to Constable.

This adds a service to set users as inactive by comparing the user
emails with the emails of active users in hub.
