### PR TITLE
Add body class to apply image width styles

### DIFF
--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -48,7 +48,7 @@
                       <%= gettext("posted to") %> <%= raw interest_links(announcement) %>
                       <%= time_ago_in_words announcement.inserted_at %>:
                     </p>
-                    <div style="padding-left: 1.85rem;">
+                    <div style="padding-left: 1.85rem;" class="body">
                       <%= raw markdown_with_users(announcement.body) %>
                     </div>
                   </div>
@@ -68,7 +68,7 @@
                         <img src="<%= author_avatar_url(comment.user) %>" class="avatar-rounded">
                         <strong><%= comment.user.name %></strong> left a comment <%= time_ago_in_words comment.inserted_at %>:
                       </p>
-                      <div style="padding-left: 1.85rem;">
+                      <div style="padding-left: 1.85rem;" class="body">
                         <%= raw markdown_with_users(comment.body) %>
                       </div>
                     <% end %>


### PR DESCRIPTION
There is a style in place to constrain very wide images in emails we send out,
which is applied to things under `.body` elements. This class was removed in an
email markup cleanup, and is restored here.

Resolves https://github.com/thoughtbot/constable/issues/553

Before:

![screen shot 2018-10-19 at 10 47 18 am](https://user-images.githubusercontent.com/225/47225602-75cc3700-d38c-11e8-8525-f7ebc26090be.png)


After:

![screen shot 2018-10-19 at 10 47 26 am](https://user-images.githubusercontent.com/225/47225609-79f85480-d38c-11e8-98ad-8edbb3638f2e.png)
