### PR TITLE
Re-introduce the log out button

### DIFF
--- a/web/static/css/base/_buttons.scss
+++ b/web/static/css/base/_buttons.scss
@@ -23,6 +23,7 @@
   &:focus {
     background-color: shade($action-color, 10%);
     color: #fff;
+    text-decoration: none;
   }
 
   &:disabled {

--- a/web/templates/settings/show.html.eex
+++ b/web/templates/settings/show.html.eex
@@ -8,8 +8,8 @@
       </a>
     </header>
 
-    <%= form_for @changeset, settings_path(@conn, :update), [class: "settings-form"], fn(f) -> %>
-      <div class="modal-body">
+    <div class="modal-body">
+      <%= form_for @changeset, settings_path(@conn, :update), [class: "settings-form"], fn(f) -> %>
         <div class='field'>
           <label>Your name:</label>
           <%= text_input f, :name %>
@@ -39,13 +39,13 @@
           Send me daily digest emails about what's new on Constable.
           </label>
         </div>
-      </div>
-
-      <footer>
-        <%# <%= link "Logout of Constable", to: session_path(@conn, :delete), method: :delete %1> %>
         <%= submit gettext("Save") %>
-      </footer>
-    <% end %>
+      <% end %>
+    </div>
+
+    <footer>
+      <%= link "Log out of Constable", to: session_path(@conn, :delete), method: :delete, class: "button button-secondary" %>
+    </footer>
   </div>
 
 


### PR DESCRIPTION
Accessible from the settings modal. The route/controller action etc all already existed (#303) but the link was commented as part of the modal redesign (dc56f84a92). I'm not too sure if that was deliberate, perhaps I'm the only one who ever used it :-)

I tweaked the markup of the modal slightly to accommodate the new button.

Before:

![screen shot 2017-12-22 at 16 01 34](https://user-images.githubusercontent.com/379839/34304470-d93f402c-e731-11e7-80b6-275470a4948f.png)

After:

![screen shot 2017-12-22 at 16 01 11](https://user-images.githubusercontent.com/379839/34304475-deb19fdc-e731-11e7-87a5-7533ab2aefbe.png)

If anyone has thoughts on the styling let me know and I'll revisit.