### PR TITLE
Add responsive styles to announcement subscribe button

### DIFF
--- a/assets/css/components/_announcements.scss
+++ b/assets/css/components/_announcements.scss
@@ -33,7 +33,7 @@
   flex-wrap: wrap;
   font-size: $small-font-size;
 
-  > * {
+  .announcement-metadata-item {
     flex: 1 0 auto;
   }
 

--- a/assets/css/components/_announcements.scss
+++ b/assets/css/components/_announcements.scss
@@ -22,9 +22,20 @@
   }
 }
 
-.announcement-metadata {
+.announcement-list-item-metadata {
   color: $secondary-font-color;
   font-size: $small-font-size;
+}
+
+.announcement-metadata-container {
+  color: $secondary-font-color;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: $small-font-size;
+
+  > * {
+    flex: 1 0 auto;
+  }
 
   .author {
     color: $base-font-color;
@@ -32,6 +43,7 @@
 
   .subscription {
     @include margin($small-spacing 0);
+    margin-left: 1rem;
   }
 }
 

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -64,7 +64,7 @@
           <svg class="tbds-button__icon tbds-button__icon--start">
             <use xlink:href="/images/icons.svg#plus"></use>
           </svg>
-          <%= gettext("Subscribe to thread") %>
+          <%= gettext("Subscribe to announcement") %>
         <% end %>
       <% end %>
     </div>

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -27,7 +27,7 @@
     <% end %>
   </h1>
 
-  <div class="announcement-metadata">
+  <div class="announcement-metadata-container">
     <div class="tbds-media tbds-media--block-center">
       <div class="tbds-media__figure tbds-line-height-0">
         <img
@@ -46,27 +46,27 @@
           <%= relative_timestamp(@announcement.inserted_at) %>
         </div>
       </div>
-      <div class="subscription">
-        <%= if @subscription do %>
-          <%= link to: Routes.announcement_subscription_path(@conn, :delete, @announcement),
-            method: :delete,
-            class: "tbds-button button-secondary" do %>
-            <svg class="tbds-button__icon tbds-button__icon--start">
-              <use xlink:href="/images/icons.svg#check"></use>
-            </svg>
-            <%= gettext("Subscribed to thread") %>
-          <% end %>
-        <% else %>
-          <%= link to: Routes.announcement_subscription_path(@conn, :create, @announcement),
-            method: :post,
-            class: "tbds-button button-secondary" do %>
-            <svg class="tbds-button__icon tbds-button__icon--start">
-              <use xlink:href="/images/icons.svg#plus"></use>
-            </svg>
-            <%= gettext("Subscribe to thread") %>
-          <% end %>
+    </div>
+    <div class="subscription">
+      <%= if @subscription do %>
+        <%= link to: Routes.announcement_subscription_path(@conn, :delete, @announcement),
+          method: :delete,
+          class: "tbds-button button-secondary" do %>
+          <svg class="tbds-button__icon tbds-button__icon--start">
+            <use xlink:href="/images/icons.svg#check"></use>
+          </svg>
+          <%= gettext("Subscribed to thread") %>
         <% end %>
-      </div>
+      <% else %>
+        <%= link to: Routes.announcement_subscription_path(@conn, :create, @announcement),
+          method: :post,
+          class: "tbds-button button-secondary" do %>
+          <svg class="tbds-button__icon tbds-button__icon--start">
+            <use xlink:href="/images/icons.svg#plus"></use>
+          </svg>
+          <%= gettext("Subscribe to thread") %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -28,7 +28,7 @@
   </h1>
 
   <div class="announcement-metadata-container">
-    <div class="tbds-media tbds-media--block-center">
+    <div class="announcement-metadata-item tbds-media tbds-media--block-center">
       <div class="tbds-media__figure tbds-line-height-0">
         <img
           alt="<%= @announcement.user.name %>"
@@ -47,7 +47,7 @@
         </div>
       </div>
     </div>
-    <div class="subscription">
+    <div class="announcement-metadata-item subscription">
       <%= if @subscription do %>
         <%= link to: Routes.announcement_subscription_path(@conn, :delete, @announcement),
           method: :delete,

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -7,7 +7,7 @@
         </h1>
       <% end %>
 
-      <div class="announcement-metadata">
+      <div class="announcement-list-item-metadata">
         <%= gettext "announced " %>
         <%= relative_timestamp(announcement.inserted_at) %>
         to


### PR DESCRIPTION
Fixes #678.

Adds responsive styles to the announcement subscribe button so that it doesn't squish the author.

<details>
    <summary>Portrait</summary>

    
<img width="606" alt="Image 2019-09-21 at 4 00 17 PM" src="https://user-images.githubusercontent.com/342826/65378636-53702700-dc89-11e9-87f8-e81591181132.png">



</details>

<details>
    <summary>Landscape</summary>

   
<img width="1091" alt="Image 2019-09-21 at 4 00 28 PM" src="https://user-images.githubusercontent.com/342826/65378638-566b1780-dc89-11e9-9574-831b1492ebda.png">

</details>