### PR TITLE
Make and update headings for accessibility

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -32,6 +32,7 @@
 @import "components/help-block";
 @import "components/interest";
 @import "components/pagination";
+@import "components/page-header";
 @import "components/tabs";
 @import "components/uploadable-input";
 

--- a/assets/css/components/_announcement-create.scss
+++ b/assets/css/components/_announcement-create.scss
@@ -38,11 +38,14 @@
 .header-tag {
   @include padding($tiny-spacing null $tiny-spacing $base-spacing);
   background-color: $light-gray;
-  font-size: $tiny-font-size;
   font-weight: $font-weight-bold;
   text-transform: uppercase;
   transition: background-color 0.1s ease-out;
   width: 100%;
+
+  h2 {
+    font-size: $tiny-font-size;
+  }
 
   a {
     color: inherit;

--- a/assets/css/components/_announcements.scss
+++ b/assets/css/components/_announcements.scss
@@ -3,12 +3,6 @@
 }
 
 .announcement-list-item {
-  h1 {
-    font-size: 1.75rem;
-    margin-bottom: $tiniest-spacing;
-    margin-top: 0;
-  }
-
   .announcement-metadata {
     margin-bottom: 0;
   }
@@ -20,6 +14,14 @@
   &:last-child {
     border-bottom: none;
   }
+}
+
+.announcement-list-item-heading {
+  font-size: 1.75rem;
+  font-weight: $font-weight-bold;
+  line-height: $heading-line-height;
+  margin-bottom: $tiniest-spacing;
+  margin-top: 0;
 }
 
 .announcement-list-item-metadata {
@@ -39,6 +41,7 @@
 
   .author {
     color: $base-font-color;
+    font-weight: $font-weight-bold;
   }
 
   .subscription {

--- a/assets/css/components/_comments.scss
+++ b/assets/css/components/_comments.scss
@@ -27,6 +27,7 @@
 
 .author {
   flex: 1;
+  font-weight: $font-weight-bold;
 }
 
 .comment-information {

--- a/assets/css/components/_page-header.scss
+++ b/assets/css/components/_page-header.scss
@@ -1,0 +1,3 @@
+.page-header {
+  margin-top: $large-spacing;
+}

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -11,7 +11,7 @@
 
   <div class="tbds-media__body">
     <div class="author-information">
-      <h4 class="author"><%= @comment.user.name %></h4>
+      <p class="author"><%= @comment.user.name %></p>
       <a href="#comment-<%= @comment.id %>" class="comment-time">
         <%= relative_timestamp(@comment.inserted_at) %>
       </a>

--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -4,11 +4,11 @@
   fn(f) -> %>
   <nav class="header-tags">
     <div class="header-tag header-tag-markdown active">
-      <%= gettext("Markdown") %>
+      <h2><%= gettext("Markdown") %></h2>
     </div>
 
     <div class="header-tag header-tag-preview">
-      <%= gettext("Preview") %>
+      <h2><%= gettext("Preview") %></h2>
     </div>
   </nav>
   <div class="col-markdown announcement-create active">

--- a/lib/constable_web/templates/announcement/index.html.eex
+++ b/lib/constable_web/templates/announcement/index.html.eex
@@ -37,6 +37,8 @@
     <% end %>
   </nav>
 
+  <h1 class="page-header container">Announcements</h1>
+
   <%= render ConstableWeb.AnnouncementListView,
     "index.html",
     conn: @conn,

--- a/lib/constable_web/templates/announcement/new.html.eex
+++ b/lib/constable_web/templates/announcement/new.html.eex
@@ -1,3 +1,5 @@
+<h1 class="page-header">Create an Announcement</h1>
+
 <%= render "_form.html",
   path: Routes.announcement_path(@conn, :create),
   conn: @conn,

--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -39,7 +39,7 @@
         >
       </div>
       <div class="tbds-media__body">
-        <h4><%= link @announcement.user.name, to: Routes.announcement_path(@conn, :index, user_id: @announcement.user_id), class: "author" %></h4>
+        <%= link @announcement.user.name, to: Routes.announcement_path(@conn, :index, user_id: @announcement.user_id), class: "author" %>
 
         <div class="announcement-metadata">
           <%= gettext "announced " %>
@@ -74,7 +74,7 @@
     <%= raw markdown_with_users(@announcement.body) %>
   </div>
 
-  <h4 class="tbds-margin-block-end-6"><%= gettext "Comments" %></h4>
+  <h2 class="tbds-margin-block-end-6"><%= gettext "Comments" %></h2>
   <ul class="tbds-block-stack tbds-block-stack--bordered tbds-block-stack--gap-6 comments-list">
     <li class="comments-placeholder">
       No one has commented on this announcement yet.<br />You could be the first!

--- a/lib/constable_web/templates/announcement_list/index.html.eex
+++ b/lib/constable_web/templates/announcement_list/index.html.eex
@@ -1,10 +1,9 @@
 <ul class="tbds-block-stack tbds-block-stack--gap-6 container container-pad-top">
   <%= for announcement <- @announcements do %>
     <li class="tbds-block-stack__item announcement-list-item">
-      <%= link to: Routes.announcement_path(@conn, :show, announcement) do %>
-        <h1 data-role="title" class="announcement-list-item-heading">
-          <%= announcement.title %>
-        </h1>
+      <%= link to: Routes.announcement_path(@conn, :show, announcement),
+      class: "announcement-list-item-heading", data_role: "title" do %>
+        <%= announcement.title %>
       <% end %>
 
       <div class="announcement-list-item-metadata">

--- a/test/acceptance/user_searches_announcements_test.exs
+++ b/test/acceptance/user_searches_announcements_test.exs
@@ -24,7 +24,7 @@ defmodule ConstableWeb.UserSearchesAnnouncementsTest do
 
   defp has_announcement_text?(session, announcment_title) do
     session
-    |> find(css("h1[data-role=title]"))
+    |> find(css("[data-role=title]"))
     |> has_text?(announcment_title)
   end
 end


### PR DESCRIPTION
After auditing the app for headings and their accessibility I found some issues:

* There is currently no heading for the main lists of announcements
* Announcement links are currently all `<h1>`s
* Names on individual announcements are currently `<h4>`s
* Comments section heading is currently an `<h4>`
* Names in individual comments are currently `<h4>`s
* There is currently no heading when creating an announcement
* Titles for "markdown" and "preview" when creating announcements are plain text in `<div>`s

The issue for missing headings is that according to [accessibility standards](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html) all sections of content should have an easily understandable heading.

The reason for changing h4s into other types of headings, plain link text, or `<p>` tags is that according to [accessibility standards](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html) headings should describe the purpose of the following content, and that heading levels should not be skipped.

This PR will close #764  

## Before
![Screen Shot 2019-11-04 at 9 57 35 AM](https://user-images.githubusercontent.com/13579950/68130712-d40d7e80-fee9-11e9-84f1-28f162ef59e9.png)
![Screen Shot 2019-11-04 at 9 58 17 AM](https://user-images.githubusercontent.com/13579950/68130713-d40d7e80-fee9-11e9-9c7b-82a2a110d101.png)


## After
![Screen Shot 2019-11-04 at 9 57 10 AM](https://user-images.githubusercontent.com/13579950/68130730-d96ac900-fee9-11e9-837d-07fd6c1ca407.png)
![Screen Shot 2019-11-04 at 9 58 02 AM](https://user-images.githubusercontent.com/13579950/68130731-d96ac900-fee9-11e9-9e7e-492ff8ab2686.png)

