### PR TITLE
Disallow creation of announcements with no interests

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -29,6 +29,7 @@
 @import "components/comments";
 @import "components/flex-button-container";
 @import "components/flash";
+@import "components/help-block";
 @import "components/interest";
 @import "components/pagination";
 @import "components/tabs";

--- a/assets/css/components/_help-block.scss
+++ b/assets/css/components/_help-block.scss
@@ -1,0 +1,4 @@
+.help-block {
+  color: $error-color;
+  font-style: italic;
+}

--- a/assets/css/settings/_variables.scss
+++ b/assets/css/settings/_variables.scss
@@ -44,6 +44,9 @@ $lightest-gray: lighten($light-gray, 7%);
 // Outline
 $outline-color: #0b758c;
 
+// Error
+$error-color: #e03946;
+
 // Font Colors
 $base-font-color: $tbds-color-text-default;
 $secondary-font-color: tint($tbds-color-text-default, 25%);

--- a/assets/js/announcement-form.js
+++ b/assets/js/announcement-form.js
@@ -92,6 +92,9 @@ export default class {
         labelField: 'name',
         searchField: 'name',
         options: window.INTERESTS_NAMES,
+        onInitialize() {
+          this.$control_input.attr('aria-describedby', this.$input.attr('aria-describedby'));
+        },
         onChange: value => {
           if (!this._isEditing) {
             localStorage.setItem('interests', value);

--- a/lib/constable_web/controllers/announcement_controller.ex
+++ b/lib/constable_web/controllers/announcement_controller.ex
@@ -167,7 +167,7 @@ defmodule ConstableWeb.AnnouncementController do
   defp extract_interest_names(announcement_params) do
     interest_names =
       Map.get(announcement_params, "interests")
-      |> String.split(",")
+      |> String.split(",", trim: true)
 
     announcement_params =
       announcement_params

--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -30,6 +30,7 @@
           :interests,
           value: comma_separated_interest_names(@changeset.data.interests)
         ) %>
+        <%= error_tag f, :interests %>
       </div>
 
       <div class="tbds-block-stack__item">

--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -28,7 +28,8 @@
         <%= text_input(
           :announcement,
           :interests,
-          value: comma_separated_interest_names(@changeset.data.interests)
+          value: comma_separated_interest_names(@changeset.data.interests),
+          "aria-describedby": "interests_error"
         ) %>
         <%= error_tag f, :interests %>
       </div>

--- a/lib/constable_web/views/error_helpers.ex
+++ b/lib/constable_web/views/error_helpers.ex
@@ -9,8 +9,8 @@ defmodule ConstableWeb.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field) do
-    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
-      content_tag :span, translate_error(error), class: "help-block"
+    Enum.map(Keyword.get_values(form.errors, field), fn error ->
+      content_tag(:span, translate_error(error), id: "#{field}_error", class: "help-block")
     end)
   end
 

--- a/lib/constable_web/views/error_helpers.ex
+++ b/lib/constable_web/views/error_helpers.ex
@@ -10,7 +10,7 @@ defmodule ConstableWeb.ErrorHelpers do
   """
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error), id: "#{field}_error", class: "help-block")
+      content_tag(:span, translate_error(error), id: "#{field}_error", class: "help-block", role: "alert")
     end)
   end
 

--- a/test/acceptance/user_announcement_test.exs
+++ b/test/acceptance/user_announcement_test.exs
@@ -21,6 +21,18 @@ defmodule ConstableWeb.UserAnnouncementTest do
     assert has_comments_placeholder?(session)
   end
 
+  test "user tries to create an announcement without adding any interests", %{session: session} do
+    user = insert(:user)
+
+    session
+    |> visit(Routes.announcement_path(Endpoint, :new, as: user.id))
+    |> fill_in(@announcement_title, with: "Hello World ❤️")
+    |> fill_in(@announcement_body, with: "# Hello!")
+    |> click_submit_button
+
+    assert has_form_error_message?(session, "you must select at least one interest")
+  end
+
   test "user previews who will receive an announcement", %{session: session} do
     elixir_interest = insert(:interest, name: "elixir")
     _uninterested_user = insert(:user)
@@ -117,5 +129,11 @@ defmodule ConstableWeb.UserAnnouncementTest do
     session
     |> find(css(".interested-user-names"))
     |> has_text?(user_names)
+  end
+
+  defp has_form_error_message?(session, message) do
+    session
+    |> find(css(".help-block"))
+    |> has_text?(message)
   end
 end


### PR DESCRIPTION
Fixes #740. 

The PR disallows the creation of announcements with no interests by adding a validation before the announcement is created, and returning an error that is displayed in the form.

![Image 2019-10-02 at 9 02 44 PM](https://user-images.githubusercontent.com/342826/66092012-27418980-e558-11e9-99de-97d902f6da94.png)
