### PR TITLE
Use `local-time` package to replace timestamps with relative time

### DIFF
--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -63,7 +63,8 @@ exports.config = {
     },
     globals: {
       $: 'jquery',
-      jQuery: 'jquery'
+      jQuery: 'jquery',
+      LocalTime: 'local-time'
     },
     whitelist: [
       "highlight.js",

--- a/assets/css/_announcement.scss
+++ b/assets/css/_announcement.scss
@@ -57,10 +57,6 @@
   color: $medium-gray;
   font-size: $tiny-font-size;
   margin-bottom: 0;
-
-  a {
-    color: inherit;
-  }
 }
 
 .announcement-interests {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6134,6 +6134,11 @@
         "object-assign": "^4.0.1"
       }
     },
+    "local-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/local-time/-/local-time-2.1.0.tgz",
+      "integrity": "sha512-4rB/8EkJIZ8O8Y5q536fSsRbzXOI0cL30l3ZKm4ISPC4D8jYOhRp/MpAaGKAYUvVIqkojT0c7kJk0RlnwtlR2w=="
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -11,6 +11,7 @@
     "highlight.js": "^9.3.0",
     "jquery": "^3.3.1",
     "jquery-textcomplete": "^1.8.4",
+    "local-time": "^2.1.0",
     "marked": "^0.5.0",
     "mousetrap": "^1.6.2",
     "normalize.css": "^8.0.0",

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -7,11 +7,9 @@
   <div class="media-body">
     <div class="author-information">
       <h4 class="author"><%= @comment.user.name %></h4>
-      <time class="comment-time">
-        <a href="#comment-<%= @comment.id %>">
-          <%= time_ago_in_words @comment.inserted_at %>
-        </a>
-      </time>
+      <a href="#comment-<%= @comment.id %>" class="comment-time">
+        <%= relative_timestamp(@comment.inserted_at) %>
+      </a>
 
       <%= if @comment.user_id == @current_user.id do %>
         <%= link to: announcement_comment_path(ConstableWeb.Endpoint, :edit, @comment.announcement_id, @comment), class: "edit-comment", data: [role: "edit-comment"] do %>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -31,9 +31,7 @@
 
         <div class="announcement-metadata">
           <%= gettext "announced" %>
-          <time>
-            <%= time_ago_in_words(@announcement.inserted_at) %>
-          </time>
+          <%= relative_timestamp(@announcement.inserted_at) %>
         </div>
       </div>
       <div class="subscription">

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -9,9 +9,7 @@
 
       <div class="announcement-metadata">
         <%= gettext "announced" %>
-        <time>
-          <%= time_ago_in_words(announcement.inserted_at) %>
-        </time>
+        <%= relative_timestamp(announcement.inserted_at) %>
         to
         <span>
         <%= for interest <- announcement.interests do %>

--- a/lib/constable_web/views/shared_view.ex
+++ b/lib/constable_web/views/shared_view.ex
@@ -4,6 +4,8 @@ defmodule ConstableWeb.SharedView do
   alias Constable.Services.MentionFinder
   import Exgravatar
 
+  use Phoenix.HTML
+
   def title(%{page_title: title}) do
     "- #{title}"
   end
@@ -14,6 +16,27 @@ defmodule ConstableWeb.SharedView do
 
   def gravatar(user) do
     gravatar_url(user.email, secure: true)
+  end
+
+  def relative_timestamp(datetime) do
+    datetime = datetime |> DateTime.from_naive!("Etc/UTC")
+
+    content_tag(
+      :time,
+      simple_date(datetime),
+      [
+        {:data,
+         [
+           format: "%B %e, %Y %l:%M%P",
+           local: "time-ago"
+         ]},
+        datetime: DateTime.to_iso8601(datetime)
+      ]
+    )
+  end
+
+  def simple_date(datetime) do
+    Enum.join([datetime.year, datetime.month, datetime.day], "/")
   end
 
   def time_ago_in_words(time) do


### PR DESCRIPTION
Resolves #325

I was originally using an html custom elements approach in https://github.com/thoughtbot/constable/pull/535 which turned out to not work out in a cross browser way. Closing that in favor of this (similar but simpler) approach which uses a standard `time` element but then similar JS approach to replace the datetime with a relative time in browser.