### PR TITLE
Use time-elements to replace timestamps with relative time

### DIFF
--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -63,7 +63,8 @@ exports.config = {
     },
     globals: {
       $: 'jquery',
-      jQuery: 'jquery'
+      jQuery: 'jquery',
+      LocalTime: 'local-time'
     },
     whitelist: [
       "highlight.js",

--- a/assets/css/_announcement.scss
+++ b/assets/css/_announcement.scss
@@ -57,10 +57,6 @@
   color: $medium-gray;
   font-size: $tiny-font-size;
   margin-bottom: 0;
-
-  a {
-    color: inherit;
-  }
 }
 
 .announcement-interests {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6134,6 +6134,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "local-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/local-time/-/local-time-2.1.0.tgz",
+      "integrity": "sha512-4rB/8EkJIZ8O8Y5q536fSsRbzXOI0cL30l3ZKm4ISPC4D8jYOhRp/MpAaGKAYUvVIqkojT0c7kJk0RlnwtlR2w=="
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,6 +11,7 @@
     "highlight.js": "^9.3.0",
     "jquery": "^3.3.1",
     "jquery-textcomplete": "^1.8.4",
+    "local-time": "^2.1.0",
     "marked": "^0.5.0",
     "mousetrap": "^1.6.2",
     "normalize.css": "^8.0.0",

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -7,11 +7,9 @@
   <div class="media-body">
     <div class="author-information">
       <h4 class="author"><%= @comment.user.name %></h4>
-      <time class="comment-time">
-        <a href="#comment-<%= @comment.id %>">
-          <%= time_ago_in_words @comment.inserted_at %>
-        </a>
-      </time>
+      <a href="#comment-<%= @comment.id %>" class="comment-time">
+        <%= relative_timestamp(@comment.inserted_at) %>
+      </a>
 
       <%= if @comment.user_id == @current_user.id do %>
         <%= link to: announcement_comment_path(ConstableWeb.Endpoint, :edit, @comment.announcement_id, @comment), class: "edit-comment", data: [role: "edit-comment"] do %>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -31,9 +31,7 @@
 
         <div class="announcement-metadata">
           <%= gettext "announced" %>
-          <time>
-            <%= time_ago_in_words(@announcement.inserted_at) %>
-          </time>
+          <%= relative_timestamp(@announcement.inserted_at) %>
         </div>
       </div>
       <div class="subscription">

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -9,9 +9,7 @@
 
       <div class="announcement-metadata">
         <%= gettext "announced" %>
-        <time>
-          <%= time_ago_in_words(announcement.inserted_at) %>
-        </time>
+        <%= relative_timestamp(announcement.inserted_at) %>
         to
         <span>
         <%= for interest <- announcement.interests do %>

--- a/lib/constable_web/views/shared_view.ex
+++ b/lib/constable_web/views/shared_view.ex
@@ -4,6 +4,8 @@ defmodule ConstableWeb.SharedView do
   alias Constable.Services.MentionFinder
   import Exgravatar
 
+  use Phoenix.HTML
+
   def title(%{page_title: title}) do
     "- #{title}"
   end
@@ -16,34 +18,58 @@ defmodule ConstableWeb.SharedView do
     gravatar_url(user.email, secure: true)
   end
 
+  def relative_timestamp(datetime) do
+    datetime = datetime |> DateTime.from_naive!("Etc/UTC")
+
+    content_tag(
+      :time,
+      Enum.join([datetime.year, datetime.month, datetime.day], "/"),
+      [
+        {:data,
+         [
+           format: "%B %e, %Y %l:%M%P",
+           local: "time-ago"
+         ]},
+        datetime: DateTime.to_iso8601(datetime)
+      ]
+    )
+  end
+
   def time_ago_in_words(time) do
-    ts = NaiveDateTime.to_erl(time) |> :calendar.datetime_to_gregorian_seconds
-    diff = :calendar.datetime_to_gregorian_seconds(:calendar.universal_time) - ts
+    ts = NaiveDateTime.to_erl(time) |> :calendar.datetime_to_gregorian_seconds()
+    diff = :calendar.datetime_to_gregorian_seconds(:calendar.universal_time()) - ts
     rel_from_now(:calendar.seconds_to_daystime(diff))
   end
 
   defp rel_from_now({0, {0, 0, sec}}) when sec < 30,
     do: "just now"
+
   defp rel_from_now({0, {0, min, _}}) when min < 2,
     do: "1 minute ago"
+
   defp rel_from_now({0, {0, min, _}}),
     do: "#{min} minutes ago"
+
   defp rel_from_now({0, {1, _, _}}),
     do: "1 hour ago"
+
   defp rel_from_now({0, {hour, _, _}}) when hour < 24,
     do: "#{hour} hours ago"
+
   defp rel_from_now({1, {_, _, _}}),
     do: "1 day ago"
+
   defp rel_from_now({day, {_, _, _}}) when day < 0,
     do: "just now"
+
   defp rel_from_now({day, {_, _, _}}),
     do: "#{day} days ago"
 
   def markdown_with_users(markdown) do
     markdown
-    |> MentionFinder.find_users
+    |> MentionFinder.find_users()
     |> bold_usernames(markdown)
-    |> Constable.Markdown.to_html
+    |> Constable.Markdown.to_html()
   end
 
   def on_first_page?(page) do
@@ -55,7 +81,7 @@ defmodule ConstableWeb.SharedView do
   end
 
   defp bold_usernames(users, text) do
-    Enum.reduce(users, text, fn(user, text) ->
+    Enum.reduce(users, text, fn user, text ->
       String.replace(text, "@#{user.username}", "**@#{user.username}**")
     end)
   end


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/constable/issues/325

As far as I can tell, this is what GitHub is actually using on their pages.

It seems like the simple js-replacement of the timestamp with a relative time works correctly in modern browsers as I've done this here. However, the replacement of content which was in the custom element will only work with polyfills in place for some browsers. I opted here to just not include any content to replace, because I couldn't figure out how/where to insert the custom elements polyfill.