### PR TITLE
Add Link to Filter by User Having Commented

### DIFF
--- a/lib/constable/models/announcement.ex
+++ b/lib/constable/models/announcement.ex
@@ -53,6 +53,13 @@ defmodule Constable.Announcement do
     |> where([a], a.user_id == ^user_id)
   end
 
+  def with_comments_by_user(query \\ __MODULE__, user_id) do
+    query
+    |> join(:inner, [a], c in assoc(a, :comments))
+    |> join(:inner, [_a, c], u in assoc(c, :user))
+    |> where([_a, c, _u], c.user_id == ^user_id)
+  end
+
   def search(query \\ __MODULE__, search_term, exclude_interests: excludes) do
     search_term = search_term |> prepare_for_tsquery
 

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -17,6 +17,16 @@ defmodule ConstableWeb.AnnouncementController do
     |> render_index(index_page)
   end
 
+  def index(conn, %{"user_id" => user_id, "comments" => "true"} = params) do
+    index_page =
+      announcements_with_user_comments(user_id)
+      |> Repo.paginate(params)
+
+    conn
+    |> assign(:show_all, false)
+    |> render_index(index_page)
+  end
+
   def index(conn, %{"user_id" => user_id} = params) do
     index_page = user_announcements(user_id) |> Repo.paginate(params)
 
@@ -175,6 +185,12 @@ defmodule ConstableWeb.AnnouncementController do
   defp announcements_of_interest(conn) do
     conn.assigns.current_user
     |> Ecto.assoc(:interesting_announcements)
+    |> Announcement.with_announcement_list_assocs()
+    |> Announcement.last_discussed_first()
+  end
+
+  defp announcements_with_user_comments(user_id) do
+    Announcement.with_comments_by_user(user_id)
     |> Announcement.with_announcement_list_assocs()
     |> Announcement.last_discussed_first()
   end

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -17,7 +17,7 @@ defmodule ConstableWeb.AnnouncementController do
     |> render_index(index_page)
   end
 
-  def index(conn, %{"user_id" => user_id, "comments" => "true"} = params) do
+  def index(conn, %{"comment_user_id" => user_id} = params) do
     index_page =
       announcements_with_user_comments(user_id)
       |> Repo.paginate(params)

--- a/lib/constable_web/templates/announcement/index.html.eex
+++ b/lib/constable_web/templates/announcement/index.html.eex
@@ -15,6 +15,17 @@
       class: class_for("your announcements", @conn)
     %>
 
+    <%= link(
+      gettext("Your comments"),
+      to: Routes.announcement_path(
+        @conn,
+        :index,
+        user_id: @current_user.id,
+        comments: true
+      ),
+      class: class_for("your comments", @conn)
+    ) %>
+
     <%= if !@show_all do %>
       <%= link to: Routes.interest_path(@conn, :index),
         data: [role: "view-all-interests"],

--- a/lib/constable_web/templates/announcement/index.html.eex
+++ b/lib/constable_web/templates/announcement/index.html.eex
@@ -20,8 +20,7 @@
       to: Routes.announcement_path(
         @conn,
         :index,
-        user_id: @current_user.id,
-        comments: true
+        comment_user_id: @current_user.id
       ),
       class: class_for("your comments", @conn)
     ) %>

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -25,7 +25,7 @@ defmodule ConstableWeb.AnnouncementView do
 
   def class_for(
     "your comments",
-    conn = %{params: %{"user_id" => id, "comments" => "true"}}
+    conn = %{params: %{"comment_user_id" => id}}
   ) do
     if current_user_same_as_announcements_user?(conn, id) do
       "selected"
@@ -33,6 +33,7 @@ defmodule ConstableWeb.AnnouncementView do
   end
 
   def class_for("your interests", %{params: %{"all" => "true"}}), do: nil
+  def class_for("your interests", %{params: %{"comment_user_id" => _}}), do: nil
   def class_for("your interests", %{params: %{"user_id" => _}}), do: nil
   def class_for("your interests", _), do: "selected"
   def class_for(_, _), do: nil

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -23,6 +23,15 @@ defmodule ConstableWeb.AnnouncementView do
     end
   end
 
+  def class_for(
+    "your comments",
+    conn = %{params: %{"user_id" => id, "comments" => "true"}}
+  ) do
+    if current_user_same_as_announcements_user?(conn, id) do
+      "selected"
+    end
+  end
+
   def class_for("your interests", %{params: %{"all" => "true"}}), do: nil
   def class_for("your interests", %{params: %{"user_id" => _}}), do: nil
   def class_for("your interests", _), do: "selected"

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -31,6 +31,42 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     refute response =~ "Do not show"
   end
 
+  test(
+    "#index shows Annoucements which have User's Comments when user_id and comments params are set",
+    %{conn: conn, user: user}
+  ) do
+    other_user = insert(:user)
+    announcement_with_user_comment =
+      insert(:announcement, title: "FooBar with My Comment", user: other_user)
+    announcement_without_user_comment =
+      insert(:announcement, title: "FizzBuzz without My Comments", user: user)
+    insert(
+      :comment,
+      body: "First! 👋",
+      announcement: announcement_with_user_comment,
+      user: user
+    )
+    insert(
+      :comment,
+      body: "word",
+      announcement: announcement_without_user_comment,
+      user: other_user
+    )
+
+    response =
+      conn
+      |> get(Routes.announcement_path(
+        conn,
+        :index,
+        user_id: user.id,
+        comments: "true"
+      ))
+      |> html_response(:ok)
+
+    assert response =~ "FooBar with My Comment"
+    refute response =~ "FizzBuzz without My Comments"
+  end
+
   test "#index only announcements of interest are shown by default", %{conn: conn, user: user} do
     my_interest = insert(:interest)
     insert(:user_interest, user: user, interest: my_interest)

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -32,7 +32,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
   end
 
   test(
-    "#index shows Annoucements which have User's Comments when user_id and comments params are set",
+    "#index shows Annoucements which have User's Comments when comment_user_id param is set",
     %{conn: conn, user: user}
   ) do
     other_user = insert(:user)
@@ -55,12 +55,7 @@ defmodule ConstableWeb.AnnouncementControllerTest do
 
     response =
       conn
-      |> get(Routes.announcement_path(
-        conn,
-        :index,
-        user_id: user.id,
-        comments: "true"
-      ))
+      |> get(Routes.announcement_path(conn, :index, comment_user_id: user.id))
       |> html_response(:ok)
 
     assert response =~ "FooBar with My Comment"

--- a/test/models/announcement_test.exs
+++ b/test/models/announcement_test.exs
@@ -105,4 +105,29 @@ defmodule Constable.AnnouncementTest do
       refute other_announcement.id in announcement_ids
     end
   end
+
+  describe ".with_comments_by_user/2" do
+    test "returns Announcements on which User has created a Comment" do
+      user = insert(:user)
+      other_user = insert(:user)
+      announcement_without_user_comment = insert(:announcement, user: user)
+      announcement_with_user_comment = insert(:announcement, user: other_user)
+
+      insert(
+        :comment,
+        body: "🐒",
+        announcement: announcement_with_user_comment,
+        user: user
+      )
+
+      announcement_ids =
+        user.id
+        |> Announcement.with_comments_by_user()
+        |> Repo.all()
+        |> Enum.map(& &1.id)
+
+      assert announcement_with_user_comment.id in announcement_ids
+      refute announcement_without_user_comment.id in announcement_ids
+    end
+  end
 end


### PR DESCRIPTION
:guardswoman: Constable Users would like to find old `Announcement` records by
filtering for those containing their own `Comments`. This change adds a
new query, controller action, and a new link to the index template to
facilitate this feature.

:octocat: This satisfies GitHub Issue #461 

:eyes: :desktop_computer: 

<img src="https://user-images.githubusercontent.com/3875361/64657416-20f03f80-d3e8-11e9-82c5-0c5247522ce0.png" height="60%" width="60%" />

:eyes: :iphone: (X)

<img src="https://user-images.githubusercontent.com/3875361/64657425-2a79a780-d3e8-11e9-8372-a4f20f9505b3.png" height="35%" width="35%" />
