### PR TITLE
Fix overflow text rendering in announcement preview and posted comments

### DIFF
--- a/assets/css/components/_announcement-create.scss
+++ b/assets/css/components/_announcement-create.scss
@@ -12,6 +12,7 @@
   display: none;
   flex: 1;
   min-height: calc(100vh - 91px);
+  min-width: calc(100vw / 2);
   padding: $large-spacing $base-spacing;
 
   @media (min-width: $breakpoint-1) {
@@ -25,6 +26,10 @@
 
 .announcement-preview {
   border-left: 1px solid darken($lightest-gray, 4%);
+
+  pre {
+    overflow-x: auto;
+  }
 }
 
 .header-tags {

--- a/assets/css/components/_comments.scss
+++ b/assets/css/components/_comments.scss
@@ -14,6 +14,10 @@
   margin-left: $tiniest-spacing;
 }
 
+.comment-container {
+  overflow-x: auto;
+}
+
 .comment-body {
   position: relative;
 }

--- a/lib/constable_web/templates/announcement/_comment.html.eex
+++ b/lib/constable_web/templates/announcement/_comment.html.eex
@@ -9,7 +9,7 @@
     >
   </div>
 
-  <div class="tbds-media__body">
+  <div class="tbds-media__body comment-container">
     <div class="author-information">
       <p class="author"><%= @comment.user.name %></p>
       <a href="#comment-<%= @comment.id %>" class="comment-time">


### PR DESCRIPTION
Closes #822 

* Adds a minimum width to the `create` and `preview` styles
* Handles overflow pre text inside the markdown preview and posted comment

~  | 📸 **Announcements**
--|--
Before | ![image](https://user-images.githubusercontent.com/5240843/70949124-df3bea00-2011-11ea-96f5-051151d81a2c.png)
After | ![Screenshot_2019-12-16 Constable - New Announcement](https://user-images.githubusercontent.com/5240843/70949105-d2b79180-2011-11ea-85b2-ff1bb8b32bc9.png)

~  | 📸 **Comments**
--|--
Before | ![image](https://user-images.githubusercontent.com/5240843/71041524-25f71600-20de-11ea-872a-d9d2a45c64b3.png)
After | ![image](https://user-images.githubusercontent.com/5240843/71041523-25f71600-20de-11ea-81a4-7b1ef988caba.png)