### PR TITLE
Allow HTML5 in announcements

### DIFF
--- a/lib/constable/markdown.ex
+++ b/lib/constable/markdown.ex
@@ -4,6 +4,6 @@ defmodule Constable.Markdown do
   def to_html(markdown) do
     markdown
     |> Earmark.as_html!(%Options{smartypants: false})
-    |> HtmlSanitizeEx.basic_html
+    |> HtmlSanitizeEx.html5()
   end
 end

--- a/test/lib/constable/markdown_test.exs
+++ b/test/lib/constable/markdown_test.exs
@@ -3,24 +3,36 @@ defmodule Constable.MarkdownTest do
 
   describe "to_html/1" do
     test "filters out JavaScript" do
-      html = """
-      <code>
-      <script>alert("Gonna steal your data!");</script>
-      <a href="javascript:alert("Stolen!")>Click please!</a>
-      </code>
-      """
-      |> Constable.Markdown.to_html
+      html =
+        """
+        <code>
+        <script>alert("Gonna steal your data!");</script>
+        <a href="javascript:alert("Stolen!")>Click please!</a>
+        </code>
+        """
+        |> Constable.Markdown.to_html()
 
       assert html == ~s[<code>\nalert("Gonna steal your data!");\n<a>Click please!</a>\n</code>]
     end
 
     test "converts markdown" do
-      html = """
-      This is a paragraph
-      """
-      |> Constable.Markdown.to_html
+      html =
+        """
+        This is a paragraph
+        """
+        |> Constable.Markdown.to_html()
 
       assert html == "<p>This is a paragraph</p>\n"
+    end
+
+    test "allows for including iframes" do
+      html =
+        """
+        <iframe>This is a paragraph</iframe>
+        """
+        |> Constable.Markdown.to_html()
+
+      assert html == "<p><iframe>This is a paragraph</iframe></p>\n"
     end
   end
 end


### PR DESCRIPTION
This partially resolves https://github.com/thoughtbot/constable/issues/492

What?
======

We change `HtmlSanitizeEx` from `basic_html` to `html5`. That function is still a work-in-progress according to some comments in the source code, but I think it is safe enough for us to use since this is an internal tool. See source code at: https://github.com/rrrene/html_sanitize_ex/blob/master/lib/html_sanitize_ex/scrubber/html5.ex

Why?
=====

The main driver behind this is the ability to add <iframe>s so we can add video in an announcement. The `html_sanitize_ex` library allows us to create a custom sanitizer where we could do basic html + iframes, but I think it makes sense to go with the html5 sanitizer even if it's a work in progress.

At some point, it might be nice to add oembed so that someone can just put a link and we can retrieve it for them, but allowing the rendering of <iframe>s is a pre-requisite for that anyway, so I think this is a good first step for those that want to add video to their announcements.

Screenshots
--------------
![screen shot 2018-09-21 at 4 49 24 pm](https://user-images.githubusercontent.com/3245976/45905492-848bf200-bdbe-11e8-92be-84014342928b.png)

![screen shot 2018-09-21 at 4 49 18 pm](https://user-images.githubusercontent.com/3245976/45905491-848bf200-bdbe-11e8-9061-cc44807dc764.png)

