### PR TITLE
Remove List-Unsubscribe headers

### DIFF
--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -19,7 +19,6 @@ defmodule Constable.Mailers.AnnouncementTest do
     headers = %{
       "Message-ID" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
       "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>",
-      "List-Unsubscribe" => Constable.EmailView.unsubscribe_link
     }
     html_announcement_body = Earmark.to_html(announcement.body)
     assert email.to == users

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -18,7 +18,6 @@ defmodule Constable.Mailers.CommentMailerTest do
     headers = %{
       "In-Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}>",
       "Reply-To" => "<announcement-#{announcement.id}@#{Constable.Env.get("INBOUND_EMAIL_DOMAIN")}>",
-      "List-Unsubscribe" => Constable.EmailView.unsubscribe_link
     }
     assert email.to == users
     assert email.subject == subject

--- a/web/emails.ex
+++ b/web/emails.ex
@@ -42,7 +42,6 @@ defmodule Constable.Emails do
     |> from_author(announcement.user)
     |> put_header("Reply-To", announcement_email_address(announcement))
     |> put_header("Message-ID", announcement_message_id(announcement))
-    |> put_header("List-Unsubscribe", Constable.EmailView.unsubscribe_link)
     |> tag("new-announcement")
     |> render(:new_announcement, %{
       announcement: announcement,
@@ -56,7 +55,6 @@ defmodule Constable.Emails do
     |> subject("Re: #{announcement.title}")
     |> from_author(comment.user)
     |> put_reply_headers(announcement)
-    |> put_header("List-Unsubscribe", Constable.EmailView.unsubscribe_link)
     |> tag("new-comment")
     |> add_unsubscribe_vars(comment)
     |> render(:new_comment, %{


### PR DESCRIPTION
Mandrill doesn't support merge-vars in this header, and leaving them in with
an incorrect link will only lead to confusion since this header triggers
unsubscribe buttons to show up in some email clients. I think it's probably
best to just remove them for now until we have a better solution for adding
these through Mandrill.
