### PR TITLE
Update Wallaby to 0.20.x

### DIFF
--- a/assets/js/textarea-image-uploader.js
+++ b/assets/js/textarea-image-uploader.js
@@ -12,5 +12,7 @@ export function setupImageUploader(selector) {
     },
   }
 
-  new Shubox(selector, shuboxOptions);
+  if (typeof(Shubox) !== 'undefined') {
+    new Shubox(selector, shuboxOptions);
+  }
 }

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,7 +22,7 @@ config :honeybadger, :environment_name, :test
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-config :wallaby, :max_wait_time, 250
+config :wallaby, max_wait_time: 250, js_logger: false
 
 # Set a higher stacktrace during test.
 config :phoenix, :stacktrace_depth, 35

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Constable.Mixfile do
       {:scrivener_ecto, "~> 1.1"},
       {:secure_random, "~> 0.1"},
       {:slugger, "~> 0.2"},
-      {:wallaby, "~> 0.6", only: :test},
+      {:wallaby, "~> 0.20", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -45,4 +45,4 @@
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], []},
   "slugger": {:hex, :slugger, "0.2.0", "7c609e6eee6dbb44e7b0db07982932356cab476f00fc8d73320cdc50d7efa18e", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "wallaby": {:hex, :wallaby, "0.6.0", "b026915c218fc6b6fbea45099c3e7cf9b05ce8346244a05db133b6b457947add", [:mix], [{:dialyze, "~> 0.2.0", [hex: :dialyze, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}]}}
+  "wallaby": {:hex, :wallaby, "0.20.0", "cc6663555ff7b05afbebb2a8b461d18a5b321658b9017f7bc77d494b7063266a", [:mix], [{:httpoison, "~> 0.12", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/acceptance/new_comment_test.exs
+++ b/test/acceptance/new_comment_test.exs
@@ -8,8 +8,8 @@ defmodule ConstableWeb.NewCommentTest do
 
     session
     |> visit(announcement_path(Endpoint, :show, announcement, as: user.id))
-    |> fill_in("comment_body", with: "My Cool Comment")
-    |> submit_comment
+    |> fill_in(text_field("comment_body"), with: "My Cool Comment")
+    |> click(button("Post Comment"))
 
     other_session
     |> visit(announcement_path(Endpoint, :show, other_announcement, as: user.id))
@@ -18,13 +18,9 @@ defmodule ConstableWeb.NewCommentTest do
     refute has_comment_text?(other_session, "My Cool Comment")
   end
 
-  defp submit_comment(session) do
-    session
-    |> find("#submit-comment")
-    |> click
-  end
-
   defp has_comment_text?(session, comment_text) do
-    find(session, ".comments-list") |> has_text?(comment_text)
+    session
+    |> find(css(".comments-list"))
+    |> has_text?(comment_text)
   end
 end

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -1,14 +1,17 @@
 defmodule ConstableWeb.UserAnnouncementTest do
   use ConstableWeb.AcceptanceCase
 
+  @announcement_title text_field("announcement_title")
+  @announcement_body text_field("announcement_body")
+
   test "user creates an announcement", %{session: session} do
     user = insert(:user)
 
     session
     |> visit(announcement_path(Endpoint, :new, as: user.id))
-    |> fill_in("announcement_title", with: "Hello World")
+    |> fill_in(@announcement_title, with: "Hello World")
     |> fill_in_interests("everyone")
-    |> fill_in("announcement_body", with: "# Hello!")
+    |> fill_in(@announcement_body, with: "# Hello!")
     |> click_submit_button
 
     assert has_announcement_title?(session, "Hello World")
@@ -25,7 +28,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
     session
     |> visit(announcement_path(Endpoint, :new, as: current_user.id))
     |> fill_in_interests("elixir")
-    |> click_link("2 people are subscribed")
+    |> click(link("2 people are subscribed"))
 
     assert has_recipient_preview?(session, "Blake, Paul")
   end
@@ -37,9 +40,9 @@ defmodule ConstableWeb.UserAnnouncementTest do
     session
     |> visit(announcement_path(Endpoint, :show, announcement, as: user.id))
     |> click_edit
-    |> fill_in("announcement_title", with: "Updated")
+    |> fill_in(@announcement_title, with: "Updated")
     |> fill_in_interests("updated")
-    |> fill_in("announcement_body", with: "# Updated")
+    |> fill_in(@announcement_body, with: "# Updated")
     |> click_submit_button
 
     assert has_announcement_title?(session, "Updated")
@@ -54,8 +57,8 @@ defmodule ConstableWeb.UserAnnouncementTest do
 
     session
     |> visit(announcement_path(Endpoint, :edit, announcement, as: user.id))
-    |> fill_in("announcement_title", with: "Updated title")
-    |> fill_in("announcement_body", with: "# Updated")
+    |> fill_in(@announcement_title, with: "Updated title")
+    |> fill_in(@announcement_body, with: "# Updated")
     |> click_submit_button
 
     assert has_announcement_title?(session, "Updated title")
@@ -64,43 +67,47 @@ defmodule ConstableWeb.UserAnnouncementTest do
 
   defp click_edit(session) do
     session
-    |> find("[data-role=edit]")
-    |> click
+    |> click(css("[data-role=edit]"))
 
     session
   end
 
   defp fill_in_interests(session, interests) do
     session
-    |> find(".selectize-input input")
-    |> fill_in(with: interests)
+    |> fill_in(css(".selectize-input input"), with: interests)
 
     session
-    |> find(".selectize-dropdown-content .create")
-    |> click
+    |> click(css(".selectize-dropdown-content .create"))
 
     session
   end
 
   defp click_submit_button(session) do
     session
-    |> find("[data-role=submit-announcement]")
-    |> click
+    |> click(css("[data-role=submit-announcement]"))
   end
 
   defp has_announcement_title?(session, text) do
-    session |> find("h1[data-role=title]") |> has_text?(text)
+    session
+    |> find(css("h1[data-role=title]"))
+    |> has_text?(text)
   end
 
   defp has_announcement_body?(session, text) do
-    session |> find("[data-role=body] h1") |> has_text?(text)
+    session
+    |> find(css("[data-role=body] h1"))
+    |> has_text?(text)
   end
 
   defp has_announcement_interest?(session, text) do
-    session |> find("[data-role=interests]") |> has_text?(text)
+    session
+    |> find(css("[data-role=interests]"))
+    |> has_text?(text)
   end
 
   defp has_recipient_preview?(session, user_names) do
-    session |> find(".interested-user-names") |> has_text?(user_names)
+    session
+    |> find(css(".interested-user-names"))
+    |> has_text?(user_names)
   end
 end

--- a/test/acceptance/user_manages_interests_test.exs
+++ b/test/acceptance/user_manages_interests_test.exs
@@ -1,9 +1,9 @@
 defmodule ConstableWeb.UserManagesInterestsTest do
   use ConstableWeb.AcceptanceCase, async: true
 
-  @unsubscribe_link_css "[data-role=unsubscribe-from-interest]"
-  @subscribe_link_css "[data-role=subscribe-to-interest]"
-  @view_all_interests_css "[data-role=view-all-interests]"
+  @unsubscribe_link_css css("[data-role=unsubscribe-from-interest]")
+  @subscribe_link_css css("[data-role=subscribe-to-interest]")
+  @view_all_interests_css css("[data-role=view-all-interests]")
 
   test "user manages interests", %{session: session} do
     insert(:interest)
@@ -38,11 +38,11 @@ defmodule ConstableWeb.UserManagesInterestsTest do
   end
 
   defp subscribed_to_interest?(session) do
-    session |> has_css?(@unsubscribe_link_css)
+    session |> has?(@unsubscribe_link_css)
   end
 
   defp not_subscribed_to_interest?(session) do
-    session |> has_css?(@subscribe_link_css)
+    session |> has?(@subscribe_link_css)
   end
 
   defp subscribe_to_interest(session) do

--- a/test/acceptance/user_searches_announcements_test.exs
+++ b/test/acceptance/user_searches_announcements_test.exs
@@ -8,7 +8,7 @@ defmodule ConstableWeb.UserSearchesAnnouncementsTest do
 
     session
     |> visit(announcement_path(Endpoint, :new, as: user.id))
-    |> fill_in("query", with: matching_announcement.title)
+    |> fill_in(text_field("query"), with: matching_announcement.title)
     |> submit_search
 
     assert has_announcement_text?(session, matching_announcement.title)
@@ -24,7 +24,7 @@ defmodule ConstableWeb.UserSearchesAnnouncementsTest do
 
   defp has_announcement_text?(session, announcment_title) do
     session
-    |> find("h1[data-role=title]")
+    |> find(css("h1[data-role=title]"))
     |> has_text?(announcment_title)
   end
 end

--- a/test/acceptance/user_sets_slack_channel_for_interest_test.exs
+++ b/test/acceptance/user_sets_slack_channel_for_interest_test.exs
@@ -1,6 +1,8 @@
 defmodule ConstableWeb.UserSetsSlackChannelForInterestTest do
   use ConstableWeb.AcceptanceCase
 
+  @interest_slack_channel text_field("interest_slack_channel")
+
   test "user adds the slack channel for an interest", %{session: session} do
     interest = insert(:interest, name: "interest")
     user = insert(:user)
@@ -8,7 +10,7 @@ defmodule ConstableWeb.UserSetsSlackChannelForInterestTest do
     session
     |> visit(interest_path(Endpoint, :show, interest, as: user.id))
     |> click_edit_interest
-    |> fill_in("interest_slack_channel", with: "#channel-name")
+    |> fill_in(@interest_slack_channel, with: "#channel-name")
     |> click_submit
 
     assert has_slack_channel_set?(session, "#channel-name")
@@ -24,7 +26,7 @@ defmodule ConstableWeb.UserSetsSlackChannelForInterestTest do
 
     session
     |> click_edit_interest
-    |> fill_in("interest_slack_channel", with: "#new-channel-name")
+    |> fill_in(@interest_slack_channel, with: "#new-channel-name")
     |> click_submit
 
     assert has_slack_channel_set?(session, "#new-channel-name")
@@ -44,32 +46,30 @@ defmodule ConstableWeb.UserSetsSlackChannelForInterestTest do
 
   defp click_remove_slack_channel(session) do
     session
-    |> click("a[data-role=remove-channel]")
+    |> click(css("a[data-role=remove-channel]"))
   end
 
   defp click_edit_interest(session) do
     session
-    |> find("a[data-role=edit-interest]")
-    |> click
+    |> click(css("a[data-role=edit-interest]"))
 
     session
   end
 
   defp has_slack_channel_set?(session, channel_name) do
     session
-    |> find("[data-role=current-channel]")
+    |> find(css("[data-role=current-channel]"))
     |> has_text?(channel_name)
   end
 
   defp has_no_slack_channel_set?(session) do
     session
-    |> find("[data-role=current-channel]")
+    |> find(css("[data-role=current-channel]"))
     |> has_text?("add a slack channel")
   end
 
   defp click_submit(session) do
     session
-    |> find("#submit-channel-name")
-    |> click
+    |> click(css("#submit-channel-name"))
   end
 end

--- a/test/acceptance/user_unsubscribes_test.exs
+++ b/test/acceptance/user_unsubscribes_test.exs
@@ -24,15 +24,19 @@ defmodule ConstableWeb.UserUnsubscribesTest do
 
   defp has_unsubscribed_flash_message?(session) do
     session
-    |> find(".flash")
+    |> find(css(".flash"))
     |> has_text?("unsubscribed")
   end
 
   defp has_announcement_title?(session, text) do
-    session |> find("h1[data-role=title]") |> has_text?(text)
+    session
+    |> find(css("h1[data-role=title]"))
+    |> has_text?(text)
   end
 
   defp has_login_button?(session) do
-    session |> find("a.sign-in-link") |> has_text?("Sign in")
+    session
+    |> find(css("a.sign-in-link"))
+    |> has_text?("Sign in")
   end
 end

--- a/test/support/acceptance_case.ex
+++ b/test/support/acceptance_case.ex
@@ -11,6 +11,8 @@ defmodule ConstableWeb.AcceptanceCase do
       import ConstableWeb.Router.Helpers
       import Constable.Factory
       import ConstableWeb.WallabyHelper
+      import Wallaby.Query, only: [link: 1, button: 1, css: 1, text_field: 1]
+
       Application.put_env(:wallaby, :base_url, ConstableWeb.Endpoint.url)
     end
   end


### PR DESCRIPTION
What changed?
============

Our version of Wallaby is fairly outdated. We update to the newest version `0.20.0`.

The biggest changes that we made include the `Wallaby.Query` module. This module exposes functions like `link/1`, `button/1`, etc. that are meant to play nicely with `Wallaby.Browser` functions, such as `click/2`.

So we can do things like,

```elixir
session
|> fill_in(text_field("Name"), with: "thoughtbot")
|> click(button("Submit"))
```

where `fill_in/3` and `click/2` come from the browser module and `text_field/1` and `button/1` come form the query module.

Other changes:

The newest version of Wallaby also re-raises any javascript errors. For the longest time, `Shubox` has been undefined in development and testing, but now that Wallaby re-raises that error we had to handle it. I simply check to see if it's defined since the constant `Shubox` comes in through a script included in a header (though we may want to do something else).