### PR TITLE
Make user names clickable to see their announcements

### DIFF
--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -27,7 +27,7 @@
     <div class="media media-center">
       <img src="<%= gravatar @announcement.user %>" class="media-figure avatar-rounded avatar-rounded-large"/>
       <div class="media-body">
-        <h4 class="author"><%= @announcement.user.name %></h4>
+        <h4><%= link @announcement.user.name, to: Routes.announcement_path(@conn, :index, user_id: @announcement.user_id), class: "author" %></h4>
 
         <div class="announcement-metadata">
           <%= gettext "announced" %>

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -16,11 +16,21 @@ defmodule ConstableWeb.AnnouncementView do
   def comma_separated_interest_names(_), do: ""
 
   def class_for("all", %{params: %{"all" => "true"}}), do: "selected"
-  def class_for("your announcements", %{params: %{"user_id" => _}}), do: "selected"
+
+  def class_for("your announcements", conn = %{params: %{"user_id" => id}}) do
+    if current_user_same_as_announcements_user?(conn, id) do
+      "selected"
+    end
+  end
+
   def class_for("your interests", %{params: %{"all" => "true"}}), do: nil
   def class_for("your interests", %{params: %{"user_id" => _}}), do: nil
   def class_for("your interests", _), do: "selected"
   def class_for(_, _), do: nil
+
+  defp current_user_same_as_announcements_user?(conn, announcements_user_id) do
+    "#{conn.assigns[:current_user].id}" == announcements_user_id
+  end
 
   def interest_count_for(user) do
     length(user.interests)


### PR DESCRIPTION
What changed?
============

In 1e357b6, we introduced a  `/announcements#index` route with the query param `user_id` in order to display a user's own announcements. We leverage the core of that functionality to display the list of announcements for _any_ user when we click their name.

The only strange thing about this is that when we select a user's name, we leave the nav bar in an unselected state (i.e. no tab is marked as "selected"), since seeing another user's announcements does not have an equivalent "tab" as we might have for "All announcements" or "Your announcements".

Why this change?
================

I often find that I expect to be able to navigate to a user's announcements by clicking on their name only to be surprised by the fact that I can't.

NOTE: I'm not sure if this is a good addition to Constable. I'd be interested in hearing other people's thoughts. It's possible that announcements are meant to be slightly more ephemeral and that we should just use the search functionality if we want to find old announcements. So I'm happy to close this if others find this unhelpful.

![names-link-to-users-posts](https://user-images.githubusercontent.com/3245976/59104952-dfd82300-8900-11e9-8e15-9089e84362f4.gif)
