### PR TITLE
Conditionally show digest sections

### DIFF
--- a/web/templates/email/daily_digest.html.eex
+++ b/web/templates/email/daily_digest.html.eex
@@ -128,41 +128,46 @@
             <tr>
               <td width='40'></td>
               <td align='left'>
-                <h4><%= gettext("Recently added interests") %></h4>
+                <%= unless Enum.empty?(@interests) do %>
+                  <h4><%= gettext("Recently added interests") %></h4>
 
-                <%= for interest <- @interests do %>
-                  <div class="interest left-padded">
-                    <%= link "##{interest.name}", to: interest_url(Constable.Endpoint, :show, interest), style: "color: #{red}" %>
-                  </div>
-                <% end %>
-
-                <h4><%= gettext("Recently added announcements") %></h4><!-- Change to h4 to match interests -->
-
-                <%= for announcement <- @announcements do %>
-                  <div class="left-padded">
-                    <h4><%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %></h4>
-                    <%= gettext("posted by") %> <strong><%= announcement.user.name %></strong> <%= gettext("in") %> <%= raw interest_links(announcement) %>
-                  </div>
-                <% end %>
-
-                <h4>
-                  <%= ngettext("%{count} announcement was discussed", "%{count} announcements were discussed", length(discussed_announcements(@comments))) %>
-                  <%= ngettext("by %{count} person", "by %{count} people", length(unique_commenters(@comments))) %>
-                </h4>
-
-                <div class="left-padded">
-                  <%= for commenter <- unique_commenters(@comments) do %>
-                    <img src="<%= author_avatar_url(commenter) %>" class="avatar-rounded">
+                  <%= for interest <- @interests do %>
+                    <div class="interest left-padded">
+                      <%= link "##{interest.name}", to: interest_url(Constable.Endpoint, :show, interest), style: "color: #{red}" %>
+                    </div>
                   <% end %>
-                </div>
-
-                <%= for announcement <- discussed_announcements(@comments) do %>
-                  <div class="left-padded">
-                    <h4><%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %></h4>
-                    <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
-                  </div>
                 <% end %>
 
+                <%= unless Enum.empty?(@announcements) do %>
+                  <h4><%= gettext("Recently added announcements") %></h4><!-- Change to h4 to match interests -->
+
+                  <%= for announcement <- @announcements do %>
+                    <div class="left-padded">
+                      <h4><%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %></h4>
+                      <%= gettext("posted by") %> <strong><%= announcement.user.name %></strong> <%= gettext("in") %> <%= raw interest_links(announcement) %>
+                    </div>
+                  <% end %>
+                <% end %>
+
+                <%= unless Enum.empty?(@comments) do %>
+                  <h4>
+                    <%= ngettext("%{count} announcement was discussed", "%{count} announcements were discussed", length(discussed_announcements(@comments))) %>
+                    <%= ngettext("by %{count} person", "by %{count} people", length(unique_commenters(@comments))) %>
+                  </h4>
+
+                  <div class="left-padded">
+                    <%= for commenter <- unique_commenters(@comments) do %>
+                      <img src="<%= author_avatar_url(commenter) %>" class="avatar-rounded">
+                    <% end %>
+                  </div>
+
+                  <%= for announcement <- discussed_announcements(@comments) do %>
+                    <div class="left-padded">
+                      <h4><%= link announcement.title, to: announcement_url(Constable.Endpoint, :show, announcement), style: "color: #{red}" %></h4>
+                      <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
+                    </div>
+                  <% end %>
+                <% end %>
               </td>
               <td width='40'></td>
             </tr>

--- a/web/templates/email/daily_digest.text.eex
+++ b/web/templates/email/daily_digest.text.eex
@@ -1,5 +1,6 @@
 <%= gettext("# Daily digest of new Interests and Announcements") %>
 
+<%= unless Enum.empty?(@interests) do %>
 <%= gettext("Recently added interests") %>
 -------------
 
@@ -7,6 +8,8 @@
   #<%= interest.name %> - <%= interest_url(Constable.Endpoint, :show, interest) %>
 <% end %>
 
+<% end %>
+<%= unless Enum.empty?(@announcements) do %>
 <%= gettext("Recently added announcements") %>
 -----------------
 
@@ -15,6 +18,8 @@
   <%= gettext("posted by") %> <%= announcement.user.name %> <%= gettext("in") %> <%= interest_names(announcement) %>
 <% end %>
 
+<% end %>
+<%= unless Enum.empty?(@comments) do %>
 <%= ngettext("%{count} announcement was discussed", "%{count} announcements were discussed", length(discussed_announcements(@comments))) %>
 <%= ngettext("by %{count} person", "by %{count} people", length(unique_commenters(@comments))) %>
 
@@ -23,5 +28,6 @@
   <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
 <% end %>
 
+<% end %>
 <%= gettext("View Interests and Announcements on Constable") %>
 <%= announcement_url(Constable.Endpoint, :index) %>


### PR DESCRIPTION
Previously, we were always showing each section of the daily digest
(Interests, Announcements, Comments) regardless of if there was content to
show. This was mildly annoying, as it led to empty sections, most commonly
with interests.

To fix this, we can check to see if we have content to show before we actually
show it. This will lead to cleaner emails when there is less content to show.

I don't know if this is the best solution for this. I had a thought that a
ViewModel-type thing would be useful here but I don't know if that's a common
pattern in Elixir.
