### PR TITLE
Retain existing interests when editing an announcement

### DIFF
--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -48,6 +48,21 @@ defmodule Constable.UserAnnouncementTest do
     assert has_announcement_body?(session, "Updated")
   end
 
+  test "user edits an announcement and interests are kept", %{session: session} do
+    user = insert(:user)
+    elixir_interest = insert(:interest, name: "elixir")
+    announcement = insert(:announcement, user: user) |> tag_with_interest(elixir_interest)
+
+    session
+    |> visit(announcement_path(Endpoint, :edit, announcement.id, as: user.id))
+    |> fill_in("announcement_title", with: "Updated title")
+    |> fill_in("announcement_body", with: "# Updated")
+    |> click_submit_button
+
+    assert has_announcement_title?(session, "Updated title")
+    assert has_announcement_interest?(session, "elixir")
+  end
+
   defp click_edit(session) do
     session
     |> find("[data-role=edit]")

--- a/web/controllers/announcement_controller.ex
+++ b/web/controllers/announcement_controller.ex
@@ -74,7 +74,7 @@ defmodule Constable.AnnouncementController do
   end
 
   def edit(conn, %{"id" => id}) do
-    announcement = Repo.get!(Announcement, id)
+    announcement = Repo.get!(Announcement, id) |> Repo.preload([:interests])
     render_form(conn, "edit.html", announcement)
   end
 

--- a/web/templates/announcement/_form.html.eex
+++ b/web/templates/announcement/_form.html.eex
@@ -18,7 +18,7 @@
       <section class="recipients-preview">
         Please select interests:
       </section>
-      <%= text_input :announcement, :interests, placeholder: gettext("Interests") %>
+      <%= text_input :announcement, :interests, value: comma_separated_interest_names(@changeset.data.interests), placeholder: gettext("Interests") %>
 
       <%= textarea f,
         :body,

--- a/web/views/announcement_view.ex
+++ b/web/views/announcement_view.ex
@@ -7,6 +7,14 @@ defmodule Constable.AnnouncementView do
     |> Poison.encode!
   end
 
+  def comma_separated_interest_names(interests) when is_list(interests) do
+    interests
+    |> Enum.map(&(&1.name))
+    |> Enum.join(",")
+  end
+
+  def comma_separated_interest_names(_), do: ""
+
   def class_for("all", %{params: %{"all" => "true"}}) do
     "selected"
   end


### PR DESCRIPTION
Fixes #335.

Retain existing interests when editing an announcement.

Editing announcements is soft-disabled at the moment (the links are hidden) - I'm not sure if my test should be marked as pending or not. I got around this by visiting the edit announcement page directly (rather than via the edit link).

I'm not sure how much of an anti-pattern it is to sometimes preload interests in `AnnouncementController` (e.g. `edit`) and sometimes not (e.g. `new`). It means we end up having to check this when rendering the announcement form.
