### PR TITLE
Removed import Bamboo.Email line in web/emails.ex

### DIFF
--- a/web/emails.ex
+++ b/web/emails.ex
@@ -1,7 +1,6 @@
 defmodule Constable.Emails do
   use Bamboo.Phoenix, view: Constable.EmailView
 
-  import Bamboo.Email
   import Bamboo.MandrillHelper
   alias Constable.Repo
   alias Constable.Subscription


### PR DESCRIPTION
Removed `import Bamboo.Email` line given `use Bamboo.Phoenix, view: Constable.EmailView`  

See [`phoenix.ex` in Bamboo](https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/phoenix.ex#L107) (Relevant Snippet below):
```elixir
defmacro __using__(view: view_module) do
 verify_phoenix_dep
 quote do
   import Bamboo.Email
   import Bamboo.Phoenix, except: [render: 3]
...
end
```