### PR TITLE
Improve interests link and page

### DIFF
--- a/lib/constable_web/templates/announcement/index.html.eex
+++ b/lib/constable_web/templates/announcement/index.html.eex
@@ -30,10 +30,9 @@
         data: [role: "view-all-interests"],
         class: "tabs__link--push" do %>
         <%= dngettext("interest-count",
-          "Subscribed to 1 interest",
-          "Subscribed to %{count} interests",
+          "View interests (%{count} subscription)",
+          "View interests (%{count} subscriptions)",
           interest_count_for(@current_user)) %>
-        <%= gettext " (edit)" %>
       <% end %>
     <% end %>
   </nav>

--- a/lib/constable_web/templates/interest/index.html.eex
+++ b/lib/constable_web/templates/interest/index.html.eex
@@ -1,6 +1,11 @@
 <div class="interests container container-pad-top">
   <h1><%= gettext "Interests" %></h1>
-
+  <p>
+    <%= dngettext("interest-count",
+        "You are subscribed to %{count} interest.",
+        "You are subscribed to %{count} interests.",
+        interest_count_for(@current_user)) %>
+  </p>
   <ul class="tbds-block-stack tbds-block-stack--bordered tbds-block-stack--gap-5 interests-list">
     <%= for interest <- @interests do %>
       <li class="tbds-block-stack__item interest-list-item">

--- a/lib/constable_web/views/announcement_view.ex
+++ b/lib/constable_web/views/announcement_view.ex
@@ -24,9 +24,9 @@ defmodule ConstableWeb.AnnouncementView do
   end
 
   def class_for(
-    "your comments",
-    conn = %{params: %{"comment_user_id" => id}}
-  ) do
+        "your comments",
+        conn = %{params: %{"comment_user_id" => id}}
+      ) do
     if current_user_same_as_announcements_user?(conn, id) do
       "selected"
     end

--- a/lib/constable_web/views/interest_view.ex
+++ b/lib/constable_web/views/interest_view.ex
@@ -2,4 +2,8 @@ defmodule ConstableWeb.InterestView do
   use ConstableWeb, :view
 
   import Constable.User, only: [interested_in?: 2]
+
+  def interest_count_for(user) do
+    length(user.interests)
+  end
 end


### PR DESCRIPTION
Fixes #690.

## In this PR
 - Updates the interest link text to be less confusing
 - Adds the number of subscribed interests to the top of the interests list

I would love suggestions on the wording of the link text and text on the interests page.

## Screenshots

<details>
    <summary>Interests link</summary>

    
![Image 2019-09-20 at 3 53 36 PM](https://user-images.githubusercontent.com/342826/65355092-248d7e80-dbbf-11e9-896b-152a25bffc6d.png)


</details>

<details>
    <summary>Interests page</summary>

    
![Image 2019-09-20 at 3 53 44 PM](https://user-images.githubusercontent.com/342826/65355106-2eaf7d00-dbbf-11e9-963f-5487bdae125a.png)


</details>