### PR TITLE
Allow loading of environment variables in config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 erl_crash.dump
 *.ez
 
+.elixir_ls/
+
 assets/node_modules/
 priv/static
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 erl_crash.dump
 *.ez
 
-.elixir_ls/
-
 assets/node_modules/
 priv/static
 

--- a/lib/constable/application.ex
+++ b/lib/constable/application.ex
@@ -8,8 +8,9 @@ defmodule Constable.Application do
   use Application
 
   def start(_type, _args) do
-    unless Mix.env == "production" do
-      Envy.auto_load
+    unless Mix.env() == "production" do
+      Envy.auto_load()
+      Envy.reload_config()
     end
 
     setup_dependencies()


### PR DESCRIPTION
This PR fixes #654 

The source of the issue is described in [envy#4](https://github.com/BlakeWilliams/envy/issues/4) and a solution was implemented: [Envy.reload_config](https://github.com/BlakeWilliams/envy#using-envy-in-config).

This is necessary because at the time the config files are loaded, `envy` has not yet loaded the `.env` file. This PR utilizes `Envy.reload_config` to reload the config after the environment has been loaded.