### PR TITLE
Permitted domain email fixes

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,3 +2,4 @@ MANDRILL_KEY=GetFromMandrillSettings
 OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook
+PERMITTED_EMAIL_DOMAIN=thoughtbot.com

--- a/app.json
+++ b/app.json
@@ -37,6 +37,9 @@
     "OUTBOUND_EMAIL_DOMAIN": {
       "required": true
     },
+    "PERMITTED_EMAIL_DOMAIN": {
+      "required": true
+    },
     "SECRET_KEY_BASE": {
       "generator": "secret"
     },

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,8 +14,7 @@ config :constable, ConstableWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "tJ+MdrPlKWMpmz7JyJgSu/11xvwnNZo7Sz8IAacy9MM6di3GqackE9iNjhkHI9p8",
   render_errors: [view: ConstableWeb.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: Constable.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: Constable.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger
 config :logger, :console,
@@ -23,10 +22,10 @@ config :logger, :console,
   metadata: [:request_id]
 
 # To sign in, users must have an email in this domain
-config :constable, :permitted_email_domain, "thoughtbot.com"
+config :constable, :permitted_email_domain, System.get_env("PERMITTED_EMAIL_DOMAIN")
 
 config :oauth2, serializers: %{"application/json" => Poison}
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,10 +19,12 @@ config :constable, :sql_sandbox, true
 
 config :constable, :shubox_script_url, "http://localhost/testing123.js"
 
-config :constable, Constable.Mailer,
-  adapter: Bamboo.TestAdapter
+config :constable, Constable.Mailer, adapter: Bamboo.TestAdapter
 
 config :honeybadger, :environment_name, :test
+
+# The tests all use thoughtbot.com user emails
+config :constable, :permitted_email_domain, "thoughtbot.com"
 
 config :wallaby,
   max_wait_time: 250,

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,4 +1,4 @@
 erlang_version=21.0
 elixir_version=1.7.3
 always_rebuild=true
-config_vars_to_export=(DATABASE_URL MANDRILL_KEY URL_PORT SHUBOX_SCRIPT_URL)
+config_vars_to_export=(DATABASE_URL MANDRILL_KEY URL_PORT SHUBOX_SCRIPT_URL PERMITTED_EMAIL_DOMAIN)


### PR DESCRIPTION
Resolves https://github.com/thoughtbot/constable/issues/448

It appears that despite having an env var set with the permitted email domain on the demo server ... the code does not actually use that env var. We'll have to set this on staging and production as well prior to deploy.