### PR TITLE
Add "View on Constable" link to top of emails

### DIFF
--- a/lib/constable_web/templates/email/new_announcement.html.eex
+++ b/lib/constable_web/templates/email/new_announcement.html.eex
@@ -8,6 +8,12 @@
         Announced to <%= raw interest_links(@announcement) %>
         <%= time_ago_in_words @announcement.inserted_at %>:
       </td>
+      <td align="right">
+        <%= link to: announcement_url_for_footer(@announcement, nil),
+          style: "color: #{light_gray()}; font-size: 14px;" do %>
+          <%= gettext("View on Constable") %>
+        <% end %>
+      </td>
     </tr>
     <tr>
       <td colspan="2" height="20"></td>

--- a/lib/constable_web/templates/email/new_comment.html.eex
+++ b/lib/constable_web/templates/email/new_comment.html.eex
@@ -12,6 +12,12 @@
         <% end %>
         <%= raw Constable.Markdown.to_html(@comment.body) %>
       </td>
+      <td align="right">
+        <%= link to: announcement_url_for_footer(@announcement, @comment),
+          style: "color: #{light_gray()}; font-size: 14px;" do %>
+          <%= gettext("View on Constable") %>
+        <% end %>
+      </td>
     </tr>
     <tr>
       <td colspan="2" height="35"></td>


### PR DESCRIPTION
Closes https://github.com/thoughtbot/constable/issues/797

What changed?
=============

We add a "View on Constable" link to the top of the new announcement and new comment emails. Because the announcements and comments can vary in length, it is sometimes difficult to find the link if the reader prefers to see the announcement in the browser.

This brings a gray link to the top that is same color and size as the interests displayed on the top left.

***I'd love feedback on:***

(a) should these be gray (like the top left header) or red (like the bottom link)?
(b) should we include the top link on new comment emails? (I did for consistency, but it may seem overkill)

## Screenshots

### New Announcement

![Screen Shot 2019-12-31 at 9 55 46 AM](https://user-images.githubusercontent.com/3245976/71625091-f0f5c380-2bb3-11ea-95ff-66902ca0e5a2.png)


### New Comment

![Screen Shot 2019-12-31 at 9 55 41 AM](https://user-images.githubusercontent.com/3245976/71625094-f4894a80-2bb3-11ea-8d34-6aef992e5370.png)
