### PR TITLE
Improve comments area empty state

### DIFF
--- a/assets/css/components/_comments.scss
+++ b/assets/css/components/_comments.scss
@@ -1,6 +1,6 @@
 .comments-placeholder {
-  display: none;
   color: #999;
+  display: none;
   font-size: 1.3rem;
   text-align: center;
 }

--- a/assets/css/components/_comments.scss
+++ b/assets/css/components/_comments.scss
@@ -1,3 +1,14 @@
+.comments-placeholder {
+  display: none;
+  color: #999;
+  font-size: 1.3rem;
+  text-align: center;
+}
+
+.comments-placeholder:only-child {
+  display: block;
+}
+
 .edit-comment {
   font-size: $tiny-font-size;
   margin-left: $tiniest-spacing;

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -70,6 +70,9 @@
 
   <h4 class="tbds-margin-block-end-6"><%= gettext "Comments" %></h4>
   <ul class="tbds-block-stack tbds-block-stack--bordered tbds-block-stack--gap-6 comments-list">
+    <li class="comments-placeholder">
+      No one has commented on this announcement yet.<br />You could be the first!
+    </li>
     <%= for comment <- @announcement.comments do %>
       <%= render "_comment.html", comment: comment, conn: @conn, current_user: @current_user %>
     <% end %>

--- a/test/acceptance/new_comment_test.exs
+++ b/test/acceptance/new_comment_test.exs
@@ -2,7 +2,7 @@ defmodule ConstableWeb.NewCommentTest do
   use ConstableWeb.AcceptanceCase
 
   test "new comments are displayed in real time", %{session: session} do
-    {:ok, other_session} = Wallaby.start_session
+    {:ok, other_session} = Wallaby.start_session()
     [announcement, other_announcement] = insert_pair(:announcement)
     user = insert(:user)
 
@@ -15,6 +15,7 @@ defmodule ConstableWeb.NewCommentTest do
     |> visit(Routes.announcement_path(Endpoint, :show, other_announcement, as: user.id))
 
     assert has_comment_text?(session, "My Cool Comment")
+    refute has_comments_placeholder?(session)
     refute has_comment_text?(other_session, "My Cool Comment")
   end
 
@@ -22,5 +23,11 @@ defmodule ConstableWeb.NewCommentTest do
     session
     |> find(css(".comments-list"))
     |> has_text?(comment_text)
+  end
+
+  defp has_comments_placeholder?(session) do
+    session
+    |> all(css(".comments-placeholder"))
+    |> List.first()
   end
 end

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -18,6 +18,7 @@ defmodule ConstableWeb.UserAnnouncementTest do
     assert has_announcement_title?(session, "Hello World ❤️")
     assert has_announcement_body?(session, "Hello")
     assert has_announcement_interest?(session, "everyone")
+    assert has_comments_placeholder?(session)
   end
 
   test "user previews who will receive an announcement", %{session: session} do
@@ -105,6 +106,11 @@ defmodule ConstableWeb.UserAnnouncementTest do
     session
     |> find(css("[data-role=interests]"))
     |> has_text?(text)
+  end
+
+  defp has_comments_placeholder?(session) do
+    session
+    |> find(css(".comments-list"))
   end
 
   defp has_recipient_preview?(session, user_names) do


### PR DESCRIPTION
This PR fixes #682 by improving the comments empty state.

I would love feedback on what message we would like to display here.

<img width="665" alt="Image 2019-09-12 at 9 37 36 PM" src="https://user-images.githubusercontent.com/342826/64831900-b4bb3a80-d5a5-11e9-91e3-b5ead2713f40.png">
