### PR TITLE
Re-enable edit link on announcements

### DIFF
--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -30,7 +30,6 @@ defmodule Constable.UserAnnouncementTest do
     assert has_recipient_preview?(session, "Blake, Paul")
   end
 
-  @tag :pending
   test "user updates an announcement", %{session: session} do
     user = insert(:user)
     announcement = insert(:announcement, user: user)

--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -27,6 +27,11 @@
 
   <h1 data-role="title">
     <%= @announcement.title %>
+    <%= if @announcement.user_id == @current_user.id do %>
+      <small>
+        <%= link "edit", to: announcement_path(@conn, :edit, @announcement), data: [role: "edit"] %>
+      </small>
+    <% end %>
   </h1>
 
   <div class="announcement-metadata">


### PR DESCRIPTION
The localStorage behavior was fixed so editing an announcement does not
overwrite drafts so the edit action can be re-enabled.
