### PR TITLE
Underline links by default

### DIFF
--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -56,14 +56,14 @@ p {
 
 a {
   color: $action-color;
-  text-decoration: none;
+  text-decoration: underline;
   transition: color $base-duration $base-timing;
   word-wrap: break-word;
 
   &:active,
   &:focus,
   &:hover {
-    text-decoration: underline;
+    text-decoration: underline dashed;
   }
 }
 

--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -64,6 +64,7 @@ a {
   &:focus,
   &:hover {
     text-decoration: underline dashed;
+    text-decoration-skip-ink: auto;
   }
 }
 


### PR DESCRIPTION
Color differences in links can be hard/impossible to see for those with
color blindness. Let's underline links by default, and underline dashed
on focus & hover.

I'm having trouble getting Constable running locally (discussed in https://github.com/thoughtbot/constable/pull/603),
can someone confirm this works locally & doesn't look terrible?