### PR TITLE
Add title to announcement published date

### DIFF
--- a/web/templates/announcement/show.html.eex
+++ b/web/templates/announcement/show.html.eex
@@ -37,7 +37,7 @@
   <div class="announcement-metadata">
     <img src="<%= gravatar @announcement.user %>" class="avatar-rounded"/>
     <h4 class="author"><%= @announcement.user.name %></h4>
-    <time><%= time_ago_in_words(@announcement.inserted_at) %></time>
+    <time title="<%= Date.to_string(@announcement.inserted_at) %>"><%= time_ago_in_words(@announcement.inserted_at) %></time>
   </div>
 
   <div class="announcement-body" data-role="body">


### PR DESCRIPTION
Taking a stab at https://github.com/thoughtbot/constable/issues/325. 

Summary
=======

Using the `time_ago_in_words/1` to display the published date is really nice since it shows something like, `"2 days ago"`. When the date is too far back, however, it can get confusing.

This commit adds the title attribute to the announcement date so that the announcement published date shows up with the format: `"yyyy-mm-dd"`. It is pretty rough, but it should do the job. 

Screenshot
========

![screen shot 2017-09-01 at 4 28 15 pm](https://user-images.githubusercontent.com/3245976/29986907-7faf3eb4-8f33-11e7-9a4c-2d5a2004ca97.png)
