### PR TITLE
Use chromedriver instead of phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ follow.
 
 ### Install Required Dependencies
 
-If you're on OS X and using Homebrew, run `brew install elixir phantomjs node`.
-Otherwise, follow the instructions on the [Elixir installation page], the
-[PhantomJS page], and the [Node downloads page].
+You need to have Erlang, Elixir, Node and ChromeDriver installed. This section
+describes the easiest way to do that.
 
-Alternately, you may want to use a tool like [asdf] to ensure that your versions
-of Erlang and Elixir match what the project expects (from .tool-versions).
+If you're on OS X and using Homebrew, run `brew install node` to get nodejs.
 
-[Elixir installation page]: http://elixir-lang.org/install.html
-[PhantomJS page]: http://phantomjs.org/download.html
-[node downloads page]: https://nodejs.org/en/download/
+Once node is installed, run `npm -g install chromedriver`.
+
+Finally, install the [asdf] package manager, which will read the
+`.tool-versions` file from the repo to install the correct versions of Erlang
+and Elixir. Downloading and installing Erlang might take a while, so be patient
+on first run. You should be able to run `asdf install` from the project directly
+to install the required packages.
+
 [asdf]: https://github.com/asdf-vm/asdf
 
 ### Configure Your Local Environment

--- a/bin/setup
+++ b/bin/setup
@@ -9,18 +9,10 @@ if [ ! -f .env ]; then
   cp .sample.env .env
 fi
 
-# check if phantomjs is installed
-if ! command -v phantomjs >/dev/null; then
-  echo "You must install PhantomJS 2.x before continuing."
+# check if chromedriver is installed
+if ! command -v chromedriver >/dev/null; then
+  echo "You must install chromedriver before continuing."
   exit 1
-else
-  phantomjs_version=$(phantomjs -v)
-  major_version="${phantomjs_version%.*.*}"
-
-  if ((major_version < 2)); then
-    echo "Please update your PhantomJS to 2.x before continuing."
-    exit 1
-  fi
 fi
 
 echo "Removing previous build artifacts"

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,7 +22,10 @@ config :honeybadger, :environment_name, :test
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-config :wallaby, max_wait_time: 250, js_logger: false
+config :wallaby,
+  max_wait_time: 250,
+  js_logger: false,
+  driver: Wallaby.Experimental.Chrome
 
 # Set a higher stacktrace during test.
 config :phoenix, :stacktrace_depth, 35


### PR DESCRIPTION
The `phantomjs` browser has been moved to "legacy" buildpack on circle CI, and
is not actively maintained anymore.