### PR TITLE
Remove hashtag from view link

### DIFF
--- a/lib/constable_web/templates/email/author_footer.html.eex
+++ b/lib/constable_web/templates/email/author_footer.html.eex
@@ -14,7 +14,7 @@
   <td align="right">
     <%= link to: announcement_url_for_footer(@announcement, @comment),
       style: "color: #{red()}; font-size: 14px;" do %>
-      <%= gettext("View on #Constable") %>
+      <%= gettext("View on Constable") %>
     <% end %>
   </td>
 </tr>


### PR DESCRIPTION
Follow-up to #698.

This PR changes the email link `View on #Constable` to `View on Constable` so that it is not a hashtag.