### PR TITLE
Render previews like the final announcement

### DIFF
--- a/web/templates/announcement/_form.html.eex
+++ b/web/templates/announcement/_form.html.eex
@@ -30,7 +30,7 @@
 
   <div class="announcement-preview">
     <h1 data-role="title-preview">Preview</h1>
-    <div class="markdown" data-role="markdown-preview">
+    <div class="markdown announcement-body" data-role="markdown-preview">
       Preview
     </div>
   </div>


### PR DESCRIPTION
Previously we weren't using the same CSS on the markdown preview that we were
using on the final rendered announcement. This led to inconsistency between
the two. Notably, list elements were missing decoration and quote blocks were
rendered differently.

The simplest fix for this is to make sure we apply the same CSS to the
markdown preview that we do to the final announcement. This will help keep
parity between the two and will ensure that as we update the style for one,
the other is automatically updated.

Fixes #334
