### PR TITLE
Ui refactor for the announcement page

### DIFF
--- a/assets/css/_announcement-create.scss
+++ b/assets/css/_announcement-create.scss
@@ -37,7 +37,7 @@
 .header-tag {
   @include padding($tiny-spacing null $tiny-spacing $base-spacing);
   background-color: $light-gray;
-  font-size: $small-font-size - 2px;
+  font-size: $tiny-font-size;
   font-weight: bold;
   text-transform: uppercase;
   transition: background-color .1s ease-out;

--- a/assets/css/_announcement.scss
+++ b/assets/css/_announcement.scss
@@ -1,5 +1,18 @@
 .announcement {
-  margin-top: $base-spacing * 3;
+  margin-top: $base-spacing * 1.25;
+
+  @include media($medium-screen-up) {
+    margin-top: $large-spacing;
+  }
+
+  h1 {
+    @include margin($small-spacing null);
+
+    @include media($medium-screen-up) {
+      @include margin($base-spacing null ($base-spacing * 0.85));
+      font-size: $larger-font-size;
+    }
+  }
 
   pre {
     background-color: lighten($dark-blue, 77%);
@@ -33,7 +46,7 @@
 
 .comment-time {
   color: $medium-gray;
-  font-size: $small-font-size - 2px;
+  font-size: $tiny-font-size;
   margin-bottom: 0;
 
   a {
@@ -41,10 +54,8 @@
   }
 }
 
-.announcement-header {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: $base-spacing;
+.announcement-interests {
+  margin-bottom: $tiny-spacing;
 }
 
 .announcement-body,
@@ -54,7 +65,7 @@
   h3,
   h4 {
     @include margin($base-spacing null $small-spacing null);
-    font-family: $medium-font-family;
+    font-family: $bold-font-family;
   }
 
   h1 {
@@ -106,5 +117,14 @@
         margin-bottom: 0;
       }
     }
+  }
+}
+
+.announcement-body {
+  @include padding($base-spacing null);
+
+  @include media($medium-screen-up) {
+    @include padding($large-spacing null);
+    font-size: $medium-font-size;
   }
 }

--- a/assets/css/_announcements.scss
+++ b/assets/css/_announcements.scss
@@ -11,7 +11,7 @@
   border-bottom: $base-border;
 
   h1 {
-    margin-bottom: 0;
+    margin-bottom: $tiniest-spacing;
   }
 
   .announcement-metadata {
@@ -26,11 +26,11 @@
     color: $dark-blue;
 
     &:after {
-      content: ", "
+      content: ", ";
     }
 
     &:before {
-      content: "#"
+      content: "#";
     }
 
     &:last-of-type:after {
@@ -44,43 +44,40 @@
 }
 
 .announcement-metadata {
-  @include margin(null null $base-spacing);
   color: $medium-gray;
+  font-size: $small-font-size;
 
   .author {
-    display: inline;
     color: $base-font-color;
   }
 
-  .avatar-rounded {
-    @include position(relative, 4px null null null);
-    margin-right: 0;
+  .subscription {
+    @include margin($small-spacing 0);
   }
 }
 
 .announcement-interest {
+  @include padding(null $tiny-spacing);
+  background-color: $lightest-gray;
   color: $base-font-color;
   display: inline-flex;
-
-  &::after {
-    content: ",\00a0";
-    display: inline-block;
-    text-decoration: none;
-  }
+  font-size: $small-font-size;
+  line-height: normal;
+  margin-top: $tiniest-spacing;
 
   &::before {
-    content: "#"
+    content: "#";
   }
 
   &:last-of-type:after {
     content: "";
   }
-
-  .announcement & {
-    font-size: $small-font-size;
-  }
 }
 
 .commenters {
   margin-top: $small-spacing;
+
+  .avatar-rounded {
+    margin-bottom: $tiny-spacing;
+  }
 }

--- a/assets/css/_at-mention.scss
+++ b/assets/css/_at-mention.scss
@@ -42,8 +42,4 @@
     color: $base-font-color;
     font-size: $small-font-size;
   }
-
-  .avatar-rounded {
-    margin-bottom: 0;
-  }
 }

--- a/assets/css/_comments.scss
+++ b/assets/css/_comments.scss
@@ -4,9 +4,8 @@
 }
 
 .edit-comment {
-  font-size: 13px;
-  color: 999;
-  margin-left: 5px;
+  font-size: $tiny-font-size;
+  margin-left: $tiniest-spacing;
 }
 
 .comment-loading {
@@ -23,10 +22,11 @@
 }
 
 .comments-list {
-  border-top: 5px solid $light-gray;
+  border-top: $base-border;
   list-style-type: none;
-  margin-top: $base-spacing;
+  margin-top: $small-spacing;
   padding-top: $base-spacing;
+  position: relative;
 }
 
 .comment-body {
@@ -50,20 +50,30 @@
 .avatar-rounded {
   @include size($rounded-avatar-size);
   border-radius: 50%;
-  margin-right: $tiny-spacing / 2;
+  vertical-align: middle;
+}
+
+.avatar-rounded-large {
+  @include size($rounded-avatar-size-large);
 }
 
 .author-information {
   @extend %align-center-flex;
+  @include padding($tiniest-spacing null $tiny-spacing);
+  justify-content: space-between;
+}
+
+.author {
+  flex: 1;
 }
 
 .comment-information {
-  @extend %align-center-flex;
   justify-content: space-between;
   margin-bottom: $tiny-spacing / 2;
 }
 
-.comment-new, .comment-edit {
+.comment-new,
+.comment-edit {
   border-top: $base-border;
   margin-bottom: $base-spacing;
   padding-top: $base-spacing;

--- a/assets/css/_interest.scss
+++ b/assets/css/_interest.scss
@@ -78,8 +78,3 @@
   flex-shrink: 0;
   min-width: 7.5em;
 }
-
-.announcement-interests {
-  flex-basis: 60%;
-  margin-bottom: $small-spacing;
-}

--- a/assets/css/_layout.scss
+++ b/assets/css/_layout.scss
@@ -19,7 +19,7 @@ body,
   width: 80%;
 
   @include media($small-screen) {
-    padding: 0 $base-spacing;
+    padding: 0 $small-spacing;
     width: 100%;
   }
 }

--- a/assets/css/_media-object.scss
+++ b/assets/css/_media-object.scss
@@ -1,0 +1,16 @@
+.media {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.media-center {
+  align-items: center;
+}
+
+.media-figure {
+  margin-right: $small-spacing;
+}
+
+.media-body {
+  flex: 1 45%;
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -9,6 +9,7 @@
 @import 'login';
 
 @import 'toggle';
+@import 'media-object';
 @import 'modal';
 @import 'icon-as-pseudo';
 @import 'announcement';

--- a/assets/css/base/_grid-settings.scss
+++ b/assets/css/base/_grid-settings.scss
@@ -1,5 +1,5 @@
-$small-screen: new-breakpoint(max-width 540px);
-$medium-screen: new-breakpoint(max-width 720px);
+$small-screen: new-breakpoint(max-width 519px);
+$medium-screen: new-breakpoint(max-width 719px);
 $large-screen: new-breakpoint(max-width 860px);
 
 $small-screen-up: new-breakpoint(min-width 520px);

--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -28,6 +28,7 @@ h4 {
 
 h1 {
   font-size: $large-font-size;
+  font-family: $bold-font-family;
 }
 
 h2 {
@@ -50,13 +51,14 @@ strong {
 
 blockquote,
 p {
-  @include margin(0 null $small-spacing null);
+  @include margin(0 null ($base-line-height * 0.75) null);
 }
 
 a {
   color: $action-color;
   text-decoration: none;
   transition: color $base-duration $base-timing;
+  word-wrap: break-word;
 
   &:active,
   &:focus,

--- a/assets/css/base/_variables.scss
+++ b/assets/css/base/_variables.scss
@@ -5,15 +5,18 @@ $medium-font-family: 'hk_groteskmedium';
 $heading-font-family: $base-font-family;
 
 // Font Sizes
+$larger-font-size: 36px;
 $large-font-size: 24px;
+$medium-font-size: 18px;
 $base-font-size: 16px;
 $small-font-size: 14px;
+$tiny-font-size: 12px;
 
 // Font Weight
 $bold-weight: 500;
 
 // Line height
-$base-line-height: 1.8;
+$base-line-height: 1.65;
 $heading-line-height: 1.2;
 
 // Other Sizes
@@ -23,8 +26,10 @@ $base-spacing: 30px;
 $large-spacing: $base-spacing * 2;
 $small-spacing: $base-spacing / 2;
 $tiny-spacing: $small-spacing / 2;
+$tiniest-spacing: $tiny-spacing / 2;
 $base-z-index: 0;
-$rounded-avatar-size: 20px;
+$rounded-avatar-size-large: 40px;
+$rounded-avatar-size: 32px;
 
 // Colors
 $red: #ed3e44;

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -1,26 +1,27 @@
-<li class="comment" id="comment-<%= @comment.id %>">
-  <div class="comment-information">
-    <div class="author-information">
-      <img class="avatar-rounded" src="<%= gravatar @comment.user %>">
-      <h4 class="author"><%= @comment.user.name %></h4>
-    </div>
+<li class="comment media" id="comment-<%= @comment.id %>">
 
-    <div>
+  <div class="comment-information media-figure">
+    <img class="avatar-rounded" src="<%= gravatar @comment.user %>">
+  </div>
+
+  <div class="media-body">
+    <div class="author-information">
+      <h4 class="author"><%= @comment.user.name %></h4>
       <time class="comment-time">
         <a href="#comment-<%= @comment.id %>">
           <%= time_ago_in_words @comment.inserted_at %>
         </a>
-
       </time>
+
       <%= if @comment.user_id == @current_user.id do %>
         <%= link to: announcement_comment_path(ConstableWeb.Endpoint, :edit, @comment.announcement_id, @comment), class: "edit-comment", data: [role: "edit-comment"] do %>
           <%= gettext "(edit)" %>
         <% end %>
       <% end %>
     </div>
-  </div>
 
-  <div class="comment-body">
-    <%= raw markdown_with_users(@comment.body) %>
+    <div class="comment-body">
+      <%= raw markdown_with_users(@comment.body) %>
+    </div>
   </div>
 </li>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -1,30 +1,11 @@
 <div class="announcement container" data-announcement-id="<%= @announcement.id %>">
-  <header class="announcement-header">
-    <div class="announcement-interests" data-role="interests">
+  <header class="announcement-interests">
+    <div data-role="interests">
       <%= for interest <- @announcement.interests do %>
         <%= link interest.name, to: interest_path(@conn, :show, interest), class: "announcement-interest" %>
       <% end %>
     </div>
-
-    <div class="subscription">
-      <%= if @subscription do %>
-        <%= link to: announcement_subscription_path(@conn, :delete, @announcement.id),
-          method: :delete,
-          class: "unsubscribe-to",
-          data: [turbolinks: "refresh"] do %>
-          <%= gettext("Subscribed") %>
-        <% end %>
-      <% else %>
-        <%= link to: announcement_subscription_path(@conn, :create, @announcement.id),
-          method: :post,
-          class: "subscribe-to",
-          data: [turbolinks: "refresh"] do %>
-          <%= gettext("Subscribe") %>
-        <% end %>
-      <% end %>
-    </div>
   </header>
-
   <h1 data-role="title">
     <%= @announcement.title %>
     <%= if @announcement.user_id == @current_user.id do %>
@@ -35,15 +16,43 @@
   </h1>
 
   <div class="announcement-metadata">
-    <img src="<%= gravatar @announcement.user %>" class="avatar-rounded"/>
-    <h4 class="author"><%= @announcement.user.name %></h4>
-    <time title="<%= Date.to_string(@announcement.inserted_at) %>"><%= time_ago_in_words(@announcement.inserted_at) %></time>
+    <div class="media media-center">
+      <img src="<%= gravatar @announcement.user %>" class="media-figure avatar-rounded avatar-rounded-large"/>
+      <div class="media-body">
+        <h4 class="author"><%= @announcement.user.name %></h4>
+
+        <div class="announcement-metadata">
+          <%= gettext "announced" %>
+          <time>
+            <%= time_ago_in_words(@announcement.inserted_at) %>
+          </time>
+        </div>
+      </div>
+      <div class="subscription">
+        <%= if @subscription do %>
+          <%= link to: announcement_subscription_path(@conn, :delete, @announcement.id),
+            method: :delete,
+            class: "unsubscribe-to",
+            data: [turbolinks: "refresh"] do %>
+            <%= gettext("Subscribed to thread") %>
+          <% end %>
+        <% else %>
+          <%= link to: announcement_subscription_path(@conn, :create, @announcement.id),
+            method: :post,
+            class: "subscribe-to",
+            data: [turbolinks: "refresh"] do %>
+            <%= gettext("Subscribe to thread") %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <div class="announcement-body" data-role="body">
     <%= raw markdown_with_users(@announcement.body) %>
   </div>
 
+  <h4><%= gettext "Comments" %></h4>
   <ul class="comments-list">
     <%= for comment <- @announcement.comments do %>
       <%= render "_comment.html", comment: comment, conn: @conn, current_user: @current_user %>

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -11,7 +11,7 @@
           <%= time_ago_in_words(announcement.inserted_at) %>
         </time>
         to
-        <span class="announcement-interests">
+        <span>
         <%= for interest <- announcement.interests do %>
           <%= link to: interest_path(@conn, :show, interest), class: "announcement-interest" do %>
             <%= interest.name %>


### PR DESCRIPTION
This PR makes a few improvements to the previous announcement page design.

**Goal 1: Create a clear entry point**
The previous design lacked a clear entry point into the content. This PR solves that problem by using a bolder weight and larger size for the announcement's main heading.

**Goal 2: Achieve better typographic hierarchy**
The previous type hierarchy was too subtle. This PR solves that by creating more distinction between the announcement body copy and comment thread. It also tightens up the line-height and shortens the line-length on the announcement body. This creates more readable announcements for Constable users. We've also improved the spacing throughout the app to feel more solid.

**Goal 3: Clarify what subscribing to an announcement means**
The old design placed the subscribe button adjacent to the announcement's tags. This creates confusion around what the reader is subscribing to. Is is the message or the tags? Is it all of the tags or just one? To fix this we've moved the subscribe button below the title and adjacent to the author's name. We've also clarified the button's label to be more specific. It now says "Subscribe to thread."

**Goal 4: Increase Constable's friendliness**
The old design had avatars that were very small. Because of that each one looked more-or-less the same. This PR increases both an announcement author's avatar and a commenter's. This helps Constable readers recognize faces better.

![image](https://user-images.githubusercontent.com/5566826/37730717-c1e8587a-2d16-11e8-8e26-88c0d4b59d19.png)

