### PR TITLE
Fix missing space on bottom of announcement page

### DIFF
--- a/web/static/css/_comments.scss
+++ b/web/static/css/_comments.scss
@@ -65,6 +65,7 @@
 
 .comment-new, .comment-edit {
   border-top: $base-border;
+  margin-bottom: $base-spacing;
   padding-top: $base-spacing;
 
   input[type="submit"] {


### PR DESCRIPTION
Before
![screen shot 2017-02-24 at 9 03 32 am](https://cloud.githubusercontent.com/assets/342554/23306240/9f6ca816-fa70-11e6-8382-42751a29884e.png)

After
![screen shot 2017-02-24 at 9 03 18 am](https://cloud.githubusercontent.com/assets/342554/23306241/9f733f14-fa70-11e6-8d71-7bb628248583.png)