### PR TITLE
Update Use of Dialyzer in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ npm-debug.log
 *.sublime-workspace
 *.sublime-project
 .dialyzer.plt
+.dialyzer.plt.hash
 
 screenshots
 /config/*.secret.exs

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Run `mix test`
 
 ## Static Analysis
 
-Run `mix dialyzer.plt` to build the lookup table for static analysis. Then run
-`mix dialyzer` to run analysis. If your dependencies or your elixir version
-change, delete `.dialyzer.plt` and run `mix dialyzer.plt` to rebuild it.
+Run `mix dialyzer` to run the analysis. The lookup table will be created by this
+process. If your dependencies or your elixir version change, delete
+`.dialyzer.plt` and run `mix dialyzer.plt` to rebuild it.
 
 There are still a lot of warnings that are not fixable, but occasionally some
 real errors are found by dialyzer


### PR DESCRIPTION
When I was running through the Constable setup, I noticed the [Static Analysis](https://github.com/thoughtbot/constable/blob/master/README.md#static-analysis) section of the README, and tried running the Dialyzer. I then noticed there is no longer a task for `mix dialyzer.plt`, and that running `mix dialyzer` creates the `.dialyzer.plt` file. This PR updates the README to remove that initial step.

Additionally, the `.dialyzer.plt.hash` file was created on my local machine, and I felt this does not belong committed to the repo. I also am just learning about Erlang Dialyzer for the first time today, and am not sure if this is the best approach for this file (likewise, I did not want to ignore it via a wildcard/glob). Please let me know what the right approach is, if this file must not be gitignored. 