### PR TITLE
Easily reactivate users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ To learn more about Phoenix, check out [Programming Phoenix](https://pragprog.co
 Use `bin/console` to start the console. Use `bin/console staging|production` to
 start the console in staging or production.
 
+## Reactivating Users
+
+Users are deactivated if they leave thoughtbot. Sometimes someone with the same
+first name joins thoughtbot later and inherits the deactivated email so we need
+to reactivate the email.
+
+* Run `bin/console production`
+* Run `Constable.User.reactivate("person@thoughtbot.com")`
+
 ## Developing the Application
 
 To set up your development environment, there are a few steps you'll need to

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -48,4 +48,12 @@ defmodule Constable.UserTest do
     changeset = User.create_changeset(%User{}, %{email: "#{username}@#{@permitted_email_domain}"})
     assert changeset.changes[:name] == username
   end
+
+  test "reactivating a user" do
+    user = insert(:user, active: false)
+
+    User.reactivate(user.email)
+
+    assert Repo.get!(User, user.id).active
+  end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,5 +1,6 @@
 defmodule Constable.User do
   use Constable.Web, :model
+  alias Constable.Repo
   alias Constable.UserInterest
   alias Constable.Subscription
 
@@ -27,6 +28,12 @@ defmodule Constable.User do
     has_many :subscriptions, Subscription, on_delete: :delete_all
 
     timestamps()
+  end
+
+  def reactivate(email) when is_binary(email) do
+    Repo.get_by!(__MODULE__, email: email)
+    |> Ecto.Changeset.change(%{active: true})
+    |> Repo.update!
   end
 
   def settings_changeset(user, params \\ %{}) do


### PR DESCRIPTION
Users are deactivated if they leave thoughtbot. Sometimes someone with the same
first name joins thoughtbot later and inherits the deactivated email so we need
to reactivate the email.

This adds instructions and method for easily reactivating a user