### PR TITLE
Return last discussed announcements first

### DIFF
--- a/lib/constable_web/controllers/api/search_controller.ex
+++ b/lib/constable_web/controllers/api/search_controller.ex
@@ -11,6 +11,7 @@ defmodule ConstableWeb.Api.SearchController do
     announcements =
       search_terms
       |> Announcement.search(exclude_interests: excludes)
+      |> Announcement.last_discussed_first
       |> Repo.all
     render(conn, "index.json", announcements: announcements)
   end

--- a/lib/constable_web/models/announcement.ex
+++ b/lib/constable_web/models/announcement.ex
@@ -60,7 +60,6 @@ defmodule Constable.Announcement do
       full_join: i in assoc(a, :interests),
       group_by: a.id,
       having: fragment("NOT ARRAY_AGG(?) @> ?", i.name, ^excludes),
-      order_by: a.id,
       where: fragment("to_tsvector('english', ?) || to_tsvector('english', ?) @@ plainto_tsquery('english', ?)",
         a.title,
         a.body,

--- a/test/controllers/api/search_controller_test.exs
+++ b/test/controllers/api/search_controller_test.exs
@@ -17,7 +17,7 @@ defmodule ConstableWeb.Api.SearchesControllerTest do
     assert results_for(conn, query: "announcement body") == json_for(announcement_2)
     assert results_for(conn, query: "awesome title cool body") == json_for(announcement_3)
     assert results_for(conn, query: "sweet 401(k) bro") == json_for(announcement_4)
-    assert results_for(conn, query: "cool") == json_for([announcement_2, announcement_3])
+    assert results_for(conn, query: "cool") == json_for([announcement_3, announcement_2])
     query_with_extra_spaces = "announcement     body"
     assert results_for(conn, query: query_with_extra_spaces) == json_for(announcement_2)
   end


### PR DESCRIPTION
This closes https://github.com/thoughtbot/constable/issues/498

What?
====

A previous commit (https://github.com/thoughtbot/constable/commit/c7cec8962f6b9c7f08b8b54f26991eed26f79fcb) introduced an ordering of announcements for `Announcement.search/3` in order to fix an intermittently failing test. But that also introduced a bug. The order of announcements returned from the search were no longer ordered with the `Announcement.last_discussed_first/1`. We fix that here by removing the ordering on the `search/3` function and relying on `last_discussed_first/1` for the search controllers, both for the web and the api.