### PR TITLE
Do not show deactivated users in recipients preview

### DIFF
--- a/lib/constable_web/controllers/recipients_preview_controller.ex
+++ b/lib/constable_web/controllers/recipients_preview_controller.ex
@@ -20,6 +20,7 @@ defmodule ConstableWeb.RecipientsPreviewController do
               join: i in assoc(u, :interests),
               order_by: u.name,
               select: u.name,
+              where: u.active == true,
               where: i.name in ^interest_names
     Repo.all(query)
   end

--- a/test/controllers/recipients_preview_controller_test.exs
+++ b/test/controllers/recipients_preview_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule ContableWeb.RecipientsPreviewControllerTest do
+  use ConstableWeb.ConnCase, async: true
+
+  setup do
+    {:ok, browser_authenticate()}
+  end
+
+  describe ".show/2" do
+    test "returns the interested users' names", %{conn: conn}  do
+      interest = insert(:interest)
+      insert(:announcement) |> tag_with_interest(interest)
+      interested_user = insert(:user) |> with_interest(interest)
+
+      response =
+        conn
+        |> get(recipients_preview_path(conn, :show, %{"interests" => interest.name}))
+        |> json_response(200)
+
+      recipients_preview_html = response["recipients_preview_html"]
+
+      assert recipients_preview_html =~ interested_user.name
+    end
+
+    test "does not return inactive users", %{conn: conn} do
+      interest = insert(:interest)
+      insert(:announcement) |> tag_with_interest(interest)
+      interested_user = insert(:user, active: false) |> with_interest(interest)
+
+      response =
+        conn
+        |> get(recipients_preview_path(conn, :show, %{"interests" => interest.name}))
+        |> json_response(200)
+
+      recipients_preview_html = response["recipients_preview_html"]
+
+      refute recipients_preview_html =~ interested_user.name
+    end
+  end
+end

--- a/test/services/announcement_creator_test.exs
+++ b/test/services/announcement_creator_test.exs
@@ -101,6 +101,24 @@ defmodule Constable.Services.AnnouncementCreatorTest do
     assert_delivered_email Emails.new_announcement(announcement, [subscribed_user])
   end
 
+  test "does not send announcement email to deactivated users" do
+    interest = insert(:interest, name: "foo")
+    author = insert(:user) |> with_interest(interest)
+    subscribed_user = insert(:user) |> with_interest(interest)
+    _deactivated_user = insert(:user, active: false) |> with_interest(interest)
+
+    announcement_params = %{
+      title: "Title",
+      body: "Body",
+      user_id: author.id
+    }
+
+    AnnouncementCreator.create(announcement_params, ["foo"])
+
+    announcement = Repo.one(Announcement) |> Repo.preload(:user)
+    assert_delivered_email Emails.new_announcement(announcement, [subscribed_user])
+  end
+
   test "sends announcement email to mentioned users" do
     interest = insert(:interest, name: "foo")
     author = insert(:user) |> with_interest(interest)


### PR DESCRIPTION
Partially addresses https://github.com/thoughtbot/constable/issues/501

What changed?
=============

When creating an announcement, deactivated users still show up in the list of interested users for the `interest`s associated to the announcement. This commit scopes the query so that only active users are shown there.

Other changes:

- We add a test for the AnnouncementCreator module to ensure (and document) that deactivated users subscribed to an `interest` do not receive an email when the announcement is published.

Screenshots
==========

Not too much to see but the _**111 people are subscribed**_ no longer includes deactivated users: 

<img width="438" alt="screen shot 2018-08-14 at 8 20 09 am" src="https://user-images.githubusercontent.com/3245976/44091740-76d2d95c-9f9c-11e8-8f76-aea7c1a1ee6c.png">
