### PR TITLE
Add missing alt text to images

### DIFF
--- a/assets/js/user-autocomplete.js
+++ b/assets/js/user-autocomplete.js
@@ -26,7 +26,7 @@ export function autocompleteUsers(selector, users) {
     },
 
     template(user, _term) {
-      return `<img class="tbds-avatar tbds-avatar--circle tbds-avatar--small tbds-margin-inline-end-2" src="${user.gravatar_url}"/> ${user.username}`;
+      return `<img class="tbds-avatar tbds-avatar--circle tbds-avatar--small tbds-margin-inline-end-2" alt="${user.name}" src="${user.gravatar_url}"/> ${user.username}`;
     },
 
     replace(user) {

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -3,7 +3,7 @@
     <img
       class="tbds-avatar tbds-avatar--circle"
       src="<%= gravatar @comment.user %>"
-      alt="Picture of <%= @comment.user.name %>"
+      alt="<%= @comment.user.name %>"
     />
   </div>
 

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -29,7 +29,7 @@
         <img
           src="<%= gravatar @announcement.user %>"
           class="tbds-avatar tbds-avatar--circle"
-          alt="Picture of <%= @announcement.user.name %>"
+          alt="<%= @announcement.user.name %>"
         />
       </div>
       <div class="tbds-media__body">

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -21,10 +21,11 @@
       </div>
 
       <div class="commenters">
-        <%= for gravatar <- user_gravatars(announcement) do %>
+        <%= for commenter <- commenters(announcement) do %>
           <img
             class="commenters__avatar"
-            src="<%= gravatar %>"
+            src="<%= gravatar(commenter) %>"
+            alt="<%= commenter.name %>"
           />
         <% end %>
       </div>

--- a/lib/constable_web/templates/email/author_footer.html.eex
+++ b/lib/constable_web/templates/email/author_footer.html.eex
@@ -3,7 +3,7 @@
     <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;">
       <tr>
         <td width="50" vertical-align="middle">
-          <img alt="avatar" class="avatar" src="<%= author_avatar_url(@author) %>" style="border-radius: 50%;" width="40">
+          <img alt="<%= @author.name %>" class="avatar" src="<%= author_avatar_url(@author) %>" style="border-radius: 50%;" width="40">
         </td>
         <td>
           <%= @author.name %><br>

--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -43,7 +43,7 @@
                   <div style="padding-left: 8px;">
                     <h4><%= link announcement.title, to: Routes.announcement_url(ConstableWeb.Endpoint, :show, announcement), style: "color: #{red()}" %></h4>
                     <p>
-                      <img src="<%= author_avatar_url(announcement.user) %>" class="avatar-rounded">
+                      <img src="<%= author_avatar_url(announcement.user) %>" alt="<%= announcement.user.name %>" class="avatar-rounded">
                       <strong><%= announcement.user.name %></strong>
                       <%= gettext("posted to") %> <%= raw interest_links(announcement) %>
                       <%= time_ago_in_words announcement.inserted_at %>:
@@ -65,7 +65,7 @@
                     <p style="font-weight: normal; font-style: italic;">(Posted by <%= announcement.user.name %> <%= time_ago_in_words announcement.inserted_at %>)</p>
                     <%= for comment <- new_comments(@comments, announcement) do %>
                       <p>
-                        <img src="<%= author_avatar_url(comment.user) %>" class="avatar-rounded">
+                        <img src="<%= author_avatar_url(comment.user) %>" alt="<%= comment.user.name %>" class="avatar-rounded">
                         <strong><%= comment.user.name %></strong> left a comment <%= time_ago_in_words comment.inserted_at %>:
                       </p>
                       <div style="padding-left: 1.85rem;" class="body">

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -40,7 +40,7 @@
         <img
           src="<%= gravatar(@conn.assigns.current_user) %>"
           class="tbds-avatar tbds-avatar--circle"
-          alt="Picture of <%= @conn.assigns.current_user.name %>"
+          alt="<%= @conn.assigns.current_user.name %>"
         />
       <% end %>
       <%= link to: Routes.announcement_path(@conn, :new), class: "tbds-button app-header__announce-button" do %>

--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -4,7 +4,7 @@
     <header>
       <h2>Profile and Settings</h2>
       <a href="#" class="modal-close" data-role="closing-icon">
-        <img src="/images/icon-close.svg" />
+        <img src="/images/icon-close.svg" alt="Close" />
       </a>
     </header>
 
@@ -44,7 +44,7 @@
             <img
               class="tbds-avatar tbds-avatar--circle"
               src="<%= gravatar @current_user %>"
-              alt="Picture of <%= @current_user.name %>"
+              alt="<%= @current_user.name %>"
             />
           </div>
           <label class="tbds-media__body">

--- a/lib/constable_web/templates/user_activation/index.html.eex
+++ b/lib/constable_web/templates/user_activation/index.html.eex
@@ -2,7 +2,7 @@
   <%= for user <- @users do %>
     <div class="user-activations__user">
       <div class="meta">
-        <img class="gravatar" src="<%= gravatar(user) %>"/>
+        <img class="gravatar" src="<%= gravatar(user) %>" alt="<%= user.name %>" />
         <%= user.name %>
       </div>
       <%= link to: Routes.user_activation_path(@conn, :update, user), method: :put do %>

--- a/lib/constable_web/views/announcement_list_view.ex
+++ b/lib/constable_web/views/announcement_list_view.ex
@@ -1,18 +1,9 @@
 defmodule ConstableWeb.AnnouncementListView do
   use ConstableWeb, :view
 
-  def user_gravatars(announcement) do
-    author_gravatar = gravatar(announcement.user)
-    comment_gravatars = commenter_gravatars(announcement)
+  def commenters(announcement) do
+    comment_users = Enum.map(announcement.comments, &(&1.user))
 
-    Enum.uniq([author_gravatar | comment_gravatars])
-  end
-
-  defp commenter_gravatars(%{comments: comments}) do
-    Enum.map(comments, &comment_gravatar/1)
-  end
-
-  defp comment_gravatar(%{user: user}) do
-    gravatar(user)
+    Enum.uniq([announcement.user | comment_users])
   end
 end


### PR DESCRIPTION
This PR fixes #687:
 - Adds missing alt text to all gravatars
 - Adds missing alt test to the close button for the settings modal
 - Removes `Picture of` text from alt text which would be redundant to screen readers