### PR TITLE
Update google oauth2 scopes to ask for more information

### DIFF
--- a/lib/constable_web/services/google_strategy.ex
+++ b/lib/constable_web/services/google_strategy.ex
@@ -1,6 +1,9 @@
 defmodule GoogleStrategy do
   use OAuth2.Strategy
 
+  # https://developers.google.com/identity/protocols/googlescopes
+  @oauth_scopes "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+
   def client(redirect_uri) do
     OAuth2.Client.new([
       client_id: System.get_env("CLIENT_ID"),
@@ -14,10 +17,12 @@ defmodule GoogleStrategy do
 
   def authorize_url!(redirect_uri) do
     client(redirect_uri)
-    |> put_param(:scope, "email")
+    |> put_param(:scope, @oauth_scopes)
     |> maybe_add_redirect_uri_state(redirect_uri)
     |> OAuth2.Client.authorize_url!([])
   end
+
+  def oauth_scopes, do: @oauth_scopes
 
   def get_token!(redirect_uri, params \\ [], headers \\ [], options \\ []) do
     client(redirect_uri)

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -77,7 +77,7 @@ defmodule ConstableWeb.AuthControllerTest do
       client_id: Constable.Env.get("CLIENT_ID"),
       redirect_uri: auth_url(conn, :javascript_callback),
       response_type: "code",
-      scope: "email"
+      scope: GoogleStrategy.oauth_scopes
     )
     assert redirected_to(conn) =~ auth_uri
     assert get_session(conn, :redirect_after_success_uri) == "foo.com"
@@ -92,7 +92,7 @@ defmodule ConstableWeb.AuthControllerTest do
       client_id: Constable.Env.get("CLIENT_ID"),
       redirect_uri: "https://constable-oauth-redirector.herokuapp.com/auth",
       response_type: "code",
-      scope: "email",
+      scope: GoogleStrategy.oauth_scopes,
       state: auth_url(conn, :javascript_callback)
     )
     assert redirected_to(conn) =~ auth_uri


### PR DESCRIPTION
It appears that the `email` scope only gets us the email address and some other
information, but not the full name for the person.

This change adds the full scopes we need to pull down to keep getting `name` for
users.

Resolves https://app.honeybadger.io/projects/48229/faults/39296930