### PR TITLE
Dont generate comments list unless there are comments

### DIFF
--- a/assets/css/_comments.scss
+++ b/assets/css/_comments.scss
@@ -22,7 +22,6 @@
 }
 
 .comments-list {
-  border-top: $base-border;
   list-style-type: none;
   margin-top: $small-spacing;
   padding-top: $base-spacing;
@@ -35,15 +34,10 @@
 
 .comment {
   @include padding($base-spacing null);
-  border-bottom: $base-border;
+  border-top: $base-border;
 
   &:first-child {
     margin-top: 0;
-    padding-top: 0;
-  }
-
-  &:last-child {
-    border-bottom: none;
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/constable/issues/401 more or less.

![screen shot 2018-09-14 at 4 50 29 pm](https://user-images.githubusercontent.com/225/45574523-5185b380-b83e-11e8-971c-5ed3228d3ab2.png)


Showing the `ul` conditionally was disruptive to JS on the page which is listening to and updating that element, so I changed the order of styling instead.