### PR TITLE
Fix asset compilation

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,7 +6,7 @@ config :constable, Constable.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]],
+  watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin", cd: Path.expand("../", __DIR__)]],
   live_reload: [
     patterns: [
       ~r{priv/static/.*(js|css|png|jpeg|jpg|gif)$},

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "babel-brunch": "~6.0.0",
     "babel-preset-es2015": "^6.6.0",
-    "brunch": "~2.1.3",
+    "brunch": "~2.8.2",
     "clean-css-brunch": "~1.8.0",
     "css-brunch": "~1.7.0",
     "javascript-brunch": "~1.8.0",


### PR DESCRIPTION
* Using the :root endpoint configuration for watchers is deprecated. The :cd option at the end of the watcher argument list is now required.
* Update brunch to work with node v6.6.0.