### PR TITLE
Replace deprecated `Dict.fetch!` with `Map.fetch!`

### DIFF
--- a/lib/constable/env.ex
+++ b/lib/constable/env.ex
@@ -3,6 +3,6 @@ defmodule Constable.Env do
   Gets a variable from the environment and throws an error if it does not exist
   """
   def get(key) do
-    System.get_env |> Dict.fetch!(key)
+    System.get_env |> Map.fetch!(key)
   end
 end


### PR DESCRIPTION
`Dict` module is deprecated since Elixir [1.2](https://github.com/elixir-lang/elixir/blob/v1.2/lib/elixir/lib/dict.ex#L3).
Let's use `Map` instead.