### PR TITLE
Limit width for emails

### DIFF
--- a/web/controllers/settings_controller.ex
+++ b/web/controllers/settings_controller.ex
@@ -15,7 +15,7 @@ defmodule Constable.SettingsController do
       {:ok, _user} ->
         conn
         |> put_flash(:success, "YES!")
-        |> render "show.html", changeset: changeset, layout: false
+        |> render("show.html", changeset: changeset, layout: false)
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/web/emails.ex
+++ b/web/emails.ex
@@ -42,6 +42,7 @@ defmodule Constable.Emails do
     |> from_author(announcement.user)
     |> put_header("Reply-To", announcement_email_address(announcement))
     |> put_header("Message-ID", announcement_message_id(announcement))
+    |> put_param("inline_css", true)
     |> tag("new-announcement")
     |> add_unsubscribe_vars(announcement)
     |> render(:new_announcement, %{
@@ -56,6 +57,7 @@ defmodule Constable.Emails do
     |> subject("Re: #{announcement.title}")
     |> from_author(comment.user)
     |> put_reply_headers(announcement)
+    |> put_param("inline_css", true)
     |> tag("new-comment")
     |> add_unsubscribe_vars(announcement)
     |> render(:new_comment, %{
@@ -76,6 +78,7 @@ defmodule Constable.Emails do
     |> subject("You were mentioned in: #{announcement.title}")
     |> from_author(announcement.user)
     |> tag("new-announcement-mention")
+    |> put_param("inline_css", true)
     |> put_header("Reply-To", announcement_email_address(announcement))
     |> put_header("Message-ID", announcement_message_id(announcement))
     |> render(:new_announcement,

--- a/web/templates/email/new_announcement.html.eex
+++ b/web/templates/email/new_announcement.html.eex
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Constable announcement</title>
     <%= raw render("styles.html") %>
@@ -9,7 +9,7 @@
 
   <body leftmargin="0" marginwidth="0" marginheight="0" offset="0" topmargin="0" style="padding: 0 40px;">
     <center>
-      <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
+      <table border="0" cellpadding="0" cellspacing="0" class="flex-size body" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
         <tr>
           <td colspan="2" height="35"></td>
         </tr>
@@ -25,12 +25,14 @@
           <td colspan="2" align="left">
             <p>
               <%= raw Constable.Markdown.to_html(@announcement.body) %>
-            <p>
+            </p>
           </td>
         </tr>
         <tr>
           <td colspan="2" height="35"></td>
         </tr>
+      </table>
+      <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
         <%= render "author_footer.html", author: @author, announcement: @announcement, comment: nil %>
         <%= render "unsubscribe_footer.html" %>
         <tr>

--- a/web/templates/email/styles.html.eex
+++ b/web/templates/email/styles.html.eex
@@ -12,7 +12,15 @@
     margin-bottom: .5em; !important;
   }
 
-  @media (max-width: 600px) {
+  /* Contains content images */
+
+  .body img {
+    height:auto !important;
+    max-width: 600px !important;
+    width: 100% !important;
+  }
+
+  @media only screen and (max-width: 600px) {
 
     /* Typography */
 
@@ -42,10 +50,5 @@
       width: 100% !important;
     }
 
-    /* Contains content images */
-
-    .flex-size img {
-      max-width: 100% !important;
-    }
   }
 </style>


### PR DESCRIPTION
When a very large image comes in through email, the CSS `max-width` does
not apply in some email clients (Airmail, Gmail, Google Inbox), so the
email appears extremely wide and you must scroll left/right to read each
paragraph.

This is an attempt to limit the email width.
The max width for the New Announcement and New Comment emails should now
be 600px.

See: http://templates.mailchimp.com/development/responsive-email/fluid-images/