### PR TITLE
Add slugs to announcements

### DIFF
--- a/lib/constable/factory.ex
+++ b/lib/constable/factory.ex
@@ -48,8 +48,12 @@ defmodule Constable.Factory do
   end
 
   def announcement_factory do
+    title = sequence(:email, &"Post Title#{&1}")
+    slug = Slugger.slugify_downcase(title)
+
     %Constable.Announcement{
-      title: sequence(:email, &"Post Title#{&1}"),
+      title: title,
+      slug: slug,
       body: "Post Body",
       user: build(:user)
     }

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -67,7 +67,7 @@ defmodule ConstableWeb.AnnouncementController do
 
     case AnnouncementCreator.create(announcement_params, interest_names) do
       {:ok, announcement} ->
-        redirect(conn, to: announcement_path(conn, :show, announcement.id))
+        redirect(conn, to: announcement_path(conn, :show, announcement))
       {:error, changeset} ->
         interests = Repo.all(Interest)
         render(conn, "new.html", %{
@@ -96,14 +96,14 @@ defmodule ConstableWeb.AnnouncementController do
     if announcement.user_id == current_user.id do
       case AnnouncementUpdater.update(announcement, announcement_params, interest_names) do
         {:ok, announcement} ->
-          redirect(conn, to: announcement_path(conn, :show, announcement.id))
+          redirect(conn, to: announcement_path(conn, :show, announcement))
         {:error, _changeset} ->
           render_form(conn, "edit", announcement)
       end
     else
       conn
       |> put_flash(:error, gettext("You do not have permission to edit that announcement"))
-      |> redirect(to: announcement_path(conn, :show, announcement.id))
+      |> redirect(to: announcement_path(conn, :show, announcement))
     end
   end
 

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -7,6 +7,8 @@ defmodule ConstableWeb.AnnouncementController do
   alias Constable.{Announcement, Comment, Interest, Subscription}
   alias Constable.Services.AnnouncementCreator
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "id"
+
   def index(conn, %{"all" => "true"} = params) do
     index_page = all_announcements() |> Repo.paginate(params)
 

--- a/lib/constable_web/controllers/api/announcement_controller.ex
+++ b/lib/constable_web/controllers/api/announcement_controller.ex
@@ -6,6 +6,8 @@ defmodule ConstableWeb.Api.AnnouncementController do
   alias Constable.Services.AnnouncementUpdater
   alias ConstableWeb.Api.AnnouncementView
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "id"
+
   def index(conn, _params) do
     announcements = Repo.all(Announcement)
     render(conn, "index.json", announcements: announcements)

--- a/lib/constable_web/controllers/api/comment_controller.ex
+++ b/lib/constable_web/controllers/api/comment_controller.ex
@@ -3,6 +3,8 @@ defmodule ConstableWeb.Api.CommentController do
 
   alias Constable.Services.CommentCreator
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "announcement_id"
+
   def create(conn, %{"comment" => params}) do
     current_user = current_user(conn)
     params = Map.put(params, "user_id", current_user.id)

--- a/lib/constable_web/controllers/api/subscription_controller.ex
+++ b/lib/constable_web/controllers/api/subscription_controller.ex
@@ -3,6 +3,8 @@ defmodule ConstableWeb.Api.SubscriptionController do
 
   alias Constable.Subscription
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "announcement_id"
+
   def index(conn, _params) do
     current_user = current_user(conn)
     subscriptions = subscriptions_for(current_user)

--- a/lib/constable_web/controllers/comment_controller.ex
+++ b/lib/constable_web/controllers/comment_controller.ex
@@ -5,6 +5,8 @@ defmodule ConstableWeb.CommentController do
   alias Constable.Comment
   alias Constable.Services.CommentCreator
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "announcement_id"
+
   def create(conn, %{"announcement_id" => announcement_id, "comment" => comment_params}) do
     comment_params = comment_params
       |> Map.put("user_id", conn.assigns.current_user.id)
@@ -43,7 +45,7 @@ defmodule ConstableWeb.CommentController do
 
     case Repo.update(changeset) do
       {:ok, comment} ->
-        redirect_to_comment_on_announcement_page(conn, comment)
+        redirect_to_comment_on_announcement_page(conn, announcement, comment)
       {:error, _changeset} ->
         conn
         |> render("edit.html",
@@ -54,7 +56,7 @@ defmodule ConstableWeb.CommentController do
     end
   end
 
-  defp redirect_to_comment_on_announcement_page(conn, comment) do
-    redirect(conn, to: announcement_path(conn, :show, comment.announcement_id) <> "#comment-#{comment.id}")
+  defp redirect_to_comment_on_announcement_page(conn, announcement, comment) do
+    redirect(conn, to: announcement_path(conn, :show, announcement) <> "#comment-#{comment.id}")
   end
 end

--- a/lib/constable_web/controllers/subscriptions_controller.ex
+++ b/lib/constable_web/controllers/subscriptions_controller.ex
@@ -3,6 +3,8 @@ defmodule ConstableWeb.SubscriptionController do
 
   alias Constable.Subscription
 
+  plug Constable.Plugs.Deslugifier, slugified_key: "announcement_id"
+
   def create(conn, %{"announcement_id" => announcement_id}) do
     changeset = Subscription.changeset(%{
       announcement_id: announcement_id,

--- a/lib/constable_web/models/announcement.ex
+++ b/lib/constable_web/models/announcement.ex
@@ -9,6 +9,7 @@ defmodule Constable.Announcement do
   schema "announcements" do
     field :title
     field :body
+    field :slug
     field :last_discussed_at, :utc_datetime, autogenerate: {DateTime, :utc_now, []}
     timestamps()
 
@@ -23,12 +24,14 @@ defmodule Constable.Announcement do
     announcement
     |> cast(params, ~w(title body))
     |> validate_required([:title, :body])
+    |> generate_slug()
   end
 
   def create_changeset(announcement, params) do
     announcement
     |> cast(params, ~w(title body user_id))
     |> validate_required([:title, :body])
+    |> generate_slug()
   end
 
   def last_discussed_first(query \\ __MODULE__) do
@@ -66,6 +69,17 @@ defmodule Constable.Announcement do
     )
   end
 
+  defp generate_slug(changeset) do
+    case get_change(changeset, :title) do
+      nil -> changeset
+      title -> put_change(changeset, :slug, slugify(title))
+    end
+  end
+
+  defp slugify(title) do
+    Slugger.slugify_downcase(title)
+  end
+
   defp prepare_for_tsquery(search_term) do
     search_term
     |> String.split(" ", trim: true)
@@ -75,5 +89,11 @@ defmodule Constable.Announcement do
 
   defp newest_comments_first do
     from(c in Comment, order_by: [asc: c.inserted_at])
+  end
+end
+
+defimpl Phoenix.Param, for: Constable.Announcement do
+  def to_param(%{slug: slug, id: id}) do
+    "#{id}-#{slug}"
   end
 end

--- a/lib/constable_web/plugs/deslugifier.ex
+++ b/lib/constable_web/plugs/deslugifier.ex
@@ -1,0 +1,25 @@
+defmodule Constable.Plugs.Deslugifier do
+  def init(opts) do
+    case Keyword.get(opts, :slugified_key) do
+      nil -> raise "Must provide a :slugified_key to #{inspect __MODULE__}"
+      key -> key
+    end
+  end
+
+  def call(conn, key) do
+    with {:ok, slugified_id} <- Map.fetch(conn.params, key),
+         {:ok, id} <- deslugify(slugified_id)
+    do
+      put_in(conn, [Access.key!(:params), key], id)
+    else
+      _ -> conn
+    end
+  end
+
+  defp deslugify(slugified_id) do
+    case Integer.parse(slugified_id) do
+      {int, _} when int > 0 -> {:ok, int}
+      _ -> :error
+    end
+  end
+end

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -30,14 +30,14 @@
       </div>
       <div class="subscription">
         <%= if @subscription do %>
-          <%= link to: announcement_subscription_path(@conn, :delete, @announcement.id),
+          <%= link to: announcement_subscription_path(@conn, :delete, @announcement),
             method: :delete,
             class: "unsubscribe-to unsubscribe-to-thread",
             data: [turbolinks: "refresh"] do %>
             <%= gettext("Subscribed to thread") %>
           <% end %>
         <% else %>
-          <%= link to: announcement_subscription_path(@conn, :create, @announcement.id),
+          <%= link to: announcement_subscription_path(@conn, :create, @announcement),
             method: :post,
             class: "subscribe-to",
             data: [turbolinks: "refresh"] do %>

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -1,7 +1,7 @@
 <ul class="container container-pad-top announcement-list">
   <%= for announcement <- @announcements do %>
     <li class="announcement-list-item">
-      <%= link to: announcement_path(@conn, :show, announcement.id) do %>
+      <%= link to: announcement_path(@conn, :show, announcement) do %>
         <h1 data-role="title" class="announcement-list-item-heading">
           <%= announcement.title %>
         </h1>

--- a/lib/mix/tasks/temp/backfill_announcement_slugs.ex
+++ b/lib/mix/tasks/temp/backfill_announcement_slugs.ex
@@ -1,0 +1,24 @@
+defmodule Mix.Tasks.Temp.BackfillAnnouncementSlugs do
+  use Mix.Task
+  import Ecto.Query
+
+  alias Constable.{Announcement, Repo}
+
+  def run(_) do
+    Mix.Task.run "app.start"
+
+    Announcement
+    |> Repo.all()
+    |> Enum.each(fn announcement ->
+      slug = Slugger.slugify_downcase(announcement.title)
+
+      query =
+        from(a in Announcement,
+            where: a.id == ^announcement.id,
+            update: [set: [slug: ^slug]]
+            )
+
+      Repo.update_all(query, [])
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -72,6 +72,7 @@ defmodule Constable.Mixfile do
       {:quick_alias, "~> 0.1.0"},
       {:scrivener_ecto, "~> 1.1"},
       {:secure_random, "~> 0.1"},
+      {:slugger, "~> 0.2"},
       {:wallaby, "~> 0.6", only: :test},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -42,5 +42,6 @@
   "scrivener": {:hex, :scrivener, "2.2.1", "5a84cdfc042e3c318a03f965d8197b8294676a8fff7c4a29e482a90c467ebf19", [:mix], []},
   "scrivener_ecto": {:hex, :scrivener_ecto, "1.1.3", "f5615f67964e43e8c9958263939bc365c4783cac652dc282784bbd32bb14723f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:postgrex, "~> 0.11.0 or ~> 0.12.0 or ~> 0.13.0", [hex: :postgrex, optional: true]}, {:scrivener, "~> 2.0", [hex: :scrivener, optional: false]}]},
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], []},
+  "slugger": {:hex, :slugger, "0.2.0", "7c609e6eee6dbb44e7b0db07982932356cab476f00fc8d73320cdc50d7efa18e", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "wallaby": {:hex, :wallaby, "0.6.0", "b026915c218fc6b6fbea45099c3e7cf9b05ce8346244a05db133b6b457947add", [:mix], [{:dialyze, "~> 0.2.0", [hex: :dialyze, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}]}}

--- a/priv/repo/migrations/20180413164621_add_slug_to_announcements.exs
+++ b/priv/repo/migrations/20180413164621_add_slug_to_announcements.exs
@@ -1,0 +1,9 @@
+defmodule Constable.Repo.Migrations.AddSlugToAnnouncements do
+  use Ecto.Migration
+
+  def change do
+    alter table(:announcements) do
+      add :slug, :string
+    end
+  end
+end

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -35,7 +35,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
     announcement = insert(:announcement, user: user)
 
     session
-    |> visit(announcement_path(Endpoint, :show, announcement.id, as: user.id))
+    |> visit(announcement_path(Endpoint, :show, announcement, as: user.id))
     |> click_edit
     |> fill_in("announcement_title", with: "Updated")
     |> fill_in_interests("updated")
@@ -53,7 +53,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
     announcement = insert(:announcement, user: user) |> tag_with_interest(elixir_interest)
 
     session
-    |> visit(announcement_path(Endpoint, :edit, announcement.id, as: user.id))
+    |> visit(announcement_path(Endpoint, :edit, announcement, as: user.id))
     |> fill_in("announcement_title", with: "Updated title")
     |> fill_in("announcement_body", with: "# Updated")
     |> click_submit_button

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -32,7 +32,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
   test "#show renders markdown as html", %{conn: conn} do
     announcement = insert(:announcement, body: "# Hello")
 
-    conn = get conn, announcement_path(conn, :show, announcement.id)
+    conn = get conn, announcement_path(conn, :show, announcement)
 
     assert html_response(conn, :ok) =~ "<h1>Hello</h1>"
   end
@@ -41,7 +41,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     announcement = insert(:announcement)
     insert(:comment, body: "# Comment", announcement: announcement)
 
-    conn = get conn, announcement_path(conn, :show, announcement.id)
+    conn = get conn, announcement_path(conn, :show, announcement)
 
     assert html_response(conn, :ok) =~ "<h1>Comment</h1>"
   end
@@ -49,7 +49,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
   test "comments on show page have an edit link if current user is the author", %{conn: conn, user: user} do
     comment = insert(:comment, user: user)
 
-    conn = get conn, announcement_path(conn, :show, comment.announcement.id)
+    conn = get conn, announcement_path(conn, :show, comment.announcement)
 
     assert html_response(conn, :ok) =~ "(edit)"
   end
@@ -58,7 +58,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     another_user = insert(:user)
     comment = insert(:comment, user: another_user)
 
-    conn = get conn, announcement_path(conn, :show, comment.announcement.id)
+    conn = get conn, announcement_path(conn, :show, comment.announcement)
 
     refute html_response(conn, :ok) =~ "(edit)"
   end

--- a/test/controllers/api/announcement_controller_test.exs
+++ b/test/controllers/api/announcement_controller_test.exs
@@ -19,7 +19,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#show renders single announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user)
 
-    conn = get conn, api_announcement_path(conn, :show, announcement.id)
+    conn = get conn, api_announcement_path(conn, :show, announcement)
 
     assert json_response(conn, 200) == render_json("show.json", announcement: announcement)
   end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -28,7 +28,7 @@ defmodule ConstableWeb.CommentControllerTest do
       body: "Foo"
     }
 
-    assert redirected_to(conn) =~ announcement_path(conn, :show, announcement)
+    assert redirected_to(conn) =~ announcement_path(conn, :show, announcement.id)
   end
 
   test "#create redirects back to the announcement with flash on failure", %{conn: conn} do

--- a/test/models/announcement_test.exs
+++ b/test/models/announcement_test.exs
@@ -1,6 +1,7 @@
 defmodule Constable.AnnouncementTest do
   use Constable.ModelCase, async: true
   alias Constable.Announcement
+  alias Ecto.Changeset
 
   test "inserting a record sets the last_discussed_at" do
     announcement = build(:announcement) |> insert
@@ -8,27 +9,81 @@ defmodule Constable.AnnouncementTest do
     assert announcement.last_discussed_at
   end
 
-  test "last_discussed_first" do
-    oldest = insert(:announcement, last_discussed_at: Constable.Time.days_ago(1))
-    newest = insert(:announcement, last_discussed_at: Constable.Time.now)
+  describe ".update_changeset/2" do
+    test "generates a slug from the new title" do
+      title = "A normal title"
+      announcement = insert(:announcement)
 
-    announcements = Announcement.last_discussed_first |> Repo.all
+      slug =
+        announcement
+        |> Announcement.update_changeset(%{title: title})
+        |> Changeset.get_change(:slug)
 
-    assert List.first(announcements).id == newest.id
-    assert List.last(announcements).id == oldest.id
+      assert slug == "a-normal-title"
+    end
+
+    test "does not generate slug if title is nil" do
+      announcement = build(:announcement)
+
+      slug =
+        announcement
+        |> Announcement.create_changeset(%{title: nil})
+        |> Changeset.get_change(:slug)
+
+      refute slug
+    end
   end
 
-  test "interests are sorted alphabetically" do
-    interest_a = insert(:interest, name: "a")
-    interest_b = insert(:interest, name: "b")
-    insert(:announcement)
-      |> tag_with_interest(interest_b)
-      |> tag_with_interest(interest_a)
+  describe ".create_changeset/2" do
+    test "generates a slug from the title" do
+      title = "A normal title"
+      announcement = build(:announcement)
 
-    announcement = Announcement.with_announcement_list_assocs
-      |> Repo.one
+      slug =
+        announcement
+        |> Announcement.create_changeset(%{title: title})
+        |> Changeset.get_change(:slug)
 
-    assert announcement.interests |> List.first == interest_a
-    assert announcement.interests |> List.last  == interest_b
+      assert slug == "a-normal-title"
+    end
+
+    test "does not generate slug if not title is nil" do
+      announcement = build(:announcement)
+
+      slug =
+        announcement
+        |> Announcement.create_changeset(%{title: nil})
+        |> Changeset.get_change(:slug)
+
+      refute slug
+    end
+  end
+
+  describe ".last_discussed_first/1" do
+    test "returns the last discussed announcement" do
+      oldest = insert(:announcement, last_discussed_at: Constable.Time.days_ago(1))
+      newest = insert(:announcement, last_discussed_at: Constable.Time.now)
+
+      announcements = Announcement.last_discussed_first |> Repo.all
+
+      assert List.first(announcements).id == newest.id
+      assert List.last(announcements).id == oldest.id
+    end
+  end
+
+  describe ".with_announcement_list_assocs/1" do
+    test "interests are sorted alphabetically" do
+      interest_a = insert(:interest, name: "a")
+      interest_b = insert(:interest, name: "b")
+      insert(:announcement)
+        |> tag_with_interest(interest_b)
+        |> tag_with_interest(interest_a)
+
+      announcement = Announcement.with_announcement_list_assocs
+        |> Repo.one
+
+      assert announcement.interests |> List.first == interest_a
+      assert announcement.interests |> List.last  == interest_b
+    end
   end
 end

--- a/test/plugs/deslugifier_test.exs
+++ b/test/plugs/deslugifier_test.exs
@@ -1,0 +1,41 @@
+defmodule Constable.Plugs.DeslugifierTest do
+  use ConstableWeb.ConnCase, async: true
+
+  alias Constable.Plugs.Deslugifier
+
+  test "takes a slugified_key upon initialization" do
+    assert Deslugifier.init(slugified_key: "id") == "id"
+  end
+
+  test "raises an error if no slugified_key is provided" do
+    error_msg = "Must provide a :slugified_key to Constable.Plugs.Deslugifier"
+
+    assert_raise RuntimeError, error_msg, fn ->
+      Deslugifier.init([])
+    end
+  end
+
+  test "turns an id-slugified-title into an id" do
+    conn = build_conn(:get, "foo", id: "23-slugified-title")
+
+    conn = Deslugifier.call(conn, "id")
+
+    assert conn.params["id"] == 23
+  end
+
+  test "returns unmodified conn if key is not in params" do
+    conn = build_conn(:get, "foo")
+
+    unmodified_conn = Deslugifier.call(conn, "id")
+
+    assert unmodified_conn == conn
+  end
+
+  test "returns unmodified conn if it fails to deslugify key" do
+    conn = build_conn(:get, "foo", id: "slugified-title-no-id")
+
+    unmodified_conn = Deslugifier.call(conn, "id")
+
+    assert unmodified_conn == conn
+  end
+end

--- a/test/views/api/announcement_view_test.exs
+++ b/test/views/api/announcement_view_test.exs
@@ -3,11 +3,13 @@ defmodule ConstableWeb.Api.AnnouncementViewTest do
 
   alias ConstableWeb.Api.AnnouncementView
   alias ConstableWeb.Api.CommentView
+  alias ConstableWeb.Router.Helpers
 
   test "show.json returns correct fields" do
     interest = insert(:interest)
     announcement = insert(:announcement) |> tag_with_interest(interest)
     comment = insert(:comment, announcement: announcement)
+    announcement_url = Helpers.announcement_url(ConstableWeb.Endpoint, :show, announcement)
 
     rendered_announcement = render_one(announcement, AnnouncementView, "show.json")
 
@@ -21,7 +23,7 @@ defmodule ConstableWeb.Api.AnnouncementViewTest do
         user_id: announcement.user_id,
         comments: render_many([comment], CommentView, "comment.json"),
         interest_ids: [interest.id],
-        url: "http://localhost:4001/announcements/#{announcement.id}",
+        url: announcement_url,
       }
     }
   end


### PR DESCRIPTION
This is an alternate implementation for adding slugs. The first implementation can be found in https://github.com/thoughtbot/constable/pull/465. I think this is a better implementation because it decouples a web concern (the url having slugs) from the persistence layer.

What?
=====

We add slugs to announcements for better urls. We do so in a way that maintains backwards compatibility and allows for urls with ids and urls with the new slugs.

A note on terminology
=====================

We technically add two things that could be called "slugs". One is a column in the announcements table. The other is what is now at the end of an announcement path (e.g. "announcements/:slug").

The slugs in the database are a slugified version of the announcement's title. The slugs in the path are really a composite slug of the announcement id and the slug in the database field. So the slugs in the url have the form of `id-slugified-title'.

Details
========

We add slugs to announcements paths that have an `id-sluggified-title` format. We do this by implementing the Phoenix.Param protocol for announcement so that all path helpers automatically generate a slug that is a combination of the id and the slug.

We also add a column `slug` to announcements table. We are not including an index because we do not intend to retrieve records by the slug. We'll retrieve them by id.

In order to transform a url `:slug` into an `id` that we can use to retrieve announcements, we created a `Deslugifier` plug that takes care of removing the slugified title from the parameter when used. This plug is used in all controllers that deal with announcements, including associations like comments since the have nested paths (e.g. `announcements/:announcement_id/comments/:id`)

Why this approach?
==================

The benefit of this approach is that we don't have to worry about what form the "id" will come in. It could be an integer or it could be the new slugs. The deslugifier will transform the slug into an id at the boundary and essentially throw away the slug (for the purposes of the primary id). This means that all old urls are automatically okay, while new urls will be supported. It also means that changing the title of the announcement will not break any old links someone saved outside of constable.