### PR TITLE
Update Elixir to version 1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-      - image: circleci/elixir:1.4-node-browsers
+      - image: circleci/elixir:1.5-node-browsers
         environment:
           MIX_ENV: test
           CLIENT_ID: fake

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 19.2
-elixir 1.4.0
+elixir 1.5.0

--- a/lib/constable_web/models/interest.ex
+++ b/lib/constable_web/models/interest.ex
@@ -22,7 +22,7 @@ defmodule Constable.Interest do
     interest
     |> cast(params, ~w(name slack_channel))
     |> validate_required(:name)
-    |> update_change(:name, &String.strip(&1))
+    |> update_change(:name, &String.trim(&1))
     |> update_change(:name, &String.replace(&1, "#", ""))
     |> update_change(:name, &String.replace(&1, " ", "-"))
     |> update_change(:name, &String.downcase/1)

--- a/lib/constable_web/models/user.ex
+++ b/lib/constable_web/models/user.ex
@@ -104,7 +104,7 @@ defmodule Constable.User do
 
   defp is_blank?(nil), do: true
   defp is_blank?(string) when is_binary(string) do
-    case String.strip(string) do
+    case String.trim(string) do
       "" -> true
       _ -> false
     end

--- a/lib/constable_web/templates/session/new.html.eex
+++ b/lib/constable_web/templates/session/new.html.eex
@@ -1,3 +1,3 @@
 <%= link to: auth_path(@conn, :index, browser: true), class: "sign-in-link button" do %>
   <%= gettext "Sign in with Google" %>
-<%= end %>
+<% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Constable.Mixfile do
   def project do
     [app: :constable,
      version: "0.0.1",
-     elixir: "~> 1.4",
+     elixir: "~> 1.5",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,

--- a/test/controllers/email_reply_controller_test.exs
+++ b/test/controllers/email_reply_controller_test.exs
@@ -50,7 +50,7 @@ defmodule ConstableWeb.EmailReplyTest do
     post(conn, "/email_replies", email_reply_webhook)
 
     comment = Repo.one(Comment)
-    assert comment.body == String.strip(user_text)
+    assert comment.body == String.trim(user_text)
   end
 
   defp create_email_reply_webhook(message_attributes) do


### PR DESCRIPTION
What changed?
============

Many of our dependencies require Elixir's version to be 1.5 or higher. For example, many of the PRs that dependabot opened have a build failing because they need elixir 1.5 or higher.

So as to not introduce too many changes at once, this sets it to 1.5.0 (instead of going higher) and fixes a few deprecation warnings.