### PR TITLE
Adds a skip to main content link for screen readers

### DIFF
--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -21,7 +21,7 @@
     <script src="<%= Application.fetch_env!(:constable, :shubox_script_url) %>"></script>
   </head>
   <body>
-  <a class="tbds-skip-link" href="#main">Skip to main content</a>
+    <a class="tbds-skip-link" href="#main">Skip to main content</a>
     <header class="app-header links-no-underline">
       <%= link "Constable", to: "/", class: "app-header__logo" %>
 

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -21,6 +21,7 @@
     <script src="<%= Application.fetch_env!(:constable, :shubox_script_url) %>"></script>
   </head>
   <body>
+  <a class="tbds-skip-link" href="#main">Skip to main content</a>
     <header class="app-header links-no-underline">
       <%= link "Constable", to: "/", class: "app-header__logo" %>
 


### PR DESCRIPTION
This PR fixes #686:
 - Adds `tbds` skip link to main content container