### PR TITLE
Users can delete their own announcements

### DIFF
--- a/assets/css/_announcement.scss
+++ b/assets/css/_announcement.scss
@@ -12,6 +12,15 @@
       @include margin($base-spacing null ($base-spacing * 0.85));
       font-size: $larger-font-size;
     }
+
+    .inline-action {
+      margin-right: $tiny-spacing;
+      font-size: 0.5em;
+    }
+
+    form {
+      display: inline-block;
+    }
   }
 
   pre {

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -109,6 +109,22 @@ defmodule ConstableWeb.AnnouncementController do
     end
   end
 
+  def delete(conn, %{"id" => id}) do
+    current_user = current_user(conn)
+    announcement = Repo.get!(Announcement, id)
+
+    if announcement.user_id == current_user.id do
+      Repo.delete!(announcement)
+      conn
+      |> put_flash(:info, gettext("Announcement deleted"))
+      |> redirect(to: announcement_path(conn, :index))
+    else
+      conn
+      |> put_flash(:error, gettext("You do not have permission to delete that announcement"))
+      |> redirect(to: announcement_path(conn, :show, announcement))
+    end
+  end
+
   defp render_form(conn, action, announcement) do
     changeset = Announcement.create_changeset(announcement, %{})
     interests = Repo.all(Interest)

--- a/lib/constable_web/models/announcement.ex
+++ b/lib/constable_web/models/announcement.ex
@@ -16,7 +16,7 @@ defmodule Constable.Announcement do
     belongs_to :user, User
     has_many :comments, Comment, on_delete: :delete_all
     has_many :subscriptions, Subscription, on_delete: :delete_all
-    many_to_many :interests, Interest, join_through: AnnouncementInterest
+    many_to_many :interests, Interest, on_delete: :delete_all, join_through: AnnouncementInterest
     has_many :interested_users, through: [:interests, :users]
   end
 

--- a/lib/constable_web/router.ex
+++ b/lib/constable_web/router.ex
@@ -35,7 +35,7 @@ defmodule ConstableWeb.Router do
 
     get "/", HomeController, :index
 
-    resources "/announcements", AnnouncementController, only: [:index, :show, :new, :create, :edit, :update] do
+    resources "/announcements", AnnouncementController, only: [:index, :show, :new, :create, :edit, :delete, :update] do
       resources "/comments", CommentController, only: [:create, :edit, :update]
       resources "/subscriptions", SubscriptionController, singleton: true, only: [:create, :delete]
     end

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -9,8 +9,16 @@
   <h1 data-role="title">
     <%= @announcement.title %>
     <%= if @announcement.user_id == @current_user.id do %>
-      <small>
+      <small class="inline-action">
         <%= link "edit", to: announcement_path(@conn, :edit, @announcement), data: [role: "edit"] %>
+      </small>
+      <small class="inline-action">
+        <%= link(
+            "delete",
+            to: announcement_path(@conn, :delete, @announcement),
+            method: :delete,
+            data: [confirm: "Really delete this announcement?", role: "delete"]
+        ) %>
       </small>
     <% end %>
   </h1>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -17,7 +17,7 @@
             "delete",
             to: announcement_path(@conn, :delete, @announcement),
             method: :delete,
-            data: [confirm: "Really delete this announcement?", role: "delete"]
+            data: [confirm: gettext("Really delete this announcement?"), role: "delete"]
         ) %>
       </small>
     <% end %>

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule ConstableWeb.AnnouncementControllerTest do
   use ConstableWeb.ConnCase, async: true
+  import ConstableWeb.ControllerHelper, only: [current_user: 1]
 
   alias Constable.Announcement
 
@@ -77,5 +78,22 @@ defmodule ConstableWeb.AnnouncementControllerTest do
       |> Repo.all
 
     assert interest_names == ["boston", "everyone"]
+  end
+
+  test "#delete does not work for users who are not the owner of the announcement", %{conn: conn, user: user} do
+    owner = insert(:user)
+    announcement = insert(:announcement, user: owner)
+
+    delete conn, announcement_path(conn, :delete, announcement)
+
+    assert Repo.one(Announcement)
+  end
+
+  test "#delete works for owner of the announcement", %{conn: conn, user: user} do
+    announcement = insert(:announcement, user: user)
+
+    delete conn, announcement_path(conn, :delete, announcement)
+
+    refute Repo.one(Announcement)
   end
 end

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule ConstableWeb.AnnouncementControllerTest do
   use ConstableWeb.ConnCase, async: true
-  import ConstableWeb.ControllerHelper, only: [current_user: 1]
 
   alias Constable.Announcement
 


### PR DESCRIPTION
addresses #493 

* If a user owns an announcement, allow them to delete it.
* Improve the styling of inline actions

_Help wanted: I want to write some tests for this, but Wallaby is very out of date and I don't know where to find the old documentation. Perhaps this can wait to be merged until we update Wallaby._

---

**before**

![screenshot_2018-07-13 constable - testing 1 2 3](https://user-images.githubusercontent.com/3891632/42715413-f14f3dc4-86c4-11e8-92c2-f18649d462e2.png)

**after** 

![screenshot_2018-07-13 constable - a very good announcement](https://user-images.githubusercontent.com/3891632/42715408-ec8e4320-86c4-11e8-9eba-e69e6051aab5.png)

