### PR TITLE
Fix layout in Safari

### DIFF
--- a/assets/css/_shims.scss
+++ b/assets/css/_shims.scss
@@ -29,3 +29,7 @@
     }
   }
 }
+
+.tbds-app-frame__header {
+  flex-shrink: 0;
+}

--- a/lib/constable_web/templates/layout/_header.html.eex
+++ b/lib/constable_web/templates/layout/_header.html.eex
@@ -1,5 +1,5 @@
 <a class="tbds-skip-link" href="#main">Skip to main content</a>
-<header class="app-header links-no-underline">
+<header class="tbds-app-frame__header app-header links-no-underline">
   <%= link "Constable", to: "/", class: "app-header__logo" %>
 
   <%= form_tag Routes.search_path(@conn, :show), class: "tbds-form app-header__search-form", method: :get do %>


### PR DESCRIPTION
This bug was caused by two things:

1. In [5fda1a4] we started using `tbds-app-frame` but the header didn't
   get the `tbds-app-frame__header` class.
1. tbds has a bug in that `tbds-app-frame__header` doesn't have
   `flex-shrink` disabled. A future release of tbds will fix this; for
   not I've shimmed this fix in this project.

Fixes https://github.com/thoughtbot/constable/issues/756

[5fda1a4]: https://github.com/thoughtbot/constable/commit/5fda1a46db588bffb81efca6d090e09812c0a569

## Before

![Screen Shot 2019-09-24 at 10 06 13](https://user-images.githubusercontent.com/903327/65518857-f9eb4080-deb2-11e9-8f87-f50ecfb1662a.png)

## After

![Screen Shot 2019-09-24 at 10 06 00](https://user-images.githubusercontent.com/903327/65518866-fbb50400-deb2-11e9-8010-6b53a89b12df.png)
