### PR TITLE
Allow excluding specific interests in search

### DIFF
--- a/test/controllers/search_controller_test.exs
+++ b/test/controllers/search_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule Constable.SearchControllerTest do
+  use Constable.ConnCase, async: true
+
+  setup do
+    {:ok, browser_authenticate()}
+  end
+
+  test "#show returns announcements matching search", %{conn: conn}do
+    foo = insert(:interest, name: "foo")
+    insert(:announcement, title: "Awesome Post") |> tag_with_interest(foo)
+    insert(:announcement, title: "Not so much post", body: "awesome post!") |> tag_with_interest(foo)
+    insert(:announcement, title: "Don't show up!", body: "lame post!") |> tag_with_interest(insert(:interest))
+
+    conn = get conn, search_path(conn, :show, query: "awesome")
+
+    assert html_response(conn, :ok) =~ "Awesome Post"
+    assert html_response(conn, :ok) =~ "Not so much post"
+    refute html_response(conn, :ok) =~ "Don't show up!"
+  end
+
+  test "#show hides announcements from excluded interests", %{conn: conn} do
+    foo = insert(:interest, name: "foo")
+    bar = insert(:interest, name: "bar")
+    insert(:announcement, title: "Awesome Post") |> tag_with_interest(foo)
+    insert(:announcement, title: "Not so much post", body: "awesome post!") |> tag_with_interest(foo)
+    insert(:announcement, title: "Good post!", body: "another awesome post!") |> tag_with_interest(bar)
+
+    conn = get conn, search_path(conn, :show, query: "awesome", exclude_interests: ["foo"])
+
+    refute html_response(conn, :ok) =~ "Awesome Post"
+    refute html_response(conn, :ok) =~ "Not so much post"
+    assert html_response(conn, :ok) =~ "Good post!"
+  end
+end

--- a/web/controllers/api/search_controller.ex
+++ b/web/controllers/api/search_controller.ex
@@ -5,8 +5,13 @@ defmodule Constable.Api.SearchController do
 
   alias Constable.Announcement
 
-  def create(conn, %{"query" => search_terms}) do
-    announcements = Announcement.search(search_terms) |> Repo.all
+  def create(conn, params = %{"query" => search_terms}) do
+    excludes = params["exclude_interests"] || []
+
+    announcements = 
+      search_terms
+      |> Announcement.search(exclude_interests: excludes)
+      |> Repo.all
     render(conn, "index.json", announcements: announcements)
   end
 end

--- a/web/controllers/search_controller.ex
+++ b/web/controllers/search_controller.ex
@@ -18,8 +18,10 @@ defmodule Constable.SearchController do
     render conn, "new.html", announcements: []
   end
 
-  defp matching_announcements(%{"query" => search_terms}) do
-    Announcement.search(search_terms)
+  defp matching_announcements(params = %{"query" => search_terms}) do
+    excluded_interests = params["exclude_interests"] || []
+
+    Announcement.search(search_terms, exclude_interests: excluded_interests)
     |> Announcement.last_discussed_first
     |> Announcement.with_announcement_list_assocs
   end

--- a/web/models/announcement.ex
+++ b/web/models/announcement.ex
@@ -44,10 +44,12 @@ defmodule Constable.Announcement do
     ]
   end
 
-  def search(query \\ __MODULE__, search_term) do
+  def search(query \\ __MODULE__, search_term, exclude_interests: excludes) do
     search_term = search_term |> prepare_for_tsquery
 
     from(a in query,
+      full_join: i in assoc(a, :interests),
+      where: not i.name in ^excludes or is_nil(i.name),
       where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
         a.title,
         a.body,


### PR DESCRIPTION
This implements the ability to exclude specific interests from returned
search results. This will be helpful to tools that want to search
Constable but exclude specific interests.

This adds the feature to both the API and non-API search controller's
for parity but doesn't expose UI to use this functionality.