### PR TITLE
Refactor media queries and breakpoints

### DIFF
--- a/assets/css/_shims.scss
+++ b/assets/css/_shims.scss
@@ -20,12 +20,10 @@
   }
 }
 
-@include media($medium-screen) {
-  .app-header {
-    .tbds-button.app-header__announce-button {
-      .tbds-button__icon--start {
-        margin-inline-end: 0;
-      }
+.app-header__announce-button {
+  .tbds-button__icon--start {
+    @media (max-width: $breakpoint-2) {
+      margin-inline-end: 0;
     }
   }
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -2,10 +2,7 @@
 
 @import "~@thoughtbot/design-system/src/index";
 
-@import "settings/grid-settings";
 @import "settings/variables";
-
-@import "tools/media";
 
 @import "~normalize.css/normalize";
 @import "generic/fonts";

--- a/assets/css/components/_announcement-create.scss
+++ b/assets/css/components/_announcement-create.scss
@@ -1,20 +1,21 @@
 .flex-container {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 
-  @include media($small-screen) {
-    justify-content: flex-start;
+  @media (min-width: $breakpoint-1) {
+    justify-content: center;
   }
 }
 
 .announcement-create,
 .announcement-preview {
+  display: none;
   flex: 1;
   min-height: calc(100vh - 91px);
   padding: $large-spacing $base-spacing;
 
-  @include media($small-screen) {
-    display: none;
+  @media (min-width: $breakpoint-1) {
+    display: block;
   }
 
   &.active {
@@ -47,7 +48,7 @@
     color: inherit;
     display: block;
 
-    @include media($medium-screen-up) {
+    @media (min-width: $breakpoint-2) {
       cursor: default;
     }
   }
@@ -56,7 +57,7 @@
     background-color: $dark-blue;
     color: #fff;
 
-    @include media($medium-screen-up) {
+    @media (min-width: $breakpoint-2) {
       background-color: $light-gray;
       color: $base-font-color;
     }

--- a/assets/css/components/_announcement.scss
+++ b/assets/css/components/_announcement.scss
@@ -1,14 +1,14 @@
 .announcement {
   margin-top: $base-spacing * 1.25;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     margin-top: $large-spacing;
   }
 
   h1 {
     @include margin($small-spacing null);
 
-    @include media($medium-screen-up) {
+    @media (min-width: $breakpoint-2) {
       @include margin($base-spacing null ($base-spacing * 0.85));
       font-size: $larger-font-size;
     }
@@ -123,7 +123,7 @@
 .announcement-body {
   @include padding($base-spacing null);
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     @include padding($large-spacing null);
     font-size: $medium-font-size;
   }

--- a/assets/css/components/_app-header.scss
+++ b/assets/css/components/_app-header.scss
@@ -5,10 +5,10 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: $small-spacing $base-spacing;
+  padding: $small-spacing;
 
-  @include media($small-screen) {
-    padding: $small-spacing;
+  @media (min-width: $breakpoint-1) {
+    padding: $small-spacing $base-spacing;
   }
 }
 
@@ -19,7 +19,7 @@
   order: 2;
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     margin-bottom: 0;
   }
 }
@@ -28,7 +28,7 @@
   margin-right: $small-spacing;
   order: 1;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     order: 3;
   }
 }
@@ -39,7 +39,7 @@
   order: 4;
   position: relative;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     @include margin(0 auto null);
     flex: 0 0 18.75rem;
     order: 2;
@@ -66,7 +66,7 @@
 .app-header__announce-button-text {
   display: none;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $breakpoint-2) {
     display: block;
   }
 }

--- a/assets/css/components/_tabs.scss
+++ b/assets/css/components/_tabs.scss
@@ -5,7 +5,7 @@
   overflow-x: auto;
   width: 100%;
 
-  @include media($small-screen-up) {
+  @media (min-width: $breakpoint-1) {
     @include padding(null ($base-spacing - $small-spacing));
   }
 

--- a/assets/css/objects/_container.scss
+++ b/assets/css/objects/_container.scss
@@ -1,12 +1,7 @@
 .container {
-  margin: 0 auto;
-  max-width: 620px;
-  width: 80%;
-
-  @include media($small-screen) {
-    padding: 0 $small-spacing;
-    width: 100%;
-  }
+  @include margin(null auto);
+  @include padding(null $small-spacing);
+  max-width: 40rem;
 }
 
 .container-x-small {

--- a/assets/css/settings/_grid-settings.scss
+++ b/assets/css/settings/_grid-settings.scss
@@ -1,6 +1,0 @@
-$small-screen: ("max-width", 519px);
-$medium-screen: ("max-width", 719px);
-$large-screen: ("max-width", 860px);
-
-$small-screen-up: ("min-width", 520px);
-$medium-screen-up: ("min-width", 720px);

--- a/assets/css/settings/_variables.scss
+++ b/assets/css/settings/_variables.scss
@@ -27,6 +27,10 @@ $small-spacing: $base-spacing / 2;
 $tiny-spacing: $small-spacing / 2;
 $tiniest-spacing: $tiny-spacing / 2;
 
+// Breakpoints
+$breakpoint-1: 32em;
+$breakpoint-2: 45em;
+
 // Colors
 $dark-blue: #2e303a;
 $light-gray: #e3e3e3;

--- a/assets/css/tools/_media.scss
+++ b/assets/css/tools/_media.scss
@@ -1,5 +1,0 @@
-@mixin media($query) {
-  @media screen and (nth($query, 1): nth($query, 2)) {
-    @content;
-  }
-}


### PR DESCRIPTION
In [438cfbb] we removed Neat (v1), but copied over its `media` mixin
because, at the time, it was used quite a bit and would've been more
complicated to pull out. That situation has changed and we're now in a
better position to remove it.

The `media` mixin we copied over is not a great mixin because it uses
string parsing instead of arguments. This has perhaps led us to use a
mix of `min-width` and `max-width` queries. It made our Sass overly
complex and hard to follow.

This commit:

- Removes the `media` mixin in favor of using vanilla CSS
  `@media` queries
- Moves everything over to `min-width` queries (commonly referred to as
  "mobile-first")

[438cfbb]: https://github.com/thoughtbot/constable/commit/438cfbbf13f8f147649676037244b52d0d351be9