### PR TITLE
Update incorrect shubox script URL in dev environment

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -3,3 +3,4 @@ OUTBOUND_EMAIL_DOMAIN=staging.constable.io
 INBOUND_EMAIL_DOMAIN=inbound.staging.constable.io
 SLACK_WEBHOOK_URL=https://fakeslack/webhook
 PERMITTED_EMAIL_DOMAIN=thoughtbot.com
+SHUBOX_SCRIPT_URL=get-from-shubox-dashboard

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,9 @@ config :phoenix, :json_library, Jason
 # To sign in, users must have an email in this domain
 config :constable, :permitted_email_domain, System.get_env("PERMITTED_EMAIL_DOMAIN")
 
+# The shubox JS source URL is unique to each app/env
+config :constable, :shubox_script_url, System.get_env("SHUBOX_SCRIPT_URL")
+
 config :oauth2, serializers: %{"application/json" => Poison}
 
 # Import environment specific config. This must remain at the bottom

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -45,6 +45,4 @@ config :constable, Constable.Repo,
 
 config :constable, Constable.Mailer, adapter: Bamboo.LocalAdapter
 
-config :constable, :shubox_script_url, "http://shubox.io/x/a7c92ded.js"
-
 config :honeybadger, :environment_name, :dev

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -74,8 +74,6 @@ config :constable, Constable.Repo,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   ssl: true
 
-config :constable, :shubox_script_url, System.get_env("SHUBOX_SCRIPT_URL")
-
 config :constable, Constable.Mailer,
   adapter: Bamboo.MandrillAdapter,
   api_key: System.get_env("MANDRILL_KEY")

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,7 +17,7 @@ config :constable, Constable.Repo,
 
 config :constable, :sql_sandbox, true
 
-config :constable, :shubox_script_url, "http://localhost/testing123.js"
+config :constable, :shubox_script_url, "#"
 
 config :constable, Constable.Mailer, adapter: Bamboo.TestAdapter
 


### PR DESCRIPTION
The URL value we were using was outdated (and just erroring in local
development), and needed to be replaced with a new value.

Separately, since this project is open source, it's sort of awkward to expose
the actual value for the development URL of an account TB owns but does not
necessarily want to share with other contributors.

I've added the thougthbot constable shubox account credentials to the team
dropbox so that anyone setting up an environment can add that to their local
.env and have uploads working locally, if needed.