### PR TITLE
Add help text to change avatar

### DIFF
--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -39,6 +39,11 @@
           Send me daily digest emails about what's new on Constable.
           </label>
         </div>
+        <div class="field">
+          <label>
+            Looking to change your avatar? We use <%= link "gravatar", to: "https://en.gravatar.com/" %>. Set yours there with the same email as this account, and it will show up here.
+          </label>
+        </div>
         <%= submit gettext("Save") %>
       <% end %>
     </div>


### PR DESCRIPTION
An attempt at addressing https://github.com/thoughtbot/constable/issues/504

What changed?
=============

Adds help text in settings when someone wants to change their avatar. The explanation is not completely thorough, but it links to https://en.gravatar.com/ and informs the user to use the same email.

NOTE: I am not set on copy, so I would love input on better language.

We add the help text with the same styling of other labels in the form to keep cohesiveness with updating one's profile and settings. See the following screenshot:

![screen shot 2018-08-31 at 3 43 25 pm](https://user-images.githubusercontent.com/3245976/44933075-bff24e00-ad35-11e8-8518-8595dfb9cf6d.png)
