### PR TITLE
Adds "Your Announcements" to nav bar

### DIFF
--- a/lib/constable_web/templates/announcement/index.html.eex
+++ b/lib/constable_web/templates/announcement/index.html.eex
@@ -8,7 +8,12 @@
 
       <%= link gettext("Your interests"),
         to: Routes.announcement_path(@conn, :index),
-        class: class_for("mine", @conn)
+        class: class_for("your interests", @conn)
+      %>
+
+      <%= link gettext("Your announcements"),
+        to: Routes.announcement_path(@conn, :index, user_id: @current_user.id),
+        class: class_for("your announcements", @conn)
       %>
 
       <%= if !@show_all do %>

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -3,13 +3,13 @@ defmodule ConstableWeb.AnnouncementView do
 
   def json_interests(interests) do
     interests
-    |> Enum.map(&(%{name: &1.name}))
-    |> Poison.encode!
+    |> Enum.map(&%{name: &1.name})
+    |> Poison.encode!()
   end
 
   def comma_separated_interest_names(interests) when is_list(interests) do
     interests
-    |> Enum.map(&(&1.name))
+    |> Enum.map(& &1.name)
     |> Enum.join(",")
   end
 
@@ -18,20 +18,28 @@ defmodule ConstableWeb.AnnouncementView do
   def class_for("all", %{params: %{"all" => "true"}}) do
     "selected"
   end
-  def class_for("mine", %{params: %{"all" => "true"}}), do: nil
-  def class_for("mine", _) do
-    "mine selected"
+
+  def class_for("your announcements", %{params: %{"user_id" => _}}) do
+    "your announcements selected"
   end
+
+  def class_for("your interests", %{params: %{"all" => "true"}}), do: nil
+  def class_for("your interests", %{params: %{"user_id" => _}}), do: nil
+
+  def class_for("your interests", _) do
+    "your interests selected"
+  end
+
   def class_for(_, _), do: nil
 
   def interest_count_for(user) do
-    length user.interests
+    length(user.interests)
   end
 
   def user_autocomplete_json(users) do
     users
     |> Enum.map(&format_user_json/1)
-    |> Poison.encode!
+    |> Poison.encode!()
   end
 
   defp format_user_json(user) do

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -15,21 +15,11 @@ defmodule ConstableWeb.AnnouncementView do
 
   def comma_separated_interest_names(_), do: ""
 
-  def class_for("all", %{params: %{"all" => "true"}}) do
-    "selected"
-  end
-
-  def class_for("your announcements", %{params: %{"user_id" => _}}) do
-    "your announcements selected"
-  end
-
+  def class_for("all", %{params: %{"all" => "true"}}), do: "selected"
+  def class_for("your announcements", %{params: %{"user_id" => _}}), do: "selected"
   def class_for("your interests", %{params: %{"all" => "true"}}), do: nil
   def class_for("your interests", %{params: %{"user_id" => _}}), do: nil
-
-  def class_for("your interests", _) do
-    "your interests selected"
-  end
-
+  def class_for("your interests", _), do: "selected"
   def class_for(_, _), do: nil
 
   def interest_count_for(user) do

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -9,18 +9,18 @@ defmodule ConstableWeb.AnnouncementControllerTest do
 
   test "#index all announcements are shown when query param all is set", %{conn: conn, user: user} do
     insert(:announcement, title: "Awesome", user: user)
-    insert(:announcement, title: "Lame", user: user)
+    insert(:announcement, title: "Great", user: user)
 
     conn = get(conn, Routes.announcement_path(conn, :index, all: true))
 
     assert html_response(conn, :ok) =~ "Awesome"
-    assert html_response(conn, :ok) =~ "Lame"
+    assert html_response(conn, :ok) =~ "Great"
   end
 
   test "#index shows user's announcements when user_id is set", %{conn: conn, user: user} do
     other_user = insert(:user)
     insert(:announcement, title: "Awesome", user: user)
-    insert(:announcement, title: "Lame", user: other_user)
+    insert(:announcement, title: "Do not show", user: other_user)
 
     response =
       conn
@@ -28,7 +28,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
       |> html_response(:ok)
 
     assert response =~ "Awesome"
-    refute response =~ "Lame"
+    refute response =~ "Do not show"
   end
 
   test "#index only announcements of interest are shown by default", %{conn: conn, user: user} do

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -11,19 +11,33 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     insert(:announcement, title: "Awesome", user: user)
     insert(:announcement, title: "Lame", user: user)
 
-    conn = get conn, Routes.announcement_path(conn, :index, all: true)
+    conn = get(conn, Routes.announcement_path(conn, :index, all: true))
 
     assert html_response(conn, :ok) =~ "Awesome"
     assert html_response(conn, :ok) =~ "Lame"
   end
 
-  test "#index only my announcements are shown by default", %{conn: conn, user: user} do
+  test "#index shows user's announcements when user_id is set", %{conn: conn, user: user} do
+    other_user = insert(:user)
+    insert(:announcement, title: "Awesome", user: user)
+    insert(:announcement, title: "Lame", user: other_user)
+
+    response =
+      conn
+      |> get(Routes.announcement_path(conn, :index, user_id: user.id))
+      |> html_response(:ok)
+
+    assert response =~ "Awesome"
+    refute response =~ "Lame"
+  end
+
+  test "#index only announcements of interest are shown by default", %{conn: conn, user: user} do
     my_interest = insert(:interest)
     insert(:user_interest, user: user, interest: my_interest)
     insert(:announcement, title: "Shows up") |> tag_with_interest(my_interest)
     _announcement_with_no_matching_interest = insert(:announcement, title: "Does not show up")
 
-    conn = get conn, Routes.announcement_path(conn, :index)
+    conn = get(conn, Routes.announcement_path(conn, :index))
 
     assert html_response(conn, :ok) =~ "Shows up"
     refute html_response(conn, :ok) =~ "Does not show up"
@@ -32,7 +46,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
   test "#show renders markdown as html", %{conn: conn} do
     announcement = insert(:announcement, body: "# Hello")
 
-    conn = get conn, Routes.announcement_path(conn, :show, announcement)
+    conn = get(conn, Routes.announcement_path(conn, :show, announcement))
 
     assert html_response(conn, :ok) =~ "<h1>Hello</h1>"
   end
@@ -41,40 +55,47 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     announcement = insert(:announcement)
     insert(:comment, body: "# Comment", announcement: announcement)
 
-    conn = get conn, Routes.announcement_path(conn, :show, announcement)
+    conn = get(conn, Routes.announcement_path(conn, :show, announcement))
 
     assert html_response(conn, :ok) =~ "<h1>Comment</h1>"
   end
 
-  test "comments on show page have an edit link if current user is the author", %{conn: conn, user: user} do
+  test "comments on show page have an edit link if current user is the author", %{
+    conn: conn,
+    user: user
+  } do
     comment = insert(:comment, user: user)
 
-    conn = get conn, Routes.announcement_path(conn, :show, comment.announcement)
+    conn = get(conn, Routes.announcement_path(conn, :show, comment.announcement))
 
     assert html_response(conn, :ok) =~ "(edit)"
   end
 
-  test "comments on show page do not have an edit link if another user is the author", %{conn: conn} do
+  test "comments on show page do not have an edit link if another user is the author", %{
+    conn: conn
+  } do
     another_user = insert(:user)
     comment = insert(:comment, user: another_user)
 
-    conn = get conn, Routes.announcement_path(conn, :show, comment.announcement)
+    conn = get(conn, Routes.announcement_path(conn, :show, comment.announcement))
 
     refute html_response(conn, :ok) =~ "(edit)"
   end
 
   test "#create splits interests by ,", %{conn: conn} do
-    post conn, Routes.announcement_path(conn, :create), announcement: %{
-      title: "Hello world",
-      interests: "everyone, boston",
-      body: "# Hello"
-    }
+    post conn, Routes.announcement_path(conn, :create),
+      announcement: %{
+        title: "Hello world",
+        interests: "everyone, boston",
+        body: "# Hello"
+      }
 
-    interest_names = Repo.one!(Announcement)
+    interest_names =
+      Repo.one!(Announcement)
       |> Ecto.assoc(:interests)
       |> Ecto.Query.select([a], a.name)
       |> Ecto.Query.order_by([a], a.name)
-      |> Repo.all
+      |> Repo.all()
 
     assert interest_names == ["boston", "everyone"]
   end
@@ -83,7 +104,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     owner = insert(:user)
     announcement = insert(:announcement, user: owner)
 
-    delete conn, Routes.announcement_path(conn, :delete, announcement)
+    delete(conn, Routes.announcement_path(conn, :delete, announcement))
 
     assert Repo.one(Announcement)
   end
@@ -91,7 +112,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
   test "#delete works for owner of the announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user)
 
-    delete conn, Routes.announcement_path(conn, :delete, announcement)
+    delete(conn, Routes.announcement_path(conn, :delete, announcement))
 
     refute Repo.one(Announcement)
   end

--- a/test/models/announcement_test.exs
+++ b/test/models/announcement_test.exs
@@ -62,9 +62,9 @@ defmodule Constable.AnnouncementTest do
   describe ".last_discussed_first/1" do
     test "returns the last discussed announcement" do
       oldest = insert(:announcement, last_discussed_at: Constable.Time.days_ago(1))
-      newest = insert(:announcement, last_discussed_at: Constable.Time.now)
+      newest = insert(:announcement, last_discussed_at: Constable.Time.now())
 
-      announcements = Announcement.last_discussed_first |> Repo.all
+      announcements = Announcement.last_discussed_first() |> Repo.all()
 
       assert List.first(announcements).id == newest.id
       assert List.last(announcements).id == oldest.id
@@ -75,15 +75,34 @@ defmodule Constable.AnnouncementTest do
     test "interests are sorted alphabetically" do
       interest_a = insert(:interest, name: "a")
       interest_b = insert(:interest, name: "b")
+
       insert(:announcement)
-        |> tag_with_interest(interest_b)
-        |> tag_with_interest(interest_a)
+      |> tag_with_interest(interest_b)
+      |> tag_with_interest(interest_a)
 
-      announcement = Announcement.with_announcement_list_assocs
-        |> Repo.one
+      announcement =
+        Announcement.with_announcement_list_assocs()
+        |> Repo.one()
 
-      assert announcement.interests |> List.first == interest_a
-      assert announcement.interests |> List.last  == interest_b
+      assert announcement.interests |> List.first() == interest_a
+      assert announcement.interests |> List.last() == interest_b
+    end
+  end
+
+  describe ".for_user/1" do
+    test "returns announcements for given user" do
+      user = insert(:user)
+      announcement = insert(:announcement, user: user)
+      other_announcement = insert(:announcement, user: insert(:user))
+
+      announcement_ids =
+        user.id
+        |> Announcement.for_user()
+        |> Repo.all()
+        |> Enum.map(& &1.id)
+
+      assert announcement.id in announcement_ids
+      refute other_announcement.id in announcement_ids
     end
   end
 end


### PR DESCRIPTION
What changed?
------------

This PR adds a new tab into the announcements-interests nav bar. The tab, titled "Your announcements", allows users to see only announcements they have made.

Why?
----

When users make announcements, they have the ability to edit them in the future. Users may also want to see comments people have left in one of their previous announcements. But I have always found it difficult to find my previous announcements.

Typically, I would open an issue before creating a PR to see if this is even wanted by others. But this is simple enough that I thought I'd just take a stab at it, and see if it makes sense to merge. If we don't think this will be useful (other than for me), I'm happy to close this PR.

Demo
----

![add-your-announcements-link](https://user-images.githubusercontent.com/3245976/58348304-53246400-7e2e-11e9-930f-31c43dc007c7.gif)


Comments on some of the code
----------------------------

Most of the implementation was included alongside the implementation of the other two `announcement#index` actions, leveraging pattern matching to filter things correctly. It seems like there's a lot of logic in the controller, and it would be good to refactor it. I have decided not to do more of that in this PR to avoid introducing more changes.

There are also some unrelated changes in files I have touched due to the elixir formatter. I have decided to include those here rather than turning the formatter off, but it may be good to run the formatter across all files in a single PR so that we do not have constant PRs that have a lot of unrelated changes due to auto-formatting.