### PR TITLE
Add background-color white to at mention menu

### DIFF
--- a/assets/css/_at-mention.scss
+++ b/assets/css/_at-mention.scss
@@ -1,6 +1,7 @@
 @import '../../vendor/textcomplete.css';
 
 .dropdown-menu {
+  background-color: $white;
   border: none;
   border-radius: $base-border-radius;
   box-shadow: $base-box-shadow;


### PR DESCRIPTION
Fixes a bug with the at mention menu background being transparent and overlapping other elements.

Before:

<img width="864" alt="screen shot 2018-11-06 at 11 30 13 am" src="https://user-images.githubusercontent.com/7661887/48078749-0641ae80-e1b8-11e8-8f8c-7d685a1568f8.png">

After:

<img width="850" alt="screen shot 2018-11-06 at 11 30 22 am" src="https://user-images.githubusercontent.com/7661887/48078765-09d53580-e1b8-11e8-8048-6bf531369d76.png">

I wasn't able to test this locally because I was having trouble signing in with Google locally.