### PR TITLE
Normalize email avatar image styling

### DIFF
--- a/lib/constable_web/templates/email/author_footer.html.eex
+++ b/lib/constable_web/templates/email/author_footer.html.eex
@@ -3,7 +3,7 @@
     <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;">
       <tr>
         <td width="50" vertical-align="middle">
-          <img alt="<%= @author.name %>" class="avatar" src="<%= profile_image_url(@author) %>" style="border-radius: 50%;" width="40">
+          <img alt="<%= @author.name %>" class="avatar-rounded avatar-large" src="<%= profile_image_url(@author) %>">
         </td>
         <td>
           <%= @author.name %><br>

--- a/lib/constable_web/templates/email/daily_digest.html.eex
+++ b/lib/constable_web/templates/email/daily_digest.html.eex
@@ -43,7 +43,7 @@
                   <div style="padding-left: 8px;">
                     <h4><%= link announcement.title, to: Routes.announcement_url(ConstableWeb.Endpoint, :show, announcement), style: "color: #{red()}" %></h4>
                     <p>
-                      <img src="<%= profile_image_url(announcement.user) %>" alt="<%= announcement.user.name %>" class="avatar-rounded">
+                      <img src="<%= profile_image_url(announcement.user) %>" alt="<%= announcement.user.name %>" class="avatar-rounded avatar-small avatar-inline">
                       <strong><%= announcement.user.name %></strong>
                       <%= gettext("posted to") %> <%= raw interest_links(announcement) %>
                       <%= time_ago_in_words announcement.inserted_at %>:
@@ -65,7 +65,7 @@
                     <p style="font-weight: normal; font-style: italic;">(Posted by <%= announcement.user.name %> <%= time_ago_in_words announcement.inserted_at %>)</p>
                     <%= for comment <- new_comments(@comments, announcement) do %>
                       <p>
-                        <img src="<%= profile_image_url(comment.user) %>" alt="<%= comment.user.name %>" class="avatar-rounded">
+                        <img src="<%= profile_image_url(comment.user) %>" alt="<%= comment.user.name %>" class="avatar-rounded avatar-small avatar-inline">
                         <strong><%= comment.user.name %></strong> left a comment <%= time_ago_in_words comment.inserted_at %>:
                       </p>
                       <div style="padding-left: 1.85rem;" class="body">

--- a/lib/constable_web/templates/email/new_comment.html.eex
+++ b/lib/constable_web/templates/email/new_comment.html.eex
@@ -16,6 +16,8 @@
     <tr>
       <td colspan="2" height="35"></td>
     </tr>
+  </table>
+  <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;" width="600">
     <%= render "author_footer.html", author: @author, announcement: @announcement, comment: @comment %>
     <%= render "unsubscribe_footer.html" %>
     <tr>

--- a/lib/constable_web/templates/layout/_styles.html.eex
+++ b/lib/constable_web/templates/layout/_styles.html.eex
@@ -24,10 +24,26 @@
   }
 
   .avatar-rounded {
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .avatar-large {
+    height: 40px;
+    width: 40px;
+    border-radius: 50%;
+  }
+
+  .avatar-small {
     height: 20px;
     width: 20px;
     border-radius: 50%;
-    margin-right: 0.3rem;
+  }
+
+  .avatar-inline {
+    display: inline;
+    vertical-align: middle;
+    margin-right: 0 0.3em;
   }
 
   /* Contains content images */


### PR DESCRIPTION
Fixes #759.

It was possible for images that were not square to end up being inconsistent sizes. The styling of avatar images for post and comment emails were also different, causing inconsistencies.

## After:
![Image 2019-09-27 at 10 34 38 AM](https://user-images.githubusercontent.com/342826/65779931-b133c180-e116-11e9-877b-f093f5ab7b21.png)
