### PR TITLE
Add `height` and `width` attributes to images

### DIFF
--- a/assets/js/user-autocomplete.js
+++ b/assets/js/user-autocomplete.js
@@ -26,7 +26,7 @@ export function autocompleteUsers(selector, users) {
     },
 
     template(user, _term) {
-      return `<img class="tbds-avatar tbds-avatar--circle tbds-avatar--small tbds-margin-inline-end-2" alt="${user.name}" src="${user.gravatar_url}"/> ${user.username}`;
+      return `<img class="tbds-avatar tbds-avatar--circle tbds-avatar--small tbds-margin-inline-end-2" alt="${user.name}" src="${user.gravatar_url}" height="80" width="80"/> ${user.username}`;
     },
 
     replace(user) {

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -1,10 +1,12 @@
 <li class="tbds-media tbds-block-stack__item" id="comment-<%= @comment.id %>">
   <div class="tbds-media__figure comment-information">
     <img
-      class="tbds-avatar tbds-avatar--circle"
-      src="<%= gravatar @comment.user %>"
       alt="<%= @comment.user.name %>"
-    />
+      class="tbds-avatar tbds-avatar--circle"
+      height="80"
+      src="<%= gravatar @comment.user %>"
+      width="80"
+    >
   </div>
 
   <div class="tbds-media__body">

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -27,10 +27,12 @@
     <div class="tbds-media tbds-media--block-center">
       <div class="tbds-media__figure tbds-line-height-0">
         <img
-          src="<%= gravatar @announcement.user %>"
-          class="tbds-avatar tbds-avatar--circle"
           alt="<%= @announcement.user.name %>"
-        />
+          class="tbds-avatar tbds-avatar--circle"
+          height="80"
+          src="<%= gravatar @announcement.user %>"
+          width="80"
+        >
       </div>
       <div class="tbds-media__body">
         <h4><%= link @announcement.user.name, to: Routes.announcement_path(@conn, :index, user_id: @announcement.user_id), class: "author" %></h4>

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -23,10 +23,12 @@
       <div class="commenters">
         <%= for commenter <- commenters(announcement) do %>
           <img
-            class="commenters__avatar"
-            src="<%= gravatar(commenter) %>"
             alt="<%= commenter.name %>"
-          />
+            class="commenters__avatar"
+            height="80"
+            src="<%= gravatar(commenter) %>"
+            width="80"
+          >
         <% end %>
       </div>
     </li>

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -38,10 +38,12 @@
 
       <%= link to: Routes.settings_path(@conn, :show), class: "app-header__user-avatar remote-append tbds-line-height-0", data: [role: "settings-link"] do %>
         <img
-          src="<%= gravatar(@conn.assigns.current_user) %>"
-          class="tbds-avatar tbds-avatar--circle"
           alt="<%= @conn.assigns.current_user.name %>"
-        />
+          class="tbds-avatar tbds-avatar--circle"
+          height="80"
+          src="<%= gravatar(@conn.assigns.current_user) %>"
+          width="80"
+        >
       <% end %>
       <%= link to: Routes.announcement_path(@conn, :new), class: "tbds-button app-header__announce-button" do %>
         <svg class="tbds-button__icon tbds-button__icon--start">

--- a/lib/constable_web/templates/user_activation/index.html.eex
+++ b/lib/constable_web/templates/user_activation/index.html.eex
@@ -2,7 +2,13 @@
   <%= for user <- @users do %>
     <div class="user-activations__user">
       <div class="meta">
-        <img class="gravatar" src="<%= gravatar(user) %>" alt="<%= user.name %>" />
+        <img
+          alt="<%= user.name %>"
+          class="gravatar"
+          height="80"
+          src="<%= gravatar(user) %>"
+          width="80"
+        >
         <%= user.name %>
       </div>
       <%= link to: Routes.user_activation_path(@conn, :update, user), method: :put do %>


### PR DESCRIPTION
By defining an image's intrinsic size via `height` and `width`
attributes, the browser can better stabilize layout rendering.

No visual changes.