### PR TITLE
Make sure switches don't get squished on small screens

### DIFF
--- a/assets/css/components/_toggle.scss
+++ b/assets/css/components/_toggle.scss
@@ -1,8 +1,8 @@
 .onoffswitch {
   margin-right: $small-spacing;
+  min-width: 65px;
   position: relative;
   user-select: none;
-  width: 60px;
 }
 
 .onoffswitch-checkbox {
@@ -42,7 +42,7 @@
   box-shadow: inset 0 1px 3px 0 rgba(121, 0, 0, 0.5);
   color: $white;
   content: "ON";
-  padding-left: $tiny-spacing;
+  padding-left: $tiniest-spacing;
 }
 
 .onoffswitch-inner::after {
@@ -50,7 +50,7 @@
   box-shadow: $form-box-shadow;
   color: $tbds-brand-red;
   content: "OFF";
-  padding-right: $tiny-spacing;
+  padding-right: $tiniest-spacing;
   text-align: right;
 }
 
@@ -60,7 +60,7 @@
   background-color: $white;
   border-radius: $base-border-radius;
   display: block;
-  margin-right: 4px;
+  margin-right: 6px;
   transition: all 0.3s ease-in 0s;
 }
 


### PR DESCRIPTION
This PR fixes #681:
 - Ensures that switches don't get squished on small screens
 - Fixes minor alignment / padding issues on switches

## Before
<img width="295" alt="Image 2019-09-11 at 11 27 03 PM" src="https://user-images.githubusercontent.com/342826/64751859-985ac780-d4eb-11e9-804a-35a7e1205eb2.png">

## After
<img width="295" alt="Image 2019-09-11 at 11 27 03 PM" src="https://user-images.githubusercontent.com/342826/64751886-adcff180-d4eb-11e9-960b-6505da22c64d.png">