### PR TITLE
Improve pagination controls

### DIFF
--- a/lib/constable_web/templates/interest/show.html.eex
+++ b/lib/constable_web/templates/interest/show.html.eex
@@ -27,19 +27,13 @@
 
   <%= render ConstableWeb.AnnouncementListView, "index.html", conn: @conn, announcements: @announcements %>
 
-  <div class="pagination">
-    <ul>
-      <%= if !on_first_page?(@interest_page) do %>
-        <li class="page-next">
-          <%= link gettext("NEWER"), to: interest_path(@conn, :show, @interest, page: (@interest_page.page_number - 1)) %>
-        </li>
-      <% end %>
+  <div class="container pagination">
+    <%= if !on_first_page?(@interest_page) do %>
+      <%= link gettext(""), to: interest_path(@conn, :show, @interest, page: (@interest_page.page_number - 1)), class: "page-previous button" %>
+    <% end %>
 
-      <%= if !on_last_page?(@interest_page) do %>
-        <li class="page-prev">
-          <%= link gettext("OLDER"), to: interest_path(@conn, :show, @interest, page: (@interest_page.page_number + 1)) %>
-        </li>
-      <% end %>
-    </ul>
+    <%= if !on_last_page?(@interest_page) do %>
+      <%= link gettext(""), to: interest_path(@conn, :show, @interest, page: (@interest_page.page_number + 1)), class: "page-next button" %>
+    <% end %>
   </div>
 </div>

--- a/lib/constable_web/templates/search/new.html.eex
+++ b/lib/constable_web/templates/search/new.html.eex
@@ -11,7 +11,7 @@
 
     <div class="container pagination">
       <%= if !on_first_page?(@search_page) do %>
-        <%= link gettext("foo"), to: search_path(@conn, :show, query: @query, page: (@search_page.page_number - 1)), class: "page-next button" %>
+        <%= link gettext(""), to: search_path(@conn, :show, query: @query, page: (@search_page.page_number - 1)), class: "page-next button" %>
       <% end %>
 
       <%= if !on_last_page?(@search_page) do %>

--- a/lib/constable_web/templates/search/new.html.eex
+++ b/lib/constable_web/templates/search/new.html.eex
@@ -11,7 +11,7 @@
 
     <div class="container pagination">
       <%= if !on_first_page?(@search_page) do %>
-        <%= link gettext(""), to: search_path(@conn, :show, query: @query, page: (@search_page.page_number - 1)), class: "page-next button" %>
+        <%= link gettext(""), to: search_path(@conn, :show, query: @query, page: (@search_page.page_number - 1)), class: "page-previous button" %>
       <% end %>
 
       <%= if !on_last_page?(@search_page) do %>


### PR DESCRIPTION
The arrows of both pagination buttons are facing the same way 😆 
Let's also use the same pagination controls for announcements on the `interest/show` page as well.

![screen shot 2018-07-20 at 10 14 28 am](https://user-images.githubusercontent.com/3891632/43007224-be9a5d14-8c05-11e8-9d0e-9486af48f016.png)