### PR TITLE
Redesign subscribe and unsubscribe UI

### DIFF
--- a/assets/css/_announcement.scss
+++ b/assets/css/_announcement.scss
@@ -32,9 +32,9 @@
 }
 
 .comment-time {
+  color: $medium-gray;
   font-size: $small-font-size - 2px;
   margin-bottom: 0;
-  color: $medium-gray;
 
   a {
     color: inherit;

--- a/assets/css/_icon-as-pseudo.scss
+++ b/assets/css/_icon-as-pseudo.scss
@@ -1,0 +1,7 @@
+@mixin icon-as-pseudo($size, $image-path) {
+  @include size($size);
+  background: url("#{$image-path}") center / contain no-repeat;
+  content: "";
+  display: inline-block;
+  margin-right: $tiny-spacing / 2;
+}

--- a/assets/css/_interest.scss
+++ b/assets/css/_interest.scss
@@ -1,73 +1,85 @@
-.page-interest,
-.page-slack-channel {
-  .interest {
-    margin-top: $base-spacing;
-  }
-}
-
 .current-channel {
+  color: $base-font-color;
+  padding-top: $small-spacing;
   position: relative;
+
+  a {
+    color: $base-font-color;
+  }
 }
 
 .remove-slack-channel {
   @include position(absolute, null 0 0 null);
-
-  color: $dark-gray;
   background-color: $light-gray;
+  color: $dark-gray;
 
   &:hover {
     color: $dark-gray;
   }
 }
 
-.interests.container {
-  h1 {
-    padding-top: $base-spacing*.5;
-  }
+.interest-list-item-heading::before {
+  content: "#";
 }
 
 .interest-list-item {
+  align-items: baseline;
   border-bottom: $base-border;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
-  margin: $base-spacing*.5 0 0;
-  padding: 0;
-
-  .interest.container & {
-    border-bottom: 0;
-  }
+  padding: $small-spacing 0;
 
   h3 {
-    line-height: inherit;
     margin: 0;
-    padding: 0;
 
     &::before {
       content: "#";
     }
+
     a {
       color: $dark-gray;
       text-decoration: underline;
     }
   }
+}
 
-  a.subscribe, a.unsubscribe {
-    border-radius: $base-border-radius;
-    display: inline-block;
-    height: $base-spacing;
-    line-height: $base-spacing*1.2;
-    margin: 0;
-    padding: 0;
-    width: $base-spacing*2;
+.subscribe-to,
+.unsubscribe-to {
+  border-radius: $base-border-radius;
+  font-size: $small-font-size;
+  line-height: normal;
+  padding: $tiny-spacing $small-spacing;
+  text-align: center;
+  width: 100%;
+}
 
-    span { display: none; }
+.subscribe-to {
+  border: $base-border;
+  color: $base-font-color;
+
+  &::before {
+    @include icon-as-pseudo(10px, "/images/icon-plus.svg");
   }
+}
 
-  a.subscribe {
-    background: $light-gray url("../images/icon-plus.svg") no-repeat center / 1em;
-  }
+.unsubscribe-to {
+  background-color: $action-color;
+  color: $white;
 
-  a.unsubscribe {
-    background: $dark-blue url("../images/icon-check.svg") no-repeat center / 1em;
+  &::before {
+    @include icon-as-pseudo(12px, "/images/icon-check-white.svg");
+    transform: translateX(3px);
   }
+}
+
+.interest-list-item .link {
+  display: inline-flex;
+  flex-shrink: 0;
+  min-width: 7.5em;
+}
+
+.announcement-interests {
+  flex-basis: 60%;
+  margin-bottom: $small-spacing;
 }

--- a/assets/css/_layout.scss
+++ b/assets/css/_layout.scss
@@ -24,6 +24,10 @@ body,
   }
 }
 
+.container-pad-top {
+  padding-top: $base-spacing;
+}
+
 ul {
   margin: 0;
   padding: 0;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -10,6 +10,7 @@
 
 @import 'toggle';
 @import 'modal';
+@import 'icon-as-pseudo';
 @import 'announcement';
 @import 'announcement-create';
 @import 'announcement-form';

--- a/assets/static/images/icon-check-white.svg
+++ b/assets/static/images/icon-check-white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="11" viewBox="0 0 14 11">
+  <polygon fill="#FFFFFF" points="12.174 0 4.87 7.304 1.826 4.261 0 6.087 3.043 9.13 4.87 10.957 6.696 9.13 14 1.826"/>
+</svg>

--- a/assets/static/images/icon-check.svg
+++ b/assets/static/images/icon-check.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9.2 7.2" enable-background="new 0 0 9.2 7.2"><path fill="#fff" d="M8 0l-4.8 4.8-2-2-1.2 1.2 2 2 1.2 1.2 1.2-1.2 4.8-4.8z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="11" viewBox="0 0 14 11">
+  <polygon fill="#5B5F73" points="12.174 0 4.87 7.304 1.826 4.261 0 6.087 3.043 9.13 4.87 10.957 6.696 9.13 14 1.826"/>
+</svg>

--- a/assets/static/images/icon-plus.svg
+++ b/assets/static/images/icon-plus.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.5 8.5" enable-background="new 0 0 8.5 8.5"><path fill="#5B5F73" d="M5.1 3.4v-3.4h-1.7v3.4h-3.4v1.7h3.4v3.4h1.7v-3.4h3.4v-1.7z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+  <polygon fill="#5B5F73" points="7.2 4.8 7.2 0 4.8 0 4.8 4.8 0 4.8 0 7.2 4.8 7.2 4.8 12 7.2 12 7.2 7.2 12 7.2 12 4.8"/>
+</svg>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -10,14 +10,14 @@
       <%= if @subscription do %>
         <%= link to: announcement_subscription_path(@conn, :delete, @announcement.id),
           method: :delete,
-          class: "button button-unsubscribe",
+          class: "unsubscribe-to",
           data: [turbolinks: "refresh"] do %>
-          <%= gettext("Unsubscribe") %>
+          <%= gettext("Subscribed") %>
         <% end %>
       <% else %>
         <%= link to: announcement_subscription_path(@conn, :create, @announcement.id),
           method: :post,
-          class: "button button-subscribe",
+          class: "subscribe-to",
           data: [turbolinks: "refresh"] do %>
           <%= gettext("Subscribe") %>
         <% end %>

--- a/lib/constable_web/templates/interest/index.html.eex
+++ b/lib/constable_web/templates/interest/index.html.eex
@@ -1,4 +1,4 @@
-<div class="interests container">
+<div class="interests container container-pad-top">
   <h1><%= gettext "Interests" %></h1>
 
   <ul class="interests-list">

--- a/lib/constable_web/templates/interest/show.html.eex
+++ b/lib/constable_web/templates/interest/show.html.eex
@@ -1,7 +1,7 @@
 <div class="page-interest">
-  <div class="interest container">
+  <div class="interest container container-pad-top">
     <div class="interest-list-item">
-      <h1><%= @interest.name %></h1>
+      <h1 class="interest-list-item-heading"><%= @interest.name %></h1>
       <%= render ConstableWeb.InterestView, "subscription.html", conn: @conn, interest: @interest, current_user: @current_user %>
     </div>
 
@@ -18,14 +18,11 @@
           </p>
         <% else %>
           <p data-role="current-channel">
-            <%= gettext("Click here to add a slack channel webhook to this interest.") %>
+            <%= gettext("+ add a slack channel webhook to this interest") %>
           </p>
         <% end %>
       <% end %>
     </div>
-
-    <hr/>
-
   </div>
 
   <%= render ConstableWeb.AnnouncementListView, "index.html", conn: @conn, announcements: @announcements %>

--- a/lib/constable_web/templates/interest/subscription.html.eex
+++ b/lib/constable_web/templates/interest/subscription.html.eex
@@ -1,14 +1,14 @@
 <%= if interested_in?(@current_user, @interest) do %>
   <%= link to: interest_user_interest_path(@conn, :delete, @interest),
         method: :delete,
-        class: "unsubscribe",
+        class: "unsubscribe-to",
         data: [turbolinks: "refresh", role: "unsubscribe-from-interest"] do %>
-    <span><%= gettext("Unsubscribe") %></span>
+    <span><%= gettext("Subscribed") %></span>
   <% end %>
 <% else %>
   <%= link to: interest_user_interest_path(@conn, :create, @interest),
         method: :post,
-        class: "subscribe",
+        class: "subscribe-to",
         data: [turbolinks: "refresh", role: "subscribe-to-interest"] do %>
     <span><%= gettext("Subscribe") %></span>
   <% end %>

--- a/lib/constable_web/templates/slack_channel/edit.html.eex
+++ b/lib/constable_web/templates/slack_channel/edit.html.eex
@@ -1,6 +1,6 @@
 <div class="page-slack-channel">
-  <div class="interest container">
-    <h1><%= @interest.name %></h1>
+  <div class="interest container container-pad-top">
+    <h1 class="interest-list-item-heading"><%= @interest.name %></h1>
 
     <div>
       <%= gettext("Here you can enter the slack channel to be notified when an announcement is created for this interest.") %>


### PR DESCRIPTION
This PR creates a more cohesive and easier to understand subscription component for users. Previously we had a couple of different styles around this action. One was under "Manage your interests" and was confusingly similar in visual style to the new announcement action. The other was on the announcement page and used hard to understand iconography. It wasn't immediately clear whether or not someone was subscribed the announcement.

Tangentially this PR unifies the display of `#` before interests in a couple of different places. It also cleans up some unnecessary styles by adding a utility class for a container with padding top.

Before:
![screen shot 2018-03-19 at 5 04 15 pm](https://user-images.githubusercontent.com/5566826/37622255-98f4f26e-2b97-11e8-96a6-6b7efb310a52.png)

![screen shot 2018-03-19 at 5 04 50 pm](https://user-images.githubusercontent.com/5566826/37622314-b286fbf0-2b97-11e8-8e63-c5833698db75.png)

After:
![screen shot 2018-03-19 at 5 11 17 pm](https://user-images.githubusercontent.com/5566826/37622627-8ff8e372-2b98-11e8-98b9-fdd7dc393ac9.png)

![screen shot 2018-03-19 at 5 21 13 pm](https://user-images.githubusercontent.com/5566826/37623116-f5e6ea8e-2b99-11e8-8488-2cf0d78740d4.png)

Before (no hashtag ☹️):
![screen shot 2018-03-19 at 5 22 30 pm](https://user-images.githubusercontent.com/5566826/37623177-2a308b42-2b9a-11e8-9b9f-62f68b229aa0.png)

After (hashtag 😄) :
![screen shot 2018-03-19 at 5 22 39 pm](https://user-images.githubusercontent.com/5566826/37623192-31e4a026-2b9a-11e8-9d0c-f346a0827569.png)

