### PR TITLE
Fix broken image path for modal close icon

### DIFF
--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -4,7 +4,7 @@
     <header>
       <h2>Profile and Settings</h2>
       <a href="#" class="modal-close" data-role="closing-icon">
-        <img src="../images/icon-close.svg" />
+        <img src="/images/icon-close.svg" />
       </a>
     </header>
 


### PR DESCRIPTION
I noticed while editing a comment that the image was broken when I opened the settings modal. This changes the close icon's path to be static instead of dynamic.

To see where it is broken:
1. Open a Constable announcement that you have commented on
1. Click on "edit" for your comment on the post
1. Click on your profile image in the top right corner
1. Notice the close image is missing

Before | After
--|--
![before](https://user-images.githubusercontent.com/5240843/59808065-73213900-92af-11e9-9c3d-943a8c4312a3.png) | ![after](https://user-images.githubusercontent.com/5240843/59808064-73213900-92af-11e9-9b9c-43336b233d71.png)