### PR TITLE
Emails

### DIFF
--- a/lib/constable/services/daily_digest.ex
+++ b/lib/constable/services/daily_digest.ex
@@ -38,6 +38,6 @@ defmodule Constable.DailyDigest do
 
   defp comments_since(time) do
     Repo.all(from i in Comment, where: i.inserted_at > ^time)
-    |> Repo.preload([:announcement, :user])
+    |> Repo.preload([:user, announcement: :user])
   end
 end

--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -62,7 +62,6 @@
                 <%= for announcement <- discussed_announcements(@comments) do %>
                   <div style="padding-left: 8px;">
                     <h4><%= link announcement.title, to: announcement_url(ConstableWeb.Endpoint, :show, announcement), style: "color: #{red()}" %></h4>
-                    <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
                     <%= for comment <- new_comments(@comments, announcement) do %>
                       <p>
                         <img src="<%= author_avatar_url(comment.user) %>" class="avatar-rounded">

--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -62,6 +62,7 @@
                 <%= for announcement <- discussed_announcements(@comments) do %>
                   <div style="padding-left: 8px;">
                     <h4><%= link announcement.title, to: announcement_url(ConstableWeb.Endpoint, :show, announcement), style: "color: #{red()}" %></h4>
+                    <p style="font-weight: normal; font-style: italic;">(Posted by <%= announcement.user.name %> <%= time_ago_in_words announcement.inserted_at %>)</p>
                     <%= for comment <- new_comments(@comments, announcement) do %>
                       <p>
                         <img src="<%= author_avatar_url(comment.user) %>" class="avatar-rounded">

--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -58,12 +58,6 @@
               <%= unless Enum.empty?(@comments) do %>
                 <hr />
                 <h3><%= gettext("Discussions") %></h3>
-                <p style="font-style: italic;">
-                  &rarr; There
-                  <%= ngettext("was %{count} announcement", "were %{count} announcements", length(discussed_announcements(@comments))) %>
-                  discussed by
-                  <%= ngettext("%{count} person", "%{count} people", length(unique_commenters(@comments))) %>&hellip;
-                </p>
 
                 <%= for announcement <- discussed_announcements(@comments) do %>
                   <div style="padding-left: 8px;">

--- a/lib/constable_web/templates/email/daily_digest.text.eex
+++ b/lib/constable_web/templates/email/daily_digest.text.eex
@@ -21,7 +21,6 @@
 <% end %>
 <% end %>
 <%= unless Enum.empty?(@comments) do %>
-<%= ngettext("%{count} announcement was discussed", "%{count} announcements were discussed", length(discussed_announcements(@comments))) %> <%= ngettext("by %{count} person", "by %{count} people", length(unique_commenters(@comments))) %>
 -----------------
 <%= for announcement <- discussed_announcements(@comments) do %>
 

--- a/lib/constable_web/templates/email/daily_digest.text.eex
+++ b/lib/constable_web/templates/email/daily_digest.text.eex
@@ -25,6 +25,7 @@
 <%= for announcement <- discussed_announcements(@comments) do %>
 
  - <%= announcement.title %>
+    Posted by <%= announcement.user.name %> <%= time_ago_in_words announcement.inserted_at %>
    <%= for comment <- new_comments(@comments, announcement) do %>
      Comment by <%= comment.user.name %> <%= time_ago_in_words comment.inserted_at %>:
      <%= comment.body %>

--- a/lib/constable_web/templates/email/daily_digest.text.eex
+++ b/lib/constable_web/templates/email/daily_digest.text.eex
@@ -25,7 +25,6 @@
 <%= for announcement <- discussed_announcements(@comments) do %>
 
  - <%= announcement.title %>
-   <%= new_comment_count_text(@comments, announcement) %> <%= commenters_list_text(announcement, @comments) %>
    <%= for comment <- new_comments(@comments, announcement) do %>
      Comment by <%= comment.user.name %> <%= time_ago_in_words comment.inserted_at %>:
      <%= comment.body %>

--- a/lib/constable_web/views/email_view.ex
+++ b/lib/constable_web/views/email_view.ex
@@ -56,27 +56,6 @@ defmodule ConstableWeb.EmailView do
     |> Enum.uniq
   end
 
-  def new_comment_count_text(comments, announcement) do
-    ngettext(
-      "%{count} comment",
-      "%{count} comments",
-      Enum.count(new_comments(comments, announcement))
-    )
-  end
-
-  def commenters_list_text(announcement, comments) do
-    gettext("by ")
-    <>
-    comma_separated_commenter_list(announcement, comments)
-  end
-
-  defp comma_separated_commenter_list(announcement, comments) do
-    announcement
-    |> unique_commenters(comments)
-    |> commenter_names
-    |> Enum.join(", ")
-  end
-
   def announcement_url_for_footer(announcement, nil) do
     ConstableWeb.Router.Helpers.announcement_url(ConstableWeb.Endpoint, :show, announcement)
   end

--- a/test/emails_test.exs
+++ b/test/emails_test.exs
@@ -31,8 +31,6 @@ defmodule Constable.EmailsTest do
       assert email |> both_parts_contain(comment.user.name)
       assert email |> both_parts_contain(comment.body)
     end
-    assert email |> both_parts_contain("2 comments by #{comment_1.user.name}, #{comment_2.user.name}")
-    assert email |> both_parts_contain("1 comment by #{comment_3.user.name}")
   end
 
   defp both_parts_contain(email, string) do


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/constable/issues/427 and a few other tweaks:

- Removes what seemed like sort of a pointless summary of who commented, now that the full comments+people are right there
- Same thing for removal of high level discussion summary ("There were x announcements discussed by y people")
- Adds the name of the person who posted the announcement to the discussion summary (as requested in #427)

![screen shot 2018-09-15 at 8 56 51 am](https://user-images.githubusercontent.com/225/45586716-b33f2f80-b8c9-11e8-98a0-287ad74c1cd1.png)
