### PR TITLE
Make search input more forgiving

### DIFF
--- a/test/controllers/api/search_controller_test.exs
+++ b/test/controllers/api/search_controller_test.exs
@@ -11,10 +11,12 @@ defmodule Constable.Api.SearchesControllerTest do
     announcement_1 = insert(:announcement, title: "foobar1")
     announcement_2 = insert(:announcement, body: "announcement body cool")
     announcement_3 = insert(:announcement, title: "awesome title", body: "cool body")
+    announcement_4 = insert(:announcement, title: "sweet 401(k) bro", body: "sweet 401k")
 
     assert results_for(conn, query: "foobar1") == json_for(announcement_1)
     assert results_for(conn, query: "announcement body") == json_for(announcement_2)
     assert results_for(conn, query: "awesome title cool body") == json_for(announcement_3)
+    assert results_for(conn, query: "sweet 401(k) bro") == json_for(announcement_4)
     assert results_for(conn, query: "cool") == json_for([announcement_2, announcement_3])
     query_with_extra_spaces = "announcement     body"
     assert results_for(conn, query: query_with_extra_spaces) == json_for(announcement_2)

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -49,7 +49,7 @@ defmodule Constable.Announcement do
     search_term = search_term |> prepare_for_tsquery
 
     from(a in query,
-      where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ to_tsquery('english', ?)",
+      where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
         a.title,
         a.body,
         ^search_term


### PR DESCRIPTION
We use postgres's to_tsquery to turn user input into a tsquery data type
for querying. This function is strict about its input so searches like
`hello!` or `401 (k)` cause it to throw an exception.

To make the search input allow more values we use `plainto_tsquery`
instead of `to_tsquery` since the former is less strict about input.
