### PR TITLE
Don't write to localstorage when editing

### DIFF
--- a/web/templates/announcement/_form.html.eex
+++ b/web/templates/announcement/_form.html.eex
@@ -1,6 +1,6 @@
 <%= form_for @changeset,
   @path,
-  [class: "flex-container", data: [role: "announcement-form"]],
+  [class: "flex-container", data: [role: "announcement-form", id: @changeset.data.id]],
   fn(f) -> %>
   <nav class="header-tags">
     <div class="header-tag header-tag-markdown active">
@@ -49,7 +49,8 @@
 <script>
   (function() {
     window.INTERESTS_NAMES = <%= raw json_interests(@interests) %>;
-    require('web/static/js/announcement-form').setupForm();
+    var AnnouncementForm = require('web/static/js/announcement-form').default;
+    new AnnouncementForm();
     require('web/static/js/announcement-form-mobile').setupForm();
     require('web/static/js/textarea-image-uploader').setupImageUploader('#announcement_body');
     require('web/static/js/user-autocomplete').autocompleteUsers(


### PR DESCRIPTION
Currently when editing an announcement the announcement details are
persisted in localStorage. This means when you go back to your draft
announcement it's overwritten with the announcement you last edited.

This changes the JavaScript to check if it's editing an announcement and
to not write to localStorage if you are. It also turns the JavaScript
into a default class export instead of a `setupForm` function to help
keep track of state.
