### PR TITLE
Set json serializer for OAuth2 client

### DIFF
--- a/lib/constable/services/google_strategy.ex
+++ b/lib/constable/services/google_strategy.ex
@@ -5,14 +5,15 @@ defmodule GoogleStrategy do
   @oauth_scopes "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
 
   def client(redirect_uri) do
-    OAuth2.Client.new([
+    OAuth2.Client.new(
       client_id: System.get_env("CLIENT_ID"),
       client_secret: System.get_env("CLIENT_SECRET"),
       authorize_url: "https://accounts.google.com/o/oauth2/auth",
       token_url: "https://www.googleapis.com/oauth2/v3/token",
       site: "https://www.googleapis.com",
       redirect_uri: Constable.Pact.get(:oauth_redirect_strategy).redirect_uri(redirect_uri)
-    ])
+    )
+    |> OAuth2.Client.put_serializer("application/json", Jason)
   end
 
   def authorize_url!(redirect_uri) do


### PR DESCRIPTION
When we upgraded the oauth2 library to v1.0.x, there was an incompatible changes that we did not fulfill. The change required us to specify the Json parser we want to use. We do that in this commit.

Looking at our `mix.exs` file, it seems we have both Poison and Jason, libraries that serve the same purpose, so it seems like we should choose one in the future. For now, I selected Jason since that is the faster of the two and likely the one we will migrate everything else to.