### PR TITLE
Fix intermittent failure due to sort order

### DIFF
--- a/lib/constable_web/models/announcement.ex
+++ b/lib/constable_web/models/announcement.ex
@@ -57,6 +57,7 @@ defmodule Constable.Announcement do
       full_join: i in assoc(a, :interests),
       group_by: a.id,
       having: fragment("NOT ARRAY_AGG(?) @> ?", i.name, ^excludes),
+      order_by: a.id,
       where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
         a.title,
         a.body,


### PR DESCRIPTION
Closes https://github.com/thoughtbot/constable/issues/464

What?
=====

The api searches controller test was failing intermittently because the test compares a list of announcements with those returns from the search. Since there was no order specified in the query, the comparison would fail if the order was different even if all the correct elements were returned.

In other words,

```
assert [a, b] == [b, a] # => false
```

We add a `order_by` to the `Announcement.search` so that we guarantee an order.