### PR TITLE
Update bamboo to 0.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Constable.Mixfile do
   # Type `mix help deps` for examples and options
   defp deps do
     [
-      {:bamboo, "~> 0.6", github: "thoughtbot/bamboo"},
+      {:bamboo, "~> 0.7"},
       {:cors_plug, "~> 0.1"},
       {:cowboy, "~> 1.0"},
       {:dialyxir, "~> 0.3", only: [:dev]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"bamboo": {:git, "https://github.com/thoughtbot/bamboo.git", "25c922821b356d1272e8928d40243eb0481e9576", []},
+%{"bamboo": {:hex, :bamboo, "0.7.0", "2722e395a396dfedc12d300c900f65b216f7d7bf9d430c5dd0235690997878b7", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, optional: false]}]},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "combine": {:hex, :combine, "0.7.0"},
   "connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},


### PR DESCRIPTION
This [commit](https://github.com/thoughtbot/bamboo/commit/971f96261972fe1cde408c0edc2f50750a19c9ce) fixes the `rand_bytes` deprecation. 