### PR TITLE
Rename api and web auth plugs for consistency

### DIFF
--- a/test/plugs/api_auth_test.exs
+++ b/test/plugs/api_auth_test.exs
@@ -1,4 +1,4 @@
-defmodule Constable.Plugs.ApiAuthTest do
+defmodule Constable.Plugs.RequireApiLoginTest do
   use Constable.ConnCase
 
   test "active user is assigned to current_user assigns on conn" do
@@ -22,6 +22,6 @@ defmodule Constable.Plugs.ApiAuthTest do
   end
 
   defp run_plug(conn) do
-    conn |> Constable.Plugs.ApiAuth.call(%{})
+    conn |> Constable.Plugs.RequireApiLogin.call(%{})
   end
 end

--- a/test/plugs/require_web_login_test.exs
+++ b/test/plugs/require_web_login_test.exs
@@ -1,4 +1,4 @@
-defmodule Constable.Plugs.RequireLoginTest do
+defmodule Constable.Plugs.RequireWebLoginTest do
   use Constable.ConnCase, async: true
 
   test "user is redirected when current_user is not set" do
@@ -28,6 +28,6 @@ defmodule Constable.Plugs.RequireLoginTest do
   end
 
   defp run_plug(conn) do
-    conn |> Constable.Plugs.RequireLogin.call(%{})
+    conn |> Constable.Plugs.RequireWebLogin.call(%{})
   end
 end

--- a/web/plugs/require_api_login.ex
+++ b/web/plugs/require_api_login.ex
@@ -1,4 +1,4 @@
-defmodule Constable.Plugs.ApiAuth do
+defmodule Constable.Plugs.RequireApiLogin do
   import Plug.Conn
 
   alias Constable.Repo

--- a/web/plugs/require_web_login.ex
+++ b/web/plugs/require_web_login.ex
@@ -1,4 +1,4 @@
-defmodule Constable.Plugs.RequireLogin do
+defmodule Constable.Plugs.RequireWebLogin do
   import Plug.Conn
 
   def init(opts), do: opts

--- a/web/router.ex
+++ b/web/router.ex
@@ -14,10 +14,6 @@ defmodule Constable.Router do
     plug Constable.Plugs.FetchCurrentUser
   end
 
-  pipeline :authenticated do
-    plug Constable.Plugs.ApiAuth
-  end
-
   pipeline :api do
     plug :accepts, ~w(json)
   end
@@ -35,7 +31,7 @@ defmodule Constable.Router do
   end
 
   scope "/", Constable do
-    pipe_through [:browser, Constable.Plugs.RequireLogin]
+    pipe_through [:browser, Constable.Plugs.RequireWebLogin]
 
     get "/", HomeController, :index
 
@@ -78,7 +74,7 @@ defmodule Constable.Router do
   end
 
   scope "/api", as: :api, alias: Constable.Api do
-    pipe_through [:api, :authenticated]
+    pipe_through [:api, Constable.Plugs.RequireApiLogin]
 
     resources "/announcements", AnnouncementController
     resources "/comments", CommentController, only: [:create]


### PR DESCRIPTION
The `ApiAuth` is now `RequireApiLogin` and the `RequireLogin` plug is
now `RequireWebLogin` so the two have a consistent naming scheme since
they have the same behavior but in different contexts.
