### PR TITLE
Fix horizontal scroll on smaller viewport sizes

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,3 +1,4 @@
+@import "~normalize.css/normalize";
 @import "~bourbon/core/bourbon";
 
 @import 'media';

--- a/assets/css/base/_base.scss
+++ b/assets/css/base/_base.scss
@@ -1,3 +1,4 @@
+@import "layout";
 @import "grid-settings";
 @import "variables";
 @import "buttons";

--- a/assets/css/base/_layout.scss
+++ b/assets/css/base/_layout.scss
@@ -1,0 +1,14 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+html,
+body {
+  height: 100%;
+}


### PR DESCRIPTION
I noticed there was a horizontal scroll when I opened Constable on my phone. I found that we weren't applying `box-sizing: border-box` to the layout (which is a typical reset we employ). We also had `normalize.css` in our packages, but weren't using it within our css, so that is now among the imports.

<details>
<summary>Before/After screenshots</summary>
<p><strong>Before</strong></p>
<img src="https://user-images.githubusercontent.com/2642348/60369139-a99e3880-99c0-11e9-9fb4-26eddec1c6f3.png" alt="Before screenshot">

<hr>

<p><strong>After</strong></p>
<img src="https://user-images.githubusercontent.com/2642348/60369149-b458cd80-99c0-11e9-8e64-83f6a46087e8.png" alt="After screenshot">
</details>