### PR TITLE
Show one announcement per comment in "Your Comments"

### DIFF
--- a/lib/constable/models/announcement.ex
+++ b/lib/constable/models/announcement.ex
@@ -58,6 +58,7 @@ defmodule Constable.Announcement do
     |> join(:inner, [a], c in assoc(a, :comments))
     |> join(:inner, [_a, c], u in assoc(c, :user))
     |> where([_a, c, _u], c.user_id == ^user_id)
+    |> distinct(true)
   end
 
   def search(query \\ __MODULE__, search_term, exclude_interests: excludes) do

--- a/test/models/announcement_test.exs
+++ b/test/models/announcement_test.exs
@@ -129,5 +129,19 @@ defmodule Constable.AnnouncementTest do
       assert announcement_with_user_comment.id in announcement_ids
       refute announcement_without_user_comment.id in announcement_ids
     end
+
+    test "includes each announcement once, even with multiple comments by user" do
+      user = insert(:user)
+      announcement = insert(:announcement)
+
+      insert_pair(:comment, announcement: announcement, user: user)
+
+      found_announcement =
+        user.id
+        |> Announcement.with_comments_by_user()
+        |> Repo.one()
+
+      assert found_announcement.id == announcement.id
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/thoughtbot/constable/issues/804

What changed?
=============

Prior to this change, if someone commented multiple times on the same announcement, clicking on "Your Comments" would show them multiple entries for the same announcement (one entry per comment).

We now include a DISTINCT on the query to only show one announcement in "Your Comments" tab regardless of how many times the user has commented on it.