### PR TITLE
Fix spacing in announcement subtext

### DIFF
--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -36,7 +36,7 @@
         <h4><%= link @announcement.user.name, to: Routes.announcement_path(@conn, :index, user_id: @announcement.user_id), class: "author" %></h4>
 
         <div class="announcement-metadata">
-          <%= gettext "announced" %>
+          <%= gettext "announced " %>
           <%= relative_timestamp(@announcement.inserted_at) %>
         </div>
       </div>

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -8,7 +8,7 @@
       <% end %>
 
       <div class="announcement-metadata">
-        <%= gettext "announced" %>
+        <%= gettext "announced " %>
         <%= relative_timestamp(announcement.inserted_at) %>
         to
         <span>


### PR DESCRIPTION
This PR fixed #473 

## Before
<img width="541" alt="Image 2019-09-11 at 10 02 08 PM" src="https://user-images.githubusercontent.com/342826/64748478-524c3680-d4e0-11e9-9e99-ffb3804f18ea.png">


## After
<img width="526" alt="Image 2019-09-11 at 10 06 03 PM" src="https://user-images.githubusercontent.com/342826/64748492-5b3d0800-d4e0-11e9-9d7b-c3ace10d4ab7.png">
