### PR TITLE
Fix flash banner positioning

### DIFF
--- a/lib/constable_web/templates/layout/_flashes.html.eex
+++ b/lib/constable_web/templates/layout/_flashes.html.eex
@@ -1,11 +1,13 @@
-<%= if get_flash(@conn, :info) do %>
-  <div class="flash flash-info">
-    <%= get_flash(@conn, :info) %>
-  </div>
-<% end %>
+<header role="banner">
+  <%= if get_flash(@conn, :info) do %>
+    <div class="flash flash-info">
+      <%= get_flash(@conn, :info) %>
+    </div>
+  <% end %>
 
-<%= if get_flash(@conn, :error) do %>
-  <div class="flash flash-error">
-    <%= get_flash(@conn, :error) %>
-  </div>
-<% end %>
+  <%= if get_flash(@conn, :error) do %>
+    <div class="flash flash-error">
+      <%= get_flash(@conn, :error) %>
+    </div>
+  <% end %>
+</header>

--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -27,8 +27,8 @@
       <%= render "_header.html", conn: @conn %>
     <% end %>
 
+    <%= render "_flashes.html", conn: @conn %>
     <%= content_container(@conn, assigns) do %>
-      <%= render "_flashes.html", conn: @conn %>
       <%= render @view_module, @view_template, assigns %>
     <% end %>
   </body>


### PR DESCRIPTION
Fixes #782. 

This PR fixes an issue where the flash banners would display at the width of the sign-in dialog instead of the full page width.

The banners now exist in a `header role="banner"` element above the page content so that they are not subject to the styling of the main page content.

