### PR TITLE
Adjust viewport and content padding

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -22,6 +22,7 @@
 @import "components/announcement-form";
 @import "components/announcements";
 @import "components/app-header";
+@import "components/app-main";
 @import "components/at-mention";
 @import "components/box";
 @import "components/checkbox-switch";

--- a/assets/css/components/_app-header.scss
+++ b/assets/css/components/_app-header.scss
@@ -5,7 +5,10 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: $small-spacing;
+  padding: $small-spacing
+    calc(#{$base-spacing} + env(safe-area-inset-right))
+    $small-spacing
+    calc(#{$base-spacing} + env(safe-area-inset-left));
 
   @media (min-width: $breakpoint-1) {
     padding: $small-spacing $base-spacing;

--- a/assets/css/components/_app-main.scss
+++ b/assets/css/components/_app-main.scss
@@ -1,0 +1,6 @@
+.app-main {
+  padding: 0
+    calc(#{$tiniest-spacing} + env(safe-area-inset-right))
+    calc(#{$tiniest-spacing} + env(safe-area-inset-bottom))
+    calc(#{$tiniest-spacing} + env(safe-area-inset-left));
+}

--- a/assets/css/elements/_layout.scss
+++ b/assets/css/elements/_layout.scss
@@ -1,16 +1,22 @@
 html {
   box-sizing: border-box;
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  min-height: 100%;
+}
+
+main {
+  padding: 0
+    calc(#{$tiniest-spacing} + env(safe-area-inset-right))
+    calc(#{$tiniest-spacing} + env(safe-area-inset-bottom))
+    calc(#{$tiniest-spacing} + env(safe-area-inset-left));
 }
 
 *,
 *::before,
 *::after {
   box-sizing: inherit;
-}
-
-html,
-body {
-  height: 100%;
-  min-height: 100vh;
-  width: 100%;
 }

--- a/assets/css/elements/_layout.scss
+++ b/assets/css/elements/_layout.scss
@@ -1,11 +1,5 @@
 html {
   box-sizing: border-box;
-  height: 100%;
-  width: 100%;
-}
-
-body {
-  min-height: 100%;
 }
 
 main {

--- a/assets/css/elements/_layout.scss
+++ b/assets/css/elements/_layout.scss
@@ -2,13 +2,6 @@ html {
   box-sizing: border-box;
 }
 
-main {
-  padding: 0
-    calc(#{$tiniest-spacing} + env(safe-area-inset-right))
-    calc(#{$tiniest-spacing} + env(safe-area-inset-bottom))
-    calc(#{$tiniest-spacing} + env(safe-area-inset-left));
-}
-
 *,
 *::before,
 *::after {

--- a/lib/constable_web/templates/layout/_content_container.html.eex
+++ b/lib/constable_web/templates/layout/_content_container.html.eex
@@ -1,3 +1,3 @@
-<main id="main" class="tbds-app-frame__body">
+<main id="main" class="app-main tbds-app-frame__body">
   <%= @contents %>
 </main>

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1 viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title><%= title(assigns) %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1 viewport-fit=cover">
     <title><%= title(assigns) %></title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/lib/constable_web/templates/session/_content_container.html.eex
+++ b/lib/constable_web/templates/session/_content_container.html.eex
@@ -1,3 +1,3 @@
-<main id="main" class="tbds-app-frame__body tbds-app-frame__body--center-items">
+<main id="main" class="app-main tbds-app-frame__body tbds-app-frame__body--center-items">
   <%= @contents %>
 </main>


### PR DESCRIPTION
Fixes #679

## This PR
 - Sets the viewport meta tag `viewport-fit` to `cover` so that devices with "safe areas" display content in the safe areas
 - Adds a base padding to the `main` content area
 - Adds "safe inset" padding to `main` and `header` so that page content stays visible outside of safe areas

## Screenshots

<details>
    <summary>Portrait Top</summary>

    
<img width="606" alt="Image 2019-09-21 at 3 18 12 PM" src="https://user-images.githubusercontent.com/342826/65378237-bc54a080-dc83-11e9-908a-194e4bb26226.png">


</details>

<details>
    <summary>Portrait Bottom</summary>

    
<img width="606" alt="Image 2019-09-21 at 3 18 16 PM" src="https://user-images.githubusercontent.com/342826/65378239-c1b1eb00-dc83-11e9-90a3-0dd135d3ef69.png">


</details>

<details>
    <summary>Landscape top</summary>

    
<img width="1091" alt="Image 2019-09-21 at 3 18 23 PM" src="https://user-images.githubusercontent.com/342826/65378242-c6769f00-dc83-11e9-8ada-586e0efb19cc.png">


</details>

<details>
    <summary>Landscape bottom</summary>

    
<img width="1091" alt="Image 2019-09-21 at 3 18 27 PM" src="https://user-images.githubusercontent.com/342826/65378244-cb3b5300-dc83-11e9-8fb4-1a81cebfc25e.png">


</details>