### PR TITLE
Fix install assets in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -47,7 +47,7 @@ mix run priv/repo/seeds.exs
 
 # Grab JS dependencies from NPM
 echo "Installing npm dependencies"
-npm install
+cd assets && npm install && cd ../
 
 # Only if this isn't CI
 if [ -z "$CI" ]; then


### PR DESCRIPTION
Since Phoenix 1.3 changed the assets directory, we need to update the `bin/setup` to `cd` into the assets directory in order to `npm install`.