### PR TITLE
Fix word wrapping issue in comments

### DIFF
--- a/assets/css/_media-object.scss
+++ b/assets/css/_media-object.scss
@@ -13,4 +13,6 @@
 
 .media-body {
   flex: 1 45%;
+  min-width: 0;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
I noticed in one of the latest posts that word wrapping wasn't working as it should, causing layout issues (horizontal scrolling, or repositioning of elements). This is mostly caused by long URLs. Just using `overflow-wrap` doesn't do what you would expect, especially in a flex item. If we had a `min-width` and an `overflow-wrap` to the parent object here, it seems to solve the issue across all browsers.

**Before**
![screen shot 2018-06-11 at 2 08 16 pm](https://user-images.githubusercontent.com/2642348/41250116-00b6752a-6d84-11e8-9292-1b01eebd04c9.png)

**After**
![screen shot 2018-06-11 at 3 31 08 pm](https://user-images.githubusercontent.com/2642348/41252884-83cee50c-6d8c-11e8-8258-2ab30eaee253.png)


***
**Before**
![screen shot 2018-06-11 at 2 23 37 pm](https://user-images.githubusercontent.com/2642348/41250145-0f7fdd26-6d84-11e8-9974-8202c4924d3e.png)

**After**
![screen shot 2018-06-11 at 2 23 50 pm](https://user-images.githubusercontent.com/2642348/41250148-16980cb4-6d84-11e8-8faf-4e6e6c1492d6.png)