### PR TITLE
Support emoji in announcement titles

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Constable.MixProject do
       {:quick_alias, "~> 0.1.0"},
       {:scrivener_ecto, "~> 2.0.0"},
       {:secure_random, "~> 0.1"},
-      {:slugger, "~> 0.2"},
+      {:slugger, "~> 0.2.0"},
       {:wallaby, "~> 0.20", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -46,7 +46,7 @@
   "scrivener": {:hex, :scrivener, "2.5.0", "e1f78c62b6806d91cc9c4778deef1ea4e80aa9fadfce2c16831afe0468cc8a2c", [:mix], [], "hexpm"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.0.0", "e6ee5cc49b44e6115029185f07ffddd7e78475aa40394e98219800fed18f8e42", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm"},
-  "slugger": {:hex, :slugger, "0.3.0", "efc667ab99eee19a48913ccf3d038b1fb9f165fa4fbf093be898b8099e61b6ed", [:mix], [], "hexpm"},
+  "slugger": {:hex, :slugger, "0.2.0", "7c609e6eee6dbb44e7b0db07982932356cab476f00fc8d73320cdc50d7efa18e", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -10,12 +10,12 @@ defmodule ConstableWeb.UserAnnouncementTest do
 
     session
     |> visit(Routes.announcement_path(Endpoint, :new, as: user.id))
-    |> fill_in(@announcement_title, with: "Hello World")
+    |> fill_in(@announcement_title, with: "Hello World ❤️")
     |> fill_in_interests("everyone")
     |> fill_in(@announcement_body, with: "# Hello!")
     |> click_submit_button
 
-    assert has_announcement_title?(session, "Hello World")
+    assert has_announcement_title?(session, "Hello World ❤️")
     assert has_announcement_body?(session, "Hello")
     assert has_announcement_interest?(session, "everyone")
   end


### PR DESCRIPTION
We were seeing app errors occur when people tried to create announcements where
the title contained an Emoji.

Example: https://app.honeybadger.io/projects/48229/faults/44121036#notice-summary

We tracked this back to the Announcement changeset massaging a `slug` value out
of the announcement title while it saves. We use the Slugger library to do this,
which has a bug in version 0.3.0 around removing chars outside the expected
range: https://github.com/h4cc/slugger/issues/32

A side effect of this was that our title values wound up with non-UTF8 chars in
them and postgres threw an error.

This change locks the version of Slugger to one which was working, and adds test
coverage for including Emoji in announcement titles.