### PR TITLE
Prefix default image URL with the endpoint URL

### DIFF
--- a/lib/constable/services/fake_profile_provider.ex
+++ b/lib/constable/services/fake_profile_provider.ex
@@ -1,4 +1,5 @@
 defmodule FakeProfileProvider do
+  alias ConstableWeb.Endpoint
   alias Constable.Services.ProfileProvider
   @behaviour ProfileProvider
 
@@ -9,6 +10,6 @@ defmodule FakeProfileProvider do
 
   @impl ProfileProvider
   def image_url(_user) do
-    "/images/ralph.png"
+    "#{Endpoint.url()}/images/ralph.png"
   end
 end

--- a/lib/constable/services/hub_profile_provider.ex
+++ b/lib/constable/services/hub_profile_provider.ex
@@ -1,9 +1,10 @@
 defmodule Constable.Services.HubProfileProvider do
+  alias ConstableWeb.Endpoint
   alias Constable.Services.ProfileProvider
   @behaviour ProfileProvider
   use Memoize
 
-  @default_image_url "/images/ralph.png"
+  @default_image_path "/images/ralph.png"
 
   @impl ProfileProvider
   defmemo profile_url(user) do
@@ -17,7 +18,7 @@ defmodule Constable.Services.HubProfileProvider do
         image_url
 
       _ ->
-        @default_image_url
+        "#{Endpoint.url()}#{@default_image_path}"
     end
   end
 


### PR DESCRIPTION
Fixes #761. 

Prefixing the endpoint URL to the default image URL (e.g. `/images/ralph.png` becomes `http://.../images/ralph.png`) allows the image to resolve correctly in emails.