### PR TITLE
Subscribe users to announcements they comment on

### DIFF
--- a/assets/js/comment-form.js
+++ b/assets/js/comment-form.js
@@ -17,9 +17,12 @@ channel
   });
 
 channel.on('new-comment', payload => {
-  $(
-    `[data-announcement-id='${payload.announcement_id}'] .comments-list`
-  ).append(payload.comment_html);
+  $(`[data-announcement-id='${payload.announcement_id}'] .comments-list`)
+    .append(payload.comment_html);
+
+  if (payload.subscribed === true) {
+    $("[data-role='subscription-button'] a").replaceWith(payload.unsubscribe_button_html);
+  }
 });
 
 const resetForm = form => form.reset();

--- a/lib/constable_web/channels/live_html_channel.ex
+++ b/lib/constable_web/channels/live_html_channel.ex
@@ -8,14 +8,27 @@ defmodule ConstableWeb.LiveHtmlChannel do
   end
 
   def handle_out("new-comment", %{comment: comment}, socket) do
+    current_user = socket.assigns[:current_user]
+    announcement_id = comment.announcement_id
+
     payload = %{
-      announcement_id: comment.announcement_id,
-      comment_html: render_comment_html(comment, socket.assigns[:current_user])
+      announcement_id: announcement_id,
+      comment_html: render_comment_html(comment, current_user),
+      subscribed: comment.user_id == current_user.id,
+      unsubscribe_button_html: render_unsubscribe_button_html(announcement_id)
     }
 
     push(socket, "new-comment", payload)
 
     {:noreply, socket}
+  end
+
+  defp render_unsubscribe_button_html(announcement_id) do
+    Phoenix.View.render_to_string(
+      ConstableWeb.AnnouncementView,
+      "_unsubscribe_button.html",
+      announcement_id: announcement_id
+    )
   end
 
   defp render_comment_html(comment, current_user) do

--- a/lib/constable_web/templates/announcement/_unsubscribe_button.html.eex
+++ b/lib/constable_web/templates/announcement/_unsubscribe_button.html.eex
@@ -1,0 +1,8 @@
+<%= link to: Routes.announcement_subscription_path(ConstableWeb.Endpoint, :delete, @announcement_id),
+  method: :delete,
+  class: "tbds-button button-secondary" do %>
+  <svg class="tbds-button__icon tbds-button__icon--start">
+    <use xlink:href="/images/icons.svg#check"></use>
+  </svg>
+  <%= gettext("Subscribed to thread") %>
+<% end %>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -47,16 +47,9 @@
         </div>
       </div>
     </div>
-    <div class="announcement-metadata-item subscription">
+    <div class="announcement-metadata-item subscription" data-role="subscription-button">
       <%= if @subscription do %>
-        <%= link to: Routes.announcement_subscription_path(@conn, :delete, @announcement),
-          method: :delete,
-          class: "tbds-button button-secondary" do %>
-          <svg class="tbds-button__icon tbds-button__icon--start">
-            <use xlink:href="/images/icons.svg#check"></use>
-          </svg>
-          <%= gettext("Subscribed to thread") %>
-        <% end %>
+        <%= render "_unsubscribe_button.html", announcement_id: @announcement.id %>
       <% else %>
         <%= link to: Routes.announcement_subscription_path(@conn, :create, @announcement),
           method: :post,

--- a/test/services/comment_creator_test.exs
+++ b/test/services/comment_creator_test.exs
@@ -5,6 +5,7 @@ defmodule Constable.Services.CommentCreatorTest do
   alias ConstableWeb.Api.CommentView
   alias Constable.Comment
   alias Constable.Services.CommentCreator
+  alias Constable.Subscription
 
   test "creates a comment" do
     announcement = insert(:announcement)
@@ -95,5 +96,21 @@ defmodule Constable.Services.CommentCreatorTest do
       })
 
     assert_no_emails_delivered()
+  end
+
+  test "create subscribes the commenting user to the announcement" do
+    commenter = insert(:user)
+    announcement = insert(:announcement)
+
+    {:ok, _comment} =
+      CommentCreator.create(%{
+        user_id: commenter.id,
+        body: "Baz!",
+        announcement_id: announcement.id
+      })
+
+    subscription = Repo.one!(Subscription)
+    assert subscription.user_id == commenter.id
+    assert subscription.announcement_id == announcement.id
   end
 end


### PR DESCRIPTION
Resolves #558

This PR aims to subscribe users to announcements that they comment on. 

The general approach is to:

1. Fire a subscribe event upon comment creation
2. Update the announcement's subscribe button to reflect the new status

<hr>

Note on implementation: in a first and unimplemented pass, I attempted to create a new and separate channel subscription update for this particular update, but I was unsuccessful and opted to combine the update with the new-comment payload. If we would prefer to handle this separately, I am happy to tackle that again.