### PR TITLE
Fix intermittent failure by waiting for page element

### DIFF
--- a/lib/constable_web/templates/recipients_preview/recipients_preview.html.eex
+++ b/lib/constable_web/templates/recipients_preview/recipients_preview.html.eex
@@ -1,5 +1,5 @@
 <%= if length(@interested_user_names) > 0 do %>
-  <a class="toggle-interested-user-names" href="#">
+  <a class="toggle-interested-user-names" data-role="interested-users" href="#">
     <%= ngettext("1 person is", "%{count} people are", length(@interested_user_names)) %>
     subscribed
   </a>

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -3,6 +3,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
 
   @announcement_title text_field("announcement_title")
   @announcement_body text_field("announcement_body")
+  @interested_subscribers css("[data-role=interested-users]")
 
   test "user creates an announcement", %{session: session} do
     user = insert(:user)
@@ -28,6 +29,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
     session
     |> visit(announcement_path(Endpoint, :new, as: current_user.id))
     |> fill_in_interests("elixir")
+    |> assert_has(@interested_subscribers)
     |> click(link("2 people are subscribed"))
 
     assert has_recipient_preview?(session, "Blake, Paul")


### PR DESCRIPTION
There were occassional failures in this acceptance test because the element
could not be found, and presumably was not there yet.