### PR TITLE
Clean up .sample.env

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,4 +2,5 @@ MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook
-HUB_API_TOKEN=getFromHubIfNeeded
+CLIENT_ID=GetFromGithub
+CLIENT_SECRET=GetFromGithub


### PR DESCRIPTION
This removes the unused `HUB_API_TOKEN` and adds `CLIENT_ID` and
`CLIENT_SECRET` to make it more clear that they need to be fetched from
Github.
