### PR TITLE
Limit width for emails

### DIFF
--- a/web/templates/email/new_announcement.html.eex
+++ b/web/templates/email/new_announcement.html.eex
@@ -9,32 +9,40 @@
 
   <body leftmargin="0" marginwidth="0" marginheight="0" offset="0" topmargin="0" style="padding: 0 40px;">
     <center>
-      <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
+      <table border="0" cellspacing="0" width="100%">
         <tr>
-          <td colspan="2" height="35"></td>
-        </tr>
-        <tr style="font-size: 14px; color: <%= light_gray %>;">
-          <td align="left" colspan="2">
-            Announced to <%= raw interest_links(@announcement) %>
+          <td></td>
+          <td width="600">
+            <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="100%">
+              <tr>
+                <td colspan="2" height="35"></td>
+              </tr>
+              <tr style="font-size: 14px; color: <%= light_gray %>;">
+                <td align="left" colspan="2">
+                  Announced to <%= raw interest_links(@announcement) %>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2" height="20"></td>
+              </tr>
+              <tr>
+                <td colspan="2" align="left">
+                  <p>
+                  <%= raw Earmark.to_html(@announcement.body) %>
+                  <p>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2" height="35"></td>
+              </tr>
+              <%= render "author_footer.html", author: @author, announcement: @announcement, comment: nil %>
+              <%= render "unsubscribe_footer.html" %>
+              <tr>
+                <td colspan="2" height="45"></td>
+              </tr>
+            </table>
           </td>
-        </tr>
-        <tr>
-          <td colspan="2" height="20"></td>
-        </tr>
-        <tr>
-          <td colspan="2" align="left">
-            <p>
-              <%= raw Earmark.to_html(@announcement.body) %>
-            <p>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="2" height="35"></td>
-        </tr>
-        <%= render "author_footer.html", author: @author, announcement: @announcement, comment: nil %>
-        <%= render "unsubscribe_footer.html" %>
-        <tr>
-          <td colspan="2" height="45"></td>
+          <td></td>
         </tr>
       </table>
     </center>

--- a/web/templates/email/new_comment.html.eex
+++ b/web/templates/email/new_comment.html.eex
@@ -9,29 +9,37 @@
 
   <body leftmargin="0" marginwidth="0" marginheight="0" offset="0" topmargin="0" style="padding: 0 30px;">
     <center>
-      <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
+      <table border="0" cellspacing="0" width="100%">
         <tr>
-          <td colspan="2" height="35"></td>
-        </tr>
-        <tr>
-          <td colspan="2" align="left">
-            <%= if @mentioner do %>
-              <p>
-              <%= gettext("You were mentioned by") %> <%= @mentioner.name %>:
-              </p>
-            <% end %>
-            <p>
-              <%= raw Earmark.to_html(@comment.body) %>
-            <p>
+          <td></td>
+          <td width="600">
+            <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="100%">
+              <tr>
+                <td colspan="2" height="35"></td>
+              </tr>
+              <tr>
+                <td colspan="2" align="left">
+                  <%= if @mentioner do %>
+                  <p>
+                  <%= gettext("You were mentioned by") %> <%= @mentioner.name %>:
+                  </p>
+                  <% end %>
+                  <p>
+                  <%= raw Earmark.to_html(@comment.body) %>
+                  <p>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2" height="35"></td>
+              </tr>
+              <%= render "author_footer.html", author: @author, announcement: @announcement, comment: @comment %>
+              <%= render "unsubscribe_footer.html" %>
+              <tr>
+                <td colspan="2" height="45"></td>
+              </tr>
+            </table>
           </td>
-        </tr>
-        <tr>
-          <td colspan="2" height="35"></td>
-        </tr>
-        <%= render "author_footer.html", author: @author, announcement: @announcement, comment: @comment %>
-        <%= render "unsubscribe_footer.html" %>
-        <tr>
-          <td colspan="2" height="45"></td>
+          <td></td>
         </tr>
       </table>
     </center>


### PR DESCRIPTION
When a very large image comes in through email, the CSS `max-width` does
not apply in some email clients (Airmail, Gmail, Google Inbox), so the
email appears extremely wide and you must scroll left/right to read each
paragraph.

This is an attempt to limit the email width using a table based layout.
The max width for the New Announcement and New Comment emails should now
be 600px.

See: http://stackoverflow.com/a/24499931
