### PR TITLE
Add missing labels to form elements

### DIFF
--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -13,7 +13,7 @@
   </nav>
   <div class="col-markdown announcement-create active">
     <div class="announcement-form">
-      <%= label f, :title, "Announcement title:" %>
+      <%= label f, :title, "Announcement title" %>
       <%= text_input f, :title, placeholder: gettext("What are you announcing?") %>
 
       <section class="recipients-preview">

--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -13,6 +13,7 @@
   </nav>
   <div class="col-markdown announcement-create active">
     <div class="announcement-form">
+      <%= label f, :title, "Announcement title:" %>
       <%= text_input f, :title, placeholder: gettext("What are you announcing?") %>
 
       <section class="recipients-preview">
@@ -20,6 +21,7 @@
       </section>
       <%= text_input :announcement, :interests, value: comma_separated_interest_names(@changeset.data.interests), placeholder: gettext("Interests") %>
 
+      <%= label f, :body, "Announcement body:" %>
       <%= textarea f,
         :body,
         placeholder: gettext("Write markdown here. You can @mention specific people to notify them"),

--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -21,10 +21,10 @@
       </section>
       <%= text_input :announcement, :interests, value: comma_separated_interest_names(@changeset.data.interests), placeholder: gettext("Interests") %>
 
-      <%= label f, :body, "Announcement body:" %>
+      <%= label f, :body, "Announcement body" %>
       <%= textarea f,
         :body,
-        placeholder: gettext("Write markdown here. You can @mention specific people to notify them"),
+        placeholder: gettext("Markdown is supported. You can @mention specific people to notify them."),
         class: "uploadable-input"
         %>
     </div>

--- a/lib/constable_web/templates/comment/_form.html.eex
+++ b/lib/constable_web/templates/comment/_form.html.eex
@@ -3,7 +3,7 @@
   <%= textarea f,
     :body,
     class: "comment-textarea mousetrap uploadable-input",
-    placeholder: gettext("Write markdown here. You can @mention specific people to notify them"),
+    placeholder: gettext("Markdown is supported. You can @mention specific people to notify them."),
     required: true
   %>
 

--- a/lib/constable_web/templates/comment/_form.html.eex
+++ b/lib/constable_web/templates/comment/_form.html.eex
@@ -1,8 +1,9 @@
 <%= form_for @comment_changeset, @path, [class: "comment-form"], fn(f) -> %>
+  <%= label f, :body, "Comment on this announcement:" %>
   <%= textarea f,
     :body,
     class: "comment-textarea mousetrap uploadable-input",
-    placeholder: gettext("Your markdown formatted comment here"),
+    placeholder: gettext("Write markdown here. You can @mention specific people to notify them"),
     required: true
   %>
 

--- a/lib/constable_web/templates/comment/_form.html.eex
+++ b/lib/constable_web/templates/comment/_form.html.eex
@@ -1,5 +1,5 @@
 <%= form_for @comment_changeset, @path, [class: "comment-form"], fn(f) -> %>
-  <%= label f, :body, "Comment on this announcement:" %>
+  <%= label f, :body, "Comment on this announcement" %>
   <%= textarea f,
     :body,
     class: "comment-textarea mousetrap uploadable-input",

--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -11,7 +11,7 @@
     <div class="modal-body">
       <%= form_for @changeset, Routes.settings_path(@conn, :update), [class: "tbds-block-stack tbds-block-stack--gap-5 settings-form"], fn(f) -> %>
         <div class="tbds-block-stack__item">
-          <label>Your name:</label>
+          <%= label f, :name, "Your name:" %>
           <%= text_input f, :name %>
           <%= error_tag f, :name %>
         </div>

--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -11,7 +11,7 @@
     <div class="modal-body">
       <%= form_for @changeset, Routes.settings_path(@conn, :update), [class: "tbds-block-stack tbds-block-stack--gap-5 settings-form"], fn(f) -> %>
         <div class="tbds-block-stack__item">
-          <%= label f, :name, "Your name:" %>
+          <%= label f, :name, "Your name" %>
           <%= text_input f, :name %>
           <%= error_tag f, :name %>
         </div>

--- a/lib/constable_web/templates/slack_channel/edit.html.eex
+++ b/lib/constable_web/templates/slack_channel/edit.html.eex
@@ -8,7 +8,7 @@
 
     <div class="current-channel">
       <%= form_for @changeset, Routes.interest_slack_channel_path(@conn, :update, @interest), fn f -> %>
-        <%= label f, :slack_channel, "Name of the Slack channel" %>
+        <%= label f, :slack_channel, "Slack channel name" %>
         <%= text_input f, :slack_channel, placeholder: gettext("e.g. #everyone") %>
         <%= submit gettext("Save Slack Channel"), id: "submit-channel-name", class: "tbds-button" %>
       <% end %>

--- a/lib/constable_web/templates/slack_channel/edit.html.eex
+++ b/lib/constable_web/templates/slack_channel/edit.html.eex
@@ -8,7 +8,8 @@
 
     <div class="current-channel">
       <%= form_for @changeset, Routes.interest_slack_channel_path(@conn, :update, @interest), fn f -> %>
-        <%= text_input f, :slack_channel, placeholder: gettext("Name of the Slack channel, e.g. #everyone") %>
+        <%= label f, :slack_channel, "Name of the Slack channel" %>
+        <%= text_input f, :slack_channel, placeholder: gettext("e.g. #everyone") %>
         <%= submit gettext("Save Slack Channel"), id: "submit-channel-name", class: "tbds-button" %>
       <% end %>
 


### PR DESCRIPTION
This PR fixes #684 (with the caveat that addressing Selectize.js inputs has been split out into #724).

## Fixes in this PR:
 - Added labels to:
   - Name input in Profile and Settings
   - Comment input on announcement show page
   - Title input on new announcement page
   -  Body input on new announcement page
   - Slack channel input
 - Updates some placeholders that were duplicative once the labels were in place

## Follow-ups:
 - Interests input on new announcement page: #724 
 - On/Off switches are not accessible: #723