### PR TITLE
Add user deactivation

### DIFF
--- a/test/controllers/user_activation_controller_test.exs
+++ b/test/controllers/user_activation_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule Constable.UserActivationControllerTest do
+  use Constable.ConnCase, async: true
+
+  alias Constable.{Repo, User}
+
+  setup do
+    {:ok, browser_authenticate}
+  end
+
+  test "GET index renders deactivate button when user is active", %{conn: conn} do
+    user = insert(:user, active: true)
+    resp = get(conn, user_activation_path(conn, :index))
+
+    assert html_response(resp, 200) =~ "Deactivate"
+  end
+
+  test "GET index renders activate button when user is inactive", %{conn: conn} do
+    user = insert(:user, active: false)
+    resp = get(conn, user_activation_path(conn, :index))
+
+    assert html_response(resp, 200) =~ "Activate"
+  end
+
+  test "PUT update toggles active flag on user", %{conn: conn} do
+    user = insert(:user, active: false)
+
+    resp = put(conn, user_activation_path(conn, :update, user))
+    user = Repo.get!(User, user.id)
+    assert user.active
+
+    resp = put(conn, user_activation_path(conn, :update, user))
+    user = Repo.get!(User, user.id)
+    refute user.active
+  end
+end

--- a/web/controllers/user_activation_controller.ex
+++ b/web/controllers/user_activation_controller.ex
@@ -1,0 +1,20 @@
+defmodule Constable.UserActivationController do
+  use Constable.Web, :controller
+
+  alias Constable.{Repo, User}
+
+  def index(conn, _params) do
+    users = Repo.all(User |> order_by(desc: :active))
+    render(conn, "index.html", users: users)
+  end
+
+  def update(conn, %{"id" => id}) do
+    user = Repo.get!(User, id)
+    new_activation_status = !user.active
+
+    Ecto.Changeset.change(user, %{active: new_activation_status})
+    |> Repo.update!
+
+    redirect(conn, to: user_activation_path(conn, :index))
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -46,6 +46,7 @@ defmodule Constable.Router do
     end
     resources "/search", SearchController, singleton: true, only: [:show, :new]
     resources "/recipients_preview", RecipientsPreviewController, singleton: true, only: [:show]
+    resources "/user_activations", UserActivationController, only: [:index, :update]
   end
 
   if Mix.env == :dev do

--- a/web/static/css/_user-activations.scss
+++ b/web/static/css/_user-activations.scss
@@ -1,0 +1,23 @@
+.user-activations {
+  margin-top: $base-spacing;
+}
+
+.user-activations__user {
+  align-items:center;
+  border-bottom: 1px solid $light-gray;
+  display: flex;
+  margin-bottom: $tiny-spacing;
+  padding-bottom: $tiny-spacing;
+
+  .meta {
+    align-items:center;
+    display: flex;
+    flex: 1;
+  }
+
+  .gravatar {
+    @include size(40px);
+    border-radius: 50%;
+    margin-right: $tiny-spacing;
+  }
+}

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -21,3 +21,4 @@
 @import 'flash';
 @import 'pagination';
 @import 'uploadable-input';
+@import 'user-activations';

--- a/web/templates/user_activation/index.html.eex
+++ b/web/templates/user_activation/index.html.eex
@@ -1,0 +1,17 @@
+<div class="user-activations container">
+  <%= for user <- @users do %>
+    <div class="user-activations__user">
+      <div class="meta">
+        <img class="gravatar" src="<%= gravatar(user) %>"/>
+        <%= user.name %>
+      </div>
+      <%= link to: user_activation_path(@conn, :update, user), method: :put do %>
+        <%= if user.active do %>
+          Deactivate
+        <% else %>
+          Activate
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/web/views/user_activation_view.ex
+++ b/web/views/user_activation_view.ex
@@ -1,0 +1,3 @@
+defmodule Constable.UserActivationView do
+  use Constable.Web, :view
+end


### PR DESCRIPTION
Users can now visit /user_activations to activate/deactivate users when
they leave/rejoin the company.

<img width="1680" alt="screen shot 2016-07-22 at 3 01 20 pm" src="https://cloud.githubusercontent.com/assets/342554/17068138/30c9cb26-501d-11e6-81c1-18d27a230835.png">
