### PR TITLE
Consistently render Interests as badges

### DIFF
--- a/assets/css/_shims.scss
+++ b/assets/css/_shims.scss
@@ -33,3 +33,8 @@
 .tbds-app-frame__header {
   flex-shrink: 0;
 }
+
+.tbds-badge {
+  font-size: inherit;
+  font-weight: inherit;
+}

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -38,4 +38,6 @@
 
 @import "scopes/links-no-underline";
 
+@import "utilities/font-size";
+
 @import "shims";

--- a/assets/css/utilities/_font-size.scss
+++ b/assets/css/utilities/_font-size.scss
@@ -1,0 +1,3 @@
+.u-font-size-large {
+  font-size: $large-font-size;
+}

--- a/lib/constable_web/templates/interest/index.html.eex
+++ b/lib/constable_web/templates/interest/index.html.eex
@@ -11,7 +11,14 @@
       <li class="tbds-block-stack__item interest-list-item">
         <div class="tbds-inline-stack">
           <div class="tbds-inline-stack__item">
-            <h3><%= link interest.name, to: Routes.interest_path(@conn, :show, interest) %></h3>
+            <p class="tbds-badge tbds-margin-block-end-0">
+              <strong>
+                <%= link(
+                  interest.name,
+                  to: Routes.interest_path(@conn, :show, interest)
+                ) %>
+              </strong>
+            </p>
           </div>
           <div class="tbds-inline-stack__item tbds-inline-stack__item--push-start">
             <%= render ConstableWeb.InterestView, "subscription.html", conn: @conn, interest: interest, current_user: @current_user %>

--- a/lib/constable_web/templates/interest/show.html.eex
+++ b/lib/constable_web/templates/interest/show.html.eex
@@ -1,7 +1,10 @@
 <div class="page-interest">
   <div class="interest container container-pad-top">
+    <h1 class="u-font-size-large">
+      <span class="tbds-badge"><%= @interest.name %></span>
+    </h1>
+
     <div>
-      <h1><%= @interest.name %></h1>
       <%= render ConstableWeb.InterestView, "subscription.html", conn: @conn, interest: @interest, current_user: @current_user %>
     </div>
 

--- a/lib/constable_web/templates/slack_channel/edit.html.eex
+++ b/lib/constable_web/templates/slack_channel/edit.html.eex
@@ -1,6 +1,8 @@
 <div class="page-slack-channel">
   <div class="interest container container-pad-top">
-    <h1><%= @interest.name %></h1>
+    <h1 class="u-font-size-large">
+      <span class="tbds-badge"><%= @interest.name %></span>
+    </h1>
 
     <div>
       <%= gettext("Here you can enter the slack channel to be notified when an announcement is created for this interest.") %>


### PR DESCRIPTION
We've long rendered Interest as a "badge" on the Announcements index
and show pages. In [281f3f7] we tweaked badges and started using the
Badge component from tbds.

However, on Interest index and show pages, we were not rendering them
visually as a "badge," rather they just rendered as plain text.

This changes that to carry the visual representation of an Interest to
be a "badge" throughout Constable, creating a consistent visual system.

[281f3f7]: https://github.com/thoughtbot/constable/commit/281f3f7429c18106ba96c3bf92dc558e26d19301

## Before

<img width="892" alt="Screen Shot 2019-09-28 at 11 31 04" src="https://user-images.githubusercontent.com/903327/65819023-ae53d200-e1e5-11e9-99e8-c89ed4560ec7.png">

## After

<img width="892" alt="Screen Shot 2019-09-28 at 11 30 59" src="https://user-images.githubusercontent.com/903327/65819026-b14ec280-e1e5-11e9-96a2-a5224f560413.png">

## Before

<img width="653" alt="Screen Shot 2019-09-28 at 11 47 40" src="https://user-images.githubusercontent.com/903327/65819046-d3484500-e1e5-11e9-8d35-bda8ff59fee3.png">

## After

<img width="653" alt="Screen Shot 2019-09-28 at 11 47 43" src="https://user-images.githubusercontent.com/903327/65819048-d6433580-e1e5-11e9-9f7b-d10dc091b927.png">
