### PR TITLE
Use UTC DateTime in schema (instead of NaiveDateTime)

### DIFF
--- a/lib/constable_web.ex
+++ b/lib/constable_web.ex
@@ -75,6 +75,7 @@ defmodule ConstableWeb do
       import Ecto.Changeset
       import Ecto.Query
       import Exgravatar
+      @timestamps_opts [type: :utc_datetime, usec: false]
     end
   end
 

--- a/lib/constable_web/views/shared_view.ex
+++ b/lib/constable_web/views/shared_view.ex
@@ -19,8 +19,6 @@ defmodule ConstableWeb.SharedView do
   end
 
   def relative_timestamp(datetime) do
-    datetime = datetime |> DateTime.from_naive!("Etc/UTC")
-
     content_tag(
       :time,
       simple_date(datetime),

--- a/test/controllers/api/announcement_controller_test.exs
+++ b/test/controllers/api/announcement_controller_test.exs
@@ -24,6 +24,16 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
     assert json_response(conn, 200) == render_json("show.json", announcement: announcement)
   end
 
+  test "#show uses iso8601 timestamps", %{conn: conn, user: user} do
+    announcement = insert(:announcement, user: user, updated_at: ~N[2018-01-01 15:15:15.000000])
+
+    conn = get conn, api_announcement_path(conn, :show, announcement)
+    body = json_response(conn, 200)
+
+    # A previous Ecto version upgrade caused a regression around datetime formats
+    assert body["announcement"]["updated_at"] == "2018-01-01T15:15:15.000000Z"
+  end
+
   test "#create with valid attributes saves an announcement", %{conn: conn} do
     announcement_params = build(:announcement_params)
 


### PR DESCRIPTION
Ecto changed how it handles timezones from 1.x to 2.x, with 2.x no longer
assuming there was a timezone for a timestamp, and returning a NaiveDateTime
instead of an elixir DateTime or an Ecto.DateTime.

A side effect of this is that API responses from Constable suddenly stopped
including the timezone portion of the ISO8601 format timestamp response that
most clients assume would be available.

This change tells Ecto models to use a utc datetime type and restores the
inclusion of timezone in the ISO8601 values from the API (and elsewhere).

Resolves https://github.com/thoughtbot/constable/issues/280

Feedback wanted here: I'm not sure what tests we should have had in place to catch this problem in the first place, or how/where I should add them now to make sure we don't have same issue when we do another Ecto version upgrade and fail to catch something like this.