### PR TITLE
Fix bourbon deprecation warnings

### DIFF
--- a/web/static/css/_announcement.scss
+++ b/web/static/css/_announcement.scss
@@ -15,11 +15,11 @@
   }
 
   &.loading {
-    @include animation(loading-spinner 0.6s infinite linear);
     @include border-style(solid);
     @include border-width(0.5em);
     @include hide-text();
     @include size(5em);
+    animation: $long-duration linear infinite loading-spinner;
     border-color: $base-border-color;
     border-left-color: $dark-blue;
     border-radius: 50%;

--- a/web/static/css/_at-mention.scss
+++ b/web/static/css/_at-mention.scss
@@ -37,8 +37,8 @@
   }
 
   a {
-    @include display(flex);
-    @include align-items(center);
+    display: flex;
+    align-items: center;
     color: $base-font-color;
     font-size: $small-font-size;
   }

--- a/web/static/css/_comments.scss
+++ b/web/static/css/_comments.scss
@@ -10,12 +10,12 @@
 }
 
 .comment-loading {
-  @include animation(loading-spinner 0.6s infinite linear);
   @include border-style(solid);
   @include border-width(0.2em);
   @include hide-text();
   @include margin(null auto);
   @include size(2em);
+  animation: $long-duration linear infinite loading-spinner;
   border-color: $base-border-color;
   border-left-color: $dark-blue;
   border-radius: 50%;

--- a/web/static/css/_login.scss
+++ b/web/static/css/_login.scss
@@ -1,6 +1,6 @@
 .login-page {
-  @include align-items(center);
-  @include display(flex);
-  @include justify-content(center);
+  align-items: center;
+  display: flex;
+  justify-content: center;
   min-height: 100vh;
 }

--- a/web/static/css/base/_grid-settings.scss
+++ b/web/static/css/base/_grid-settings.scss
@@ -1,6 +1,6 @@
-$small-screen: new-breakpoint(max-width em(540));
-$medium-screen: new-breakpoint(max-width em(720));
-$large-screen: new-breakpoint(max-width em(860));
+$small-screen: new-breakpoint(max-width 540px);
+$medium-screen: new-breakpoint(max-width 720px);
+$large-screen: new-breakpoint(max-width 860px);
 
-$small-screen-up: new-breakpoint(min-width em(520));
-$medium-screen-up: new-breakpoint(min-width em(720));
+$small-screen-up: new-breakpoint(min-width 520px);
+$medium-screen-up: new-breakpoint(min-width 720px);

--- a/web/static/css/base/_variables.scss
+++ b/web/static/css/base/_variables.scss
@@ -57,6 +57,7 @@ $form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $l
 // Animations
 $base-duration: 150ms;
 $base-timing: ease;
+$long-duration: 0.6s;
 
 // Z-indeces
 $base-z-index: 0;


### PR DESCRIPTION
When running mix tasks like `mix tests` or `mix phoenix.server`, bourbon throws a lot of deprecation warnings, like the following: 

![screen shot 2017-12-09 at 1 55 48 pm](https://user-images.githubusercontent.com/3245976/33798566-e8dccc00-dce8-11e7-9b1b-16ef70b62568.png)

This commit fixes bourbon warnings for `display()`, `align-items()`, `animation()`, and `em()`.

For `em()`, we actually copy the core of the function and base value into a new function that we call `px-to-em()` so that we can continue using it in the single file where it is used. It may be worth in the future to use `em`s directly. 