### PR TITLE
Fix for long links overflowing their container on announcements/comments

### DIFF
--- a/web/static/css/_announcement.scss
+++ b/web/static/css/_announcement.scss
@@ -131,6 +131,8 @@
   }
 
   p {
+    overflow-wrap: break-word;
+      
     &:last-child {
       margin-bottom: 0;
     }


### PR DESCRIPTION
I noticed this bug on an announcement today and couldn't let it stand.

**Before**
![screen shot 2016-07-18 at 10 49 32 am](https://cloud.githubusercontent.com/assets/5566826/16918919/98c0decc-4cd5-11e6-9c8e-81fb20ffca2c.png)

**After**
![screen shot 2016-07-18 at 10 49 47 am](https://cloud.githubusercontent.com/assets/5566826/16918926/9f2dd170-4cd5-11e6-9a72-6ab6c4e9ad78.png)
