### PR TITLE
Fix display of interest pagination

### DIFF
--- a/lib/constable_web/templates/interest/show.html.eex
+++ b/lib/constable_web/templates/interest/show.html.eex
@@ -31,12 +31,24 @@
   <%= render ConstableWeb.AnnouncementListView, "index.html", conn: @conn, announcements: @announcements %>
 
   <div class="container pagination">
-    <%= if !on_first_page?(@interest_page) do %>
-      <%= link gettext(""), to: Routes.interest_path(@conn, :show, @interest, page: (@interest_page.page_number - 1)), class: "page-previous button" %>
-    <% end %>
+      <%= if !on_first_page?(@interest_page) do %>
+        <%= link to: Routes.interest_path(@conn, :show, @interest, page: (@interest_page.page_number - 1)),
+              class: "tbds-button button-secondary pagination-button" do %>
+          <svg class="tbds-button__icon tbds-button__icon--start">
+            <use xlink:href="/images/icons.svg#arrow-left"></use>
+          </svg>
+          Previous
+        <% end %>
+      <% end %>
 
-    <%= if !on_last_page?(@interest_page) do %>
-      <%= link gettext(""), to: Routes.interest_path(@conn, :show, @interest, page: (@interest_page.page_number + 1)), class: "page-next button" %>
-    <% end %>
-  </div>
+      <%= if !on_last_page?(@interest_page) do %>
+        <%= link to: Routes.interest_path(@conn, :show, @interest, page: (@interest_page.page_number + 1)),
+              class: "tbds-button button-secondary pagination-button" do %>
+          Next
+          <svg class="tbds-button__icon tbds-button__icon--end">
+            <use xlink:href="/images/icons.svg#arrow-right"></use>
+          </svg>
+        <% end %>
+      <% end %>
+    </div>
 </div>


### PR DESCRIPTION
Fixes #774. 

This turned out to just be a display issue - the pagination was rendering with zero height due to one of the many styling changes we have made over the past few months.

I changed the markup to match what we use for the announcement pagination, which fixes the display.