### PR TITLE
Unify comment/mention emails

### DIFF
--- a/web/emails.ex
+++ b/web/emails.ex
@@ -49,7 +49,7 @@ defmodule Constable.Emails do
     })
   end
 
-  def new_comment(comment, recipients) do
+  def new_comment(comment, recipients, mentioner \\ nil) do
     announcement = comment.announcement
     new_email(to: recipients)
     |> subject("Re: #{announcement.title}")
@@ -60,22 +60,13 @@ defmodule Constable.Emails do
     |> render(:new_comment, %{
       announcement: announcement,
       comment: comment,
-      author: comment.user
+      author: comment.user,
+      mentioner: mentioner
     })
   end
 
   def new_comment_mention(comment, recipients) do
-    announcement = comment.announcement
-    new_email(to: recipients)
-    |> subject("You were mentioned in: #{announcement.title}")
-    |> from_author(comment.user)
-    |> put_reply_headers(announcement)
-    |> tag("new-comment-mention")
-    |> render(:new_comment, %{
-      announcement: announcement,
-      comment: comment,
-      author: comment.user
-    })
+    new_comment(comment, recipients, comment.user)
   end
 
   def new_announcement_mention(announcement, recipients) do

--- a/web/templates/email/new_comment.html.eex
+++ b/web/templates/email/new_comment.html.eex
@@ -15,6 +15,11 @@
         </tr>
         <tr>
           <td colspan="2" align="left">
+            <%= if @mentioner do %>
+              <p>
+              <%= gettext("You were mentioned by") %> <%= @mentioner.name %>:
+              </p>
+            <% end %>
             <p>
               <%= raw Earmark.to_html(@comment.body) %>
             <p>

--- a/web/templates/email/new_comment.text.eex
+++ b/web/templates/email/new_comment.text.eex
@@ -1,3 +1,7 @@
+<% if @mentioner do %>
+<%= gettext("You were mentioned by") %> <%= @mentioner.name %>:
+
+<% end %>
 <%= @comment.body %>
 
 <%= announcement_url_for_footer(@announcement, @comment) %>


### PR DESCRIPTION
Instead of sending a completely different email for when a user is mentioned,
we should instead send a normal comment email but annotate the email to
indicate that the user was mentioned in the body.

I'm not sure if this is the _best_ way to do this, but it felt better to
remove the existing duplication rather than needing to duplicate the entire
template as well. Essentially, `new_comment_mention` becomes an alias for
`new_comment` with the third parameter filled out with the mentioner.

I spent zero time on the style in the message body, that almost certainly
needs to be given a once over by someone that knows what they are doing.

Fixes #298
