### PR TITLE
resolves babel-preset-es2016 compiling error

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -28,7 +28,8 @@ exports.config = {
 
   plugins: {
     babel: {
-      ignore: [/web\/static\/vendor/]
+      ignore: [/web\/static\/vendor/],
+      presets: ["es2015"]
     },
     postcss: {
       processors: [


### PR DESCRIPTION
Why:
Several acceptance tests are failing locally because
certain css elements can't be found. Running tests
also results in a "couldn't find preset" compile warning
for babel-preset-es2016.

This PR:
Sets the list of babel presets to only include es2015 so
the default list of [es2015, es2016] (set in babel-brunch)
isn't used. Including es2016 prompts babel-brunch to look
for babel-preset-es2016 in the current project's node modules.

Version **6.0.5** of babel-brunch includes changes that [introduces support for ES2016](https://github.com/babel/babel-brunch/commit/3e7519bbbe8e25f670067d83270aa44bbc000f7d). As their [README](https://github.com/babel/babel-brunch#configuration) states, this babel-brunch uses, by default, the es2015 and es2016 presets.

To resolve the current compile warnings and local failing tests, there are two options:
1) run `npm install babel-preset-es2016 --save`, which adds es2016 below the [es2015 dependency](https://github.com/thoughtbot/constable/blob/11ff11522e0cc7d71261d2c9c5cb521ab58974b3/package.json#L25)
2) opt out of using es2016, which is the solution shown in this PR. I chose this over adding es2016 as this project doesn't seem to need es2016 support. I also like explicitly setting the presets in use as it took me some time to figure out which dependency had the expectation that `babel-preset-es2016` was present.

Screen shot of the compile warnings looking for `babel-preset-es2016`:
<img width="1074" alt="compile-warning" src="https://cloud.githubusercontent.com/assets/4016985/20031832/59ffbf34-a354-11e6-8dbd-02ece0318201.png">
