### PR TITLE
Remove CLIENT_ variables from .sample.env

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,5 +2,3 @@ MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook
-CLIENT_ID=GetFromGithub
-CLIENT_SECRET=GetFromGithub


### PR DESCRIPTION
What?
=====
We remove `CLIENT_ID` and `CLIENT_SECRET` from `.sample.env`.

Why?
====

When someone clones the repo for the first time and runs `bin/setup` they cannot log in into the application because they do not have `CLIENT_ID` and `CLIENT_SECRET` set.

Those variables should be automatically set in `bin/setup`, but the problem is that we copy `.sample.env` with default values for those two variables, and at the same time we check the `.env` file for `CLIENT_ID` and `CLIENT_SECRET` to make sure we're not overriding keys.

Looking at `bin/setup`, we do both of these: 

```sh
 if [ ! -f .env ]; then
   echo "Copying .env file"
   cp .sample.env .env
 fi
```

and 

```sh
if ! grep -E -q 'CLIENT_ID |CLIENT_SECRET' .env; then
   heroku config --shell --remote staging | grep -E 'CLIENT_ID|CLIENT_SECRET' >> .env
fi

```

The result is that we copy `.sample.env` with the default keys and then at the end of `bin/setup` we don't actually copy the staging keys because we already have some defined (the default ones).