### PR TITLE
Format codebase with mix format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
           key: v4-npm-cache
           paths: "assets/node_modules"
 
+      - run: mix format --check-formatted
+
       - run:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 # Figure out which host to use based on Heroku deploy
 heroku_app_name = System.get_env("HEROKU_APP_NAME")
+
 if heroku_app_name && heroku_app_name =~ ~r/\Aconstable-api-staging-pr/ do
   System.put_env("HOST", "#{heroku_app_name}.herokuapp.com")
 end

--- a/lib/constable/env.ex
+++ b/lib/constable/env.ex
@@ -3,6 +3,6 @@ defmodule Constable.Env do
   Gets a variable from the environment and throws an error if it does not exist
   """
   def get(key) do
-    System.get_env |> Map.fetch!(key)
+    System.get_env() |> Map.fetch!(key)
   end
 end

--- a/lib/constable/factory.ex
+++ b/lib/constable/factory.ex
@@ -60,8 +60,7 @@ defmodule Constable.Factory do
   end
 
   def tag_with_interest(announcement, interest) do
-    insert(:announcement_interest, announcement: announcement, interest:
-    interest).announcement
+    insert(:announcement_interest, announcement: announcement, interest: interest).announcement
   end
 
   def with_subscriber(announcement, user) do

--- a/lib/constable/models/comment.ex
+++ b/lib/constable/models/comment.ex
@@ -12,7 +12,7 @@ defmodule Constable.Comment do
   end
 
   def create_changeset(model \\ %__MODULE__{}, params) do
-    create_changeset(model, params, DateTime.utc_now)
+    create_changeset(model, params, DateTime.utc_now())
   end
 
   def create_changeset(model, params, last_discussed_at) do
@@ -29,12 +29,12 @@ defmodule Constable.Comment do
   end
 
   defp set_last_discussed_at(changeset, last_discussed_at) do
-    prepare_changes changeset, fn(changeset) ->
+    prepare_changes(changeset, fn changeset ->
       Announcement
       |> where(id: ^get_field(changeset, :announcement_id))
       |> changeset.repo.update_all(set: [last_discussed_at: last_discussed_at])
 
       changeset
-    end
+    end)
   end
 end

--- a/lib/constable/models/serializers/announcement.ex
+++ b/lib/constable/models/serializers/announcement.ex
@@ -16,11 +16,11 @@ defimpl Poison.Encoder, for: Constable.Announcement do
     |> Repo.preload([:comments, :user, :interests])
     |> Map.take(@attributes)
     |> set_interests
-    |> Poison.encode!
+    |> Poison.encode!()
   end
 
   def set_interests(announcement) do
-    interest_names = Enum.map(announcement.interests, fn (interest) -> interest.name end)
+    interest_names = Enum.map(announcement.interests, fn interest -> interest.name end)
     Map.put(announcement, "interests", interest_names)
   end
 end

--- a/lib/constable/models/serializers/comment.ex
+++ b/lib/constable/models/serializers/comment.ex
@@ -2,6 +2,6 @@ defimpl Poison.Encoder, for: Constable.Comment do
   @attributes ~W(id body user announcement_id inserted_at)a
 
   def encode(comment, _options) do
-    comment |> Map.take(@attributes) |> Poison.encode!
+    comment |> Map.take(@attributes) |> Poison.encode!()
   end
 end

--- a/lib/constable/models/serializers/interest.ex
+++ b/lib/constable/models/serializers/interest.ex
@@ -3,6 +3,7 @@ defimpl Poison.Encoder, for: Constable.Interest do
     %{
       id: interest.id,
       name: interest.name
-    } |> Poison.encode!
+    }
+    |> Poison.encode!()
   end
 end

--- a/lib/constable/models/serializers/serializers.ex
+++ b/lib/constable/models/serializers/serializers.ex
@@ -1,6 +1,6 @@
 defmodule Constable.Serializers do
   def ids_as_keys(objects) do
-    Enum.reduce(objects, %{}, fn(object, objects) ->
+    Enum.reduce(objects, %{}, fn object, objects ->
       Map.put(objects, to_string(object.id), object)
     end)
   end

--- a/lib/constable/models/serializers/subscription.ex
+++ b/lib/constable/models/serializers/subscription.ex
@@ -4,6 +4,7 @@ defimpl Poison.Encoder, for: Constable.Subscription do
       id: subscription.id,
       user_id: subscription.user_id,
       announcement_id: subscription.announcement_id
-    } |> Poison.encode!
+    }
+    |> Poison.encode!()
   end
 end

--- a/lib/constable/models/serializers/user_interest.ex
+++ b/lib/constable/models/serializers/user_interest.ex
@@ -4,6 +4,7 @@ defimpl Poison.Encoder, for: Constable.UserInterest do
       id: user_interest.id,
       user_id: user_interest.user_id,
       interest_id: user_interest.interest_id
-    } |> Poison.encode!
+    }
+    |> Poison.encode!()
   end
 end

--- a/lib/constable/models/subscription.ex
+++ b/lib/constable/models/subscription.ex
@@ -26,6 +26,6 @@ defmodule Constable.Subscription do
 
   defp generate_token(changeset) do
     token = SecureRandom.urlsafe_base64(32)
-    put_change changeset, :token, token
+    put_change(changeset, :token, token)
   end
 end

--- a/lib/constable/models/user.ex
+++ b/lib/constable/models/user.ex
@@ -33,7 +33,7 @@ defmodule Constable.User do
   def reactivate(email) when is_binary(email) do
     Repo.get_by!(__MODULE__, email: email)
     |> Ecto.Changeset.change(%{active: true})
-    |> Repo.update!
+    |> Repo.update!()
   end
 
   def settings_changeset(user, params \\ %{}) do
@@ -53,7 +53,7 @@ defmodule Constable.User do
   end
 
   def interested_in?(user, interest) do
-    interest.id in Enum.map(user.interests, &(&1.id))
+    interest.id in Enum.map(user.interests, & &1.id)
   end
 
   def ordered_by_name(query \\ __MODULE__) do
@@ -70,7 +70,7 @@ defmodule Constable.User do
 
   defp require_permitted_email_domain(changeset) do
     changeset
-    |> validate_change(:email, fn(:email, value) ->
+    |> validate_change(:email, fn :email, value ->
       case String.split(value, "@") do
         [_, @permitted_email_domain] -> []
         _ -> [email: "must be a member of #{@permitted_email_domain}"]
@@ -80,14 +80,14 @@ defmodule Constable.User do
 
   defp generate_token(changeset) do
     token = SecureRandom.urlsafe_base64(32)
-    put_change changeset, :token, token
+    put_change(changeset, :token, token)
   end
 
   defp generate_username(changeset) do
     if changeset.valid? do
       email = get_change(changeset, :email)
       [username, _] = String.split(email, "@")
-      put_change changeset, :username, username
+      put_change(changeset, :username, username)
     else
       changeset
     end
@@ -95,6 +95,7 @@ defmodule Constable.User do
 
   defp ensure_name_is_set(changeset) do
     username = changeset |> get_change(:username)
+
     if get_change(changeset, :name) |> is_blank? do
       changeset |> put_change(:name, username)
     else
@@ -103,6 +104,7 @@ defmodule Constable.User do
   end
 
   defp is_blank?(nil), do: true
+
   defp is_blank?(string) when is_binary(string) do
     case String.trim(string) do
       "" -> true

--- a/lib/constable/plugs/deslugifier.ex
+++ b/lib/constable/plugs/deslugifier.ex
@@ -1,15 +1,14 @@
 defmodule Constable.Plugs.Deslugifier do
   def init(opts) do
     case Keyword.get(opts, :slugified_key) do
-      nil -> raise "Must provide a :slugified_key to #{inspect __MODULE__}"
+      nil -> raise "Must provide a :slugified_key to #{inspect(__MODULE__)}"
       key -> key
     end
   end
 
   def call(conn, key) do
     with {:ok, slugified_id} <- Map.fetch(conn.params, key),
-         {:ok, id} <- deslugify(slugified_id)
-    do
+         {:ok, id} <- deslugify(slugified_id) do
       put_in(conn, [Access.key!(:params), key], id)
     else
       _ -> conn

--- a/lib/constable/plugs/fetch_current_user.ex
+++ b/lib/constable/plugs/fetch_current_user.ex
@@ -7,7 +7,9 @@ defmodule Constable.Plugs.FetchCurrentUser do
 
   def call(conn, _) do
     case find_user(conn) do
-      :not_signed_in -> conn
+      :not_signed_in ->
+        conn
+
       user ->
         conn |> assign(:current_user, user)
     end
@@ -15,7 +17,7 @@ defmodule Constable.Plugs.FetchCurrentUser do
 
   def find_user(conn) do
     case UserIdentifier.verify_signed_user_id(conn) do
-      {:ok, user_id} -> Repo.get(User.active, user_id)
+      {:ok, user_id} -> Repo.get(User.active(), user_id)
       {:error, _} -> :not_signed_in
     end
   end

--- a/lib/constable/plugs/require_api_login.ex
+++ b/lib/constable/plugs/require_api_login.ex
@@ -10,6 +10,7 @@ defmodule Constable.Plugs.RequireApiLogin do
     case find_user(conn) do
       nil ->
         unauthorized(conn)
+
       user ->
         conn |> assign(:current_user, user)
     end
@@ -21,12 +22,13 @@ defmodule Constable.Plugs.RequireApiLogin do
   end
 
   def fetch_token(conn) do
-    get_req_header(conn, "authorization") |> List.first
+    get_req_header(conn, "authorization") |> List.first()
   end
 
   def find_user_from_token(nil), do: nil
+
   def find_user_from_token(token) do
-    Repo.get_by(User.active, token: token)
+    Repo.get_by(User.active(), token: token)
   end
 
   def unauthorized(conn) do

--- a/lib/constable/services/announcement_interest_associator.ex
+++ b/lib/constable/services/announcement_interest_associator.ex
@@ -13,7 +13,7 @@ defmodule Constable.Services.AnnouncementInterestAssociator do
   defp get_or_create_interests(names) do
     List.wrap(names)
     |> Enum.reject(&blank_interest?/1)
-    |> Enum.map(fn(name) ->
+    |> Enum.map(fn name ->
       interest = Interest.changeset(%{name: name})
 
       case Repo.get_by(Interest, interest.changes) do
@@ -21,16 +21,16 @@ defmodule Constable.Services.AnnouncementInterestAssociator do
         interest -> interest
       end
     end)
-    |> Enum.uniq
+    |> Enum.uniq()
   end
 
   defp associate_interests_with_announcement(interests, announcement) do
-    Enum.each(interests, fn(interest) ->
+    Enum.each(interests, fn interest ->
       %AnnouncementInterest{
         interest_id: interest.id,
         announcement_id: announcement.id
       }
-      |> Repo.insert!
+      |> Repo.insert!()
     end)
 
     announcement
@@ -41,7 +41,7 @@ defmodule Constable.Services.AnnouncementInterestAssociator do
   defp blank_interest?(_), do: false
 
   defp create_and_broadcast(changeset) do
-    interest = changeset |> Repo.insert!
+    interest = changeset |> Repo.insert!()
 
     ConstableWeb.Endpoint.broadcast!(
       "update",

--- a/lib/constable/services/announcement_updater.ex
+++ b/lib/constable/services/announcement_updater.ex
@@ -14,14 +14,18 @@ defmodule Constable.Services.AnnouncementUpdater do
         announcement
         |> clear_interests
         |> update_interests(interest_names)
+
         {:ok, announcement}
-      error -> error
+
+      error ->
+        error
     end
   end
 
   defp clear_interests(announcement) do
-    Repo.delete_all(from ai in AnnouncementInterest,
-      where: ai.announcement_id == ^announcement.id
+    Repo.delete_all(
+      from ai in AnnouncementInterest,
+        where: ai.announcement_id == ^announcement.id
     )
 
     announcement

--- a/lib/constable/services/comment_creator.ex
+++ b/lib/constable/services/comment_creator.ex
@@ -18,28 +18,31 @@ defmodule Constable.Services.CommentCreator do
         mentioned_users = email_mentioned_users(comment)
         email_subscribers(comment, mentioned_users)
         {:ok, comment}
-      {:error, changeset} -> {:error, changeset}
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 
   defp email_subscribers(comment, mentioned_users) do
-    users = find_subscribed_users(comment.announcement_id) -- mentioned_users
-    |> Enum.reject(fn (user) -> user.id == comment.user_id end)
+    users =
+      (find_subscribed_users(comment.announcement_id) -- mentioned_users)
+      |> Enum.reject(fn user -> user.id == comment.user_id end)
 
-    Emails.new_comment(comment, users) |> Mailer.deliver_later
+    Emails.new_comment(comment, users) |> Mailer.deliver_later()
     comment
   end
 
   defp email_mentioned_users(comment) do
     users = MentionFinder.find_users(comment.body)
 
-    Emails.new_comment_mention(comment, users) |> Mailer.deliver_later
+    Emails.new_comment_mention(comment, users) |> Mailer.deliver_later()
     users
   end
 
   defp find_subscribed_users(announcement_id) do
     Repo.all(Subscription.for_announcement(announcement_id))
-    |> Enum.map(fn (subscription) -> subscription.user end)
+    |> Enum.map(fn subscription -> subscription.user end)
   end
 
   defp broadcast(comment) do
@@ -55,7 +58,7 @@ defmodule Constable.Services.CommentCreator do
       "live-html",
       "new-comment",
       %{
-        comment: comment,
+        comment: comment
       }
     )
   end

--- a/lib/constable/services/daily_digest.ex
+++ b/lib/constable/services/daily_digest.ex
@@ -10,21 +10,26 @@ defmodule Constable.DailyDigest do
 
   def send_email(users, time) do
     if new_items_since?(time) do
-      Logger.info "Sending daily digest"
-      daily_digest_email(time, users) |> Mailer.deliver_now
+      Logger.info("Sending daily digest")
+      daily_digest_email(time, users) |> Mailer.deliver_now()
     else
-      Logger.info "No new items since: #{inspect time}"
+      Logger.info("No new items since: #{inspect(time)}")
     end
   end
 
   defp daily_digest_email(time, users) do
-    Emails.daily_digest(interests_since(time), announcements_since(time), comments_since(time), users)
+    Emails.daily_digest(
+      interests_since(time),
+      announcements_since(time),
+      comments_since(time),
+      users
+    )
   end
 
   defp new_items_since?(time) do
-    !Enum.empty?(announcements_since(time))
-    || !Enum.empty?(interests_since(time))
-    || !Enum.empty?(comments_since(time))
+    !Enum.empty?(announcements_since(time)) ||
+      !Enum.empty?(interests_since(time)) ||
+      !Enum.empty?(comments_since(time))
   end
 
   defp interests_since(time) do

--- a/lib/constable/services/email_reply_parser.ex
+++ b/lib/constable/services/email_reply_parser.ex
@@ -6,7 +6,7 @@ defmodule Constable.EmailReplyParser do
   end
 
   defp remove_quoted_email(body) do
-    Enum.reduce(reply_header_formats(), body, fn(regex, email_body) ->
+    Enum.reduce(reply_header_formats(), body, fn regex, email_body ->
       match = Regex.split(regex, email_body)
       List.first(match)
     end)
@@ -14,7 +14,7 @@ defmodule Constable.EmailReplyParser do
 
   defp reply_header_formats do
     [
-      ~r/\n\>?[[:space:]]*On.*<?\n?.*>?.*\n?wrote:\n?/,
+      ~r/\n\>?[[:space:]]*On.*<?\n?.*>?.*\n?wrote:\n?/
     ]
   end
 

--- a/lib/constable/services/mention_finder.ex
+++ b/lib/constable/services/mention_finder.ex
@@ -6,8 +6,8 @@ defmodule Constable.Services.MentionFinder do
 
   def find_users(text) do
     Regex.scan(@mention_regex, text)
-    |> Enum.map(fn ([_, username]) -> username end)
-    |> Enum.map(&(Repo.get_by(User.active, username: &1)))
+    |> Enum.map(fn [_, username] -> username end)
+    |> Enum.map(&Repo.get_by(User.active(), username: &1))
     |> Enum.reject(&is_nil/1)
   end
 end

--- a/lib/constable/services/slack_hook.ex
+++ b/lib/constable/services/slack_hook.ex
@@ -6,11 +6,14 @@ defmodule Constable.Services.SlackHook do
   def new_announcement(announcement) do
     announcement = announcement |> Repo.preload([:interests, :user])
 
-    Enum.each(announcement.interests, fn(interest) ->
+    Enum.each(announcement.interests, fn interest ->
       if interest.slack_channel do
         payload = %{
-          text: "#{announcement.user.name} posted <#{announcement_url(ConstableWeb.Endpoint, :show, announcement)}|#{announcement.title}>",
-          channel: interest.slack_channel,
+          text:
+            "#{announcement.user.name} posted <#{
+              announcement_url(ConstableWeb.Endpoint, :show, announcement)
+            }|#{announcement.title}>",
+          channel: interest.slack_channel
         }
 
         post(payload)
@@ -20,9 +23,9 @@ defmodule Constable.Services.SlackHook do
 
   defp post(payload) do
     if slack_webhook_url() do
-      spawn fn ->
+      spawn(fn ->
         HTTPoison.post(slack_webhook_url(), Poison.encode!(payload))
-      end
+      end)
     end
   end
 

--- a/lib/constable/time.ex
+++ b/lib/constable/time.ex
@@ -1,6 +1,6 @@
 defmodule Constable.Time do
   def now do
-    DateTime.utc_now
+    DateTime.utc_now()
   end
 
   def yesterday do
@@ -12,6 +12,6 @@ defmodule Constable.Time do
   end
 
   def cast!(time) do
-    time |> NaiveDateTime.from_erl! |> DateTime.from_naive!("Etc/UTC")
+    time |> NaiveDateTime.from_erl!() |> DateTime.from_naive!("Etc/UTC")
   end
 end

--- a/lib/constable_web/channels/live_html_channel.ex
+++ b/lib/constable_web/channels/live_html_channel.ex
@@ -12,7 +12,8 @@ defmodule ConstableWeb.LiveHtmlChannel do
       announcement_id: comment.announcement_id,
       comment_html: render_comment_html(comment, socket.assigns[:current_user])
     }
-    push socket, "new-comment", payload
+
+    push(socket, "new-comment", payload)
 
     {:noreply, socket}
   end

--- a/lib/constable_web/controllers/api/comment_controller.ex
+++ b/lib/constable_web/controllers/api/comment_controller.ex
@@ -12,6 +12,7 @@ defmodule ConstableWeb.Api.CommentController do
     case CommentCreator.create(params) do
       {:ok, comment} ->
         conn |> put_status(201) |> render("show.json", comment: comment)
+
       {:error, changeset} ->
         conn
         |> put_status(422)

--- a/lib/constable_web/controllers/api/interest_controller.ex
+++ b/lib/constable_web/controllers/api/interest_controller.ex
@@ -12,11 +12,12 @@ defmodule ConstableWeb.Api.InterestController do
 
   def show(conn, %{"id" => id}) do
     interest = Repo.get!(Interest, id)
-    render conn, "show.json", interest: interest
+    render(conn, "show.json", interest: interest)
   end
 
   def update(conn, %{"id" => id, "channel" => channel}) do
     interest = Repo.get!(Interest, id)
+
     case Repo.update(Interest.update_channel_changeset(interest, channel)) do
       {:ok, interest} ->
         ConstableWeb.Endpoint.broadcast!(
@@ -24,7 +25,9 @@ defmodule ConstableWeb.Api.InterestController do
           "interest:update",
           InterestView.render("show.json", %{interest: interest})
         )
+
         render(conn, "show.json", interest: interest)
+
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/lib/constable_web/controllers/api/search_controller.ex
+++ b/lib/constable_web/controllers/api/search_controller.ex
@@ -11,8 +11,9 @@ defmodule ConstableWeb.Api.SearchController do
     announcements =
       search_terms
       |> Announcement.search(exclude_interests: excludes)
-      |> Announcement.last_discussed_first
-      |> Repo.all
+      |> Announcement.last_discussed_first()
+      |> Repo.all()
+
     render(conn, "index.json", announcements: announcements)
   end
 end

--- a/lib/constable_web/controllers/api/subscription_controller.ex
+++ b/lib/constable_web/controllers/api/subscription_controller.ex
@@ -9,7 +9,7 @@ defmodule ConstableWeb.Api.SubscriptionController do
     current_user = current_user(conn)
     subscriptions = subscriptions_for(current_user)
 
-    render conn, "index.json", subscriptions: subscriptions
+    render(conn, "index.json", subscriptions: subscriptions)
   end
 
   def create(conn, %{"subscription" => params}) do
@@ -21,6 +21,7 @@ defmodule ConstableWeb.Api.SubscriptionController do
     case Repo.insert(changeset) do
       {:ok, subscription} ->
         conn |> put_status(201) |> render("show.json", subscription: subscription)
+
       {:error, changeset} ->
         conn
         |> put_status(422)
@@ -41,6 +42,6 @@ defmodule ConstableWeb.Api.SubscriptionController do
   end
 
   defp subscriptions_for(user) do
-    Repo.all Ecto.assoc(user, :subscriptions)
+    Repo.all(Ecto.assoc(user, :subscriptions))
   end
 end

--- a/lib/constable_web/controllers/api/user_interest_controller.ex
+++ b/lib/constable_web/controllers/api/user_interest_controller.ex
@@ -12,7 +12,7 @@ defmodule ConstableWeb.Api.UserInterestController do
 
   def show(conn, %{"id" => id}) do
     user_interest = Repo.get!(UserInterest, id)
-    render conn, "show.json", user_interest: user_interest
+    render(conn, "show.json", user_interest: user_interest)
   end
 
   def create(conn, %{"user_interest" => params}) do
@@ -24,6 +24,7 @@ defmodule ConstableWeb.Api.UserInterestController do
     case Repo.insert(changeset) do
       {:ok, user_interest} ->
         conn |> put_status(201) |> render("show.json", user_interest: user_interest)
+
       {:error, changeset} ->
         conn
         |> put_status(422)
@@ -44,6 +45,6 @@ defmodule ConstableWeb.Api.UserInterestController do
   end
 
   defp user_interests_for(user) do
-    Repo.all Ecto.assoc(user, :user_interests)
+    Repo.all(Ecto.assoc(user, :user_interests))
   end
 end

--- a/lib/constable_web/controllers/email_forward_controller.ex
+++ b/lib/constable_web/controllers/email_forward_controller.ex
@@ -3,7 +3,7 @@ defmodule ConstableWeb.EmailForwardController do
 
   def create(conn, %{"mandrill_events" => messages}) do
     messages
-    |> Poison.decode!
+    |> Poison.decode!()
     |> forward_emails_to_admins
 
     text(conn, nil)
@@ -12,8 +12,8 @@ defmodule ConstableWeb.EmailForwardController do
   defp forward_emails_to_admins(forwarded_emails) do
     for %{"msg" => message} <- forwarded_emails do
       message
-      |> Constable.Emails.forwarded_email
-      |> Constable.Mailer.deliver_now
+      |> Constable.Emails.forwarded_email()
+      |> Constable.Mailer.deliver_now()
     end
   end
 end

--- a/lib/constable_web/controllers/email_preview_controller.ex
+++ b/lib/constable_web/controllers/email_preview_controller.ex
@@ -5,9 +5,10 @@ defmodule ConstableWeb.EmailPreviewController do
   alias Constable.Emails
 
   def show(conn, %{"email_name" => email_name}) do
-    {:error, body} = Repo.transaction fn ->
-      email_body(email_name) |> Repo.rollback
-    end
+    {:error, body} =
+      Repo.transaction(fn ->
+        email_body(email_name) |> Repo.rollback()
+      end)
 
     html(conn, body)
   end
@@ -47,7 +48,7 @@ defmodule ConstableWeb.EmailPreviewController do
         insert(:comment, user: user_2, announcement: announcement_with_comments),
         insert(:comment, user: user_1, announcement: other_announcement_with_comments),
         insert(:comment, user: user_2, announcement: other_announcement_with_comments),
-        insert(:comment, user: user_2, announcement: other_announcement_with_comments),
+        insert(:comment, user: user_2, announcement: other_announcement_with_comments)
       ],
       []
     )
@@ -56,9 +57,9 @@ defmodule ConstableWeb.EmailPreviewController do
   defp email_for(email_name) do
     %{
       html_body: """
-      <h1>There is no email preview for #{inspect email_name}</h1>
+      <h1>There is no email preview for #{inspect(email_name)}</h1>
       <p>
-        Add one to #{inspect __MODULE__}
+        Add one to #{inspect(__MODULE__)}
       </p>
       """
     }

--- a/lib/constable_web/controllers/email_reply_controller.ex
+++ b/lib/constable_web/controllers/email_reply_controller.ex
@@ -6,7 +6,7 @@ defmodule ConstableWeb.EmailReplyController do
 
   def create(conn, %{"mandrill_events" => messages}) do
     messages
-    |> Poison.decode!
+    |> Poison.decode!()
     |> create_comments
 
     text(conn, nil)
@@ -14,12 +14,11 @@ defmodule ConstableWeb.EmailReplyController do
 
   defp create_comments(messages) do
     for message <- messages do
-      message |> comment_params |> CommentCreator.create
+      message |> comment_params |> CommentCreator.create()
     end
   end
 
-  defp comment_params(
-    %{"msg" => %{"text" => email_body, "email" => to, "from_email" => from}}) do
+  defp comment_params(%{"msg" => %{"text" => email_body, "email" => to, "from_email" => from}}) do
     %{
       user_id: user_from_email(from).id,
       announcement_id: announcement_id_from_email(to),
@@ -28,10 +27,10 @@ defmodule ConstableWeb.EmailReplyController do
   end
 
   defp user_from_email(email_address) do
-    User.with_email(email_address) |> Repo.one
+    User.with_email(email_address) |> Repo.one()
   end
 
   defp announcement_id_from_email("announcement-" <> key_and_domain) do
-    key_and_domain |> String.split("@") |> List.first
+    key_and_domain |> String.split("@") |> List.first()
   end
 end

--- a/lib/constable_web/controllers/interest_controller.ex
+++ b/lib/constable_web/controllers/interest_controller.ex
@@ -32,16 +32,16 @@ defmodule ConstableWeb.InterestController do
   end
 
   defp preload_interests(user) do
-    Repo.preload user, :interests
+    Repo.preload(user, :interests)
   end
 
   defp all_interests do
-    Repo.all Interest.ordered_by_name
+    Repo.all(Interest.ordered_by_name())
   end
 
   defp sorted_announcements(interest) do
     Ecto.assoc(interest, :announcements)
-    |> Announcement.last_discussed_first
-    |> Announcement.with_announcement_list_assocs
+    |> Announcement.last_discussed_first()
+    |> Announcement.with_announcement_list_assocs()
   end
 end

--- a/lib/constable_web/controllers/recipients_preview_controller.ex
+++ b/lib/constable_web/controllers/recipients_preview_controller.ex
@@ -15,13 +15,15 @@ defmodule ConstableWeb.RecipientsPreviewController do
   end
 
   defp interested_user_names(interest_names) do
-    query = from u in User,
-              distinct: true,
-              join: i in assoc(u, :interests),
-              order_by: u.name,
-              select: u.name,
-              where: u.active == true,
-              where: i.name in ^interest_names
+    query =
+      from u in User,
+        distinct: true,
+        join: i in assoc(u, :interests),
+        order_by: u.name,
+        select: u.name,
+        where: u.active == true,
+        where: i.name in ^interest_names
+
     Repo.all(query)
   end
 end

--- a/lib/constable_web/controllers/search_controller.ex
+++ b/lib/constable_web/controllers/search_controller.ex
@@ -15,15 +15,15 @@ defmodule ConstableWeb.SearchController do
   end
 
   def new(conn, _params) do
-    render conn, "new.html", announcements: []
+    render(conn, "new.html", announcements: [])
   end
 
   defp matching_announcements(params = %{"query" => search_terms}) do
     excluded_interests = params["exclude_interests"] || []
 
     Announcement.search(search_terms, exclude_interests: excluded_interests)
-    |> Announcement.last_discussed_first
-    |> Announcement.with_announcement_list_assocs
+    |> Announcement.last_discussed_first()
+    |> Announcement.with_announcement_list_assocs()
   end
 
   defp matching_announcements(_params = %{}) do

--- a/lib/constable_web/controllers/settings_controller.ex
+++ b/lib/constable_web/controllers/settings_controller.ex
@@ -5,7 +5,7 @@ defmodule ConstableWeb.SettingsController do
 
   def show(conn, _params) do
     changeset = User.settings_changeset(conn.assigns.current_user)
-    render conn, "show.html", changeset: changeset
+    render(conn, "show.html", changeset: changeset)
   end
 
   def update(conn, %{"user" => user_params}) do
@@ -16,6 +16,7 @@ defmodule ConstableWeb.SettingsController do
         conn
         |> put_flash(:success, "YES!")
         |> render("show.html", changeset: changeset)
+
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/lib/constable_web/controllers/slack_channel_controller.ex
+++ b/lib/constable_web/controllers/slack_channel_controller.ex
@@ -6,14 +6,16 @@ defmodule ConstableWeb.SlackChannelController do
   def edit(conn, %{"interest_id_or_name" => name}) do
     interest = find_interest(name)
     changeset = Interest.update_channel_changeset(interest, interest.slack_channel)
-    render conn, "edit.html", interest: interest, changeset: changeset
+    render(conn, "edit.html", interest: interest, changeset: changeset)
   end
 
   def update(conn, %{"interest_id_or_name" => name, "interest" => %{"slack_channel" => channel}}) do
     interest = find_interest(name)
+
     case Repo.update(Interest.update_channel_changeset(interest, channel)) do
       {:ok, interest} ->
-        redirect conn, to: Routes.interest_path(conn, :show, interest)
+        redirect(conn, to: Routes.interest_path(conn, :show, interest))
+
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -24,7 +26,7 @@ defmodule ConstableWeb.SlackChannelController do
   def delete(conn, %{"interest_id_or_name" => name}) do
     interest = find_interest(name)
     Repo.update!(Interest.changeset(interest, %{slack_channel: nil}))
-    redirect conn, to: Routes.interest_path(conn, :show, interest)
+    redirect(conn, to: Routes.interest_path(conn, :show, interest))
   end
 
   defp find_interest(interest_name) do

--- a/lib/constable_web/controllers/subscriptions_controller.ex
+++ b/lib/constable_web/controllers/subscriptions_controller.ex
@@ -6,10 +6,11 @@ defmodule ConstableWeb.SubscriptionController do
   plug Constable.Plugs.Deslugifier, slugified_key: "announcement_id"
 
   def create(conn, %{"announcement_id" => announcement_id}) do
-    changeset = Subscription.changeset(%{
-      announcement_id: announcement_id,
-      user_id: conn.assigns.current_user.id,
-    })
+    changeset =
+      Subscription.changeset(%{
+        announcement_id: announcement_id,
+        user_id: conn.assigns.current_user.id
+      })
 
     Repo.insert!(changeset)
 
@@ -17,10 +18,11 @@ defmodule ConstableWeb.SubscriptionController do
   end
 
   def delete(conn, %{"announcement_id" => announcement_id}) do
-    subscription = Repo.get_by(Subscription,
-      announcement_id: announcement_id,
-      user_id: conn.assigns.current_user.id
-    )
+    subscription =
+      Repo.get_by(Subscription,
+        announcement_id: announcement_id,
+        user_id: conn.assigns.current_user.id
+      )
 
     Repo.delete!(subscription)
     redirect(conn, to: Routes.announcement_path(conn, :show, announcement_id))

--- a/lib/constable_web/controllers/user_activation_controller.ex
+++ b/lib/constable_web/controllers/user_activation_controller.ex
@@ -13,7 +13,7 @@ defmodule ConstableWeb.UserActivationController do
     new_activation_status = !user.active
 
     Ecto.Changeset.change(user, %{active: new_activation_status})
-    |> Repo.update!
+    |> Repo.update!()
 
     redirect(conn, to: Routes.user_activation_path(conn, :index))
   end

--- a/lib/constable_web/controllers/user_interest_controller.ex
+++ b/lib/constable_web/controllers/user_interest_controller.ex
@@ -8,7 +8,7 @@ defmodule ConstableWeb.UserInterestController do
     current_user = current_user(conn)
 
     UserInterest.changeset(%{user_id: current_user.id, interest_id: interest.id})
-    |> Repo.insert!
+    |> Repo.insert!()
 
     redirect(conn, to: Routes.interest_path(conn, :index))
   end
@@ -18,7 +18,7 @@ defmodule ConstableWeb.UserInterestController do
 
     UserInterest
     |> Repo.get_by!(interest_id: interest.id, user_id: current_user(conn).id)
-    |> Repo.delete!
+    |> Repo.delete!()
 
     redirect(conn, to: Routes.interest_path(conn, :index))
   end

--- a/lib/constable_web/emails.ex
+++ b/lib/constable_web/emails.ex
@@ -36,6 +36,7 @@ defmodule Constable.Emails do
 
   def new_announcement(announcement, recipients) do
     announcement = announcement |> Repo.preload([:user, :interests])
+
     base_email()
     |> to(recipients)
     |> subject(announcement.title)
@@ -53,6 +54,7 @@ defmodule Constable.Emails do
 
   def new_comment(comment, recipients, mentioner \\ nil) do
     announcement = comment.announcement
+
     base_email()
     |> to(recipients)
     |> subject("Re: #{announcement.title}")
@@ -75,6 +77,7 @@ defmodule Constable.Emails do
 
   def new_announcement_mention(announcement, recipients) do
     announcement = announcement |> Repo.preload([:user, :interests])
+
     base_email()
     |> to(recipients)
     |> subject("You were mentioned in: #{announcement.title}")
@@ -114,17 +117,19 @@ defmodule Constable.Emails do
   end
 
   defp unsubscribe_vars(recipients, announcement) do
-    Enum.map(recipients, fn(recipient) ->
-      subscription = Repo.get_by(Subscription,
-        announcement_id: announcement.id,
-        user_id: recipient.id
-      )
+    Enum.map(recipients, fn recipient ->
+      subscription =
+        Repo.get_by(Subscription,
+          announcement_id: announcement.id,
+          user_id: recipient.id
+        )
 
       case subscription do
         nil -> nil
         subscription -> subscription_merge_var(recipient, subscription)
       end
-    end) |> Enum.reject(&is_nil/1)
+    end)
+    |> Enum.reject(&is_nil/1)
   end
 
   defp subscription_merge_var(recipient, subscription) do

--- a/lib/constable_web/router.ex
+++ b/lib/constable_web/router.ex
@@ -8,7 +8,7 @@ defmodule ConstableWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
 
-    if Mix.env == :test do
+    if Mix.env() == :test do
       plug Constable.Plugs.SetUserIdFromParams
     end
 
@@ -26,7 +26,7 @@ defmodule ConstableWeb.Router do
 
     resources "/unsubscribe", UnsubscribeController, only: [:show]
 
-    if Mix.env == :dev do
+    if Mix.env() == :dev do
       get "/emails/:email_name", EmailPreviewController, :show
     end
   end
@@ -36,21 +36,33 @@ defmodule ConstableWeb.Router do
 
     get "/", HomeController, :index
 
-    resources "/announcements", AnnouncementController, only: [:index, :show, :new, :create, :edit, :delete, :update] do
+    resources "/announcements", AnnouncementController,
+      only: [:index, :show, :new, :create, :edit, :delete, :update] do
       resources "/comments", CommentController, only: [:create, :edit, :update]
-      resources "/subscriptions", SubscriptionController, singleton: true, only: [:create, :delete]
+
+      resources "/subscriptions", SubscriptionController,
+        singleton: true,
+        only: [:create, :delete]
     end
+
     resources "/settings", SettingsController, singleton: true, only: [:show, :update]
+
     resources "/interests", InterestController, only: [:index, :show], param: "id_or_name" do
-      resources "/slack_channel", SlackChannelController, singleton: true, only: [:edit, :update, :delete]
-      resources "/user_interest", UserInterestController, singleton: true, only: [:create, :delete]
+      resources "/slack_channel", SlackChannelController,
+        singleton: true,
+        only: [:edit, :update, :delete]
+
+      resources "/user_interest", UserInterestController,
+        singleton: true,
+        only: [:create, :delete]
     end
+
     resources "/search", SearchController, singleton: true, only: [:show, :new]
     resources "/recipients_preview", RecipientsPreviewController, singleton: true, only: [:show]
     resources "/user_activations", UserActivationController, only: [:index, :update]
   end
 
-  if Mix.env == :dev do
+  if Mix.env() == :dev do
     forward "/sent_emails", Bamboo.SentEmailViewerPlug
   end
 

--- a/lib/constable_web/views/announcement_list_view.ex
+++ b/lib/constable_web/views/announcement_list_view.ex
@@ -2,7 +2,7 @@ defmodule ConstableWeb.AnnouncementListView do
   use ConstableWeb, :view
 
   def commenters(announcement) do
-    comment_users = Enum.map(announcement.comments, &(&1.user))
+    comment_users = Enum.map(announcement.comments, & &1.user)
 
     Enum.uniq([announcement.user | comment_users])
   end

--- a/lib/constable_web/views/api/announcement_view.ex
+++ b/lib/constable_web/views/api/announcement_view.ex
@@ -5,8 +5,9 @@ defmodule ConstableWeb.Api.AnnouncementView do
 
   def render("index.json", %{announcements: announcements}) do
     announcements = announcements |> Repo.preload([:comments, :interests])
+
     %{
-      announcements: render_many(announcements, __MODULE__, "announcement.json"),
+      announcements: render_many(announcements, __MODULE__, "announcement.json")
     }
   end
 
@@ -25,7 +26,8 @@ defmodule ConstableWeb.Api.AnnouncementView do
       user_id: announcement.user_id,
       comments: render_many(announcement.comments, CommentView, "comment.json"),
       interest_ids: pluck(announcement.interests, :id),
-      url: ConstableWeb.Router.Helpers.announcement_url(ConstableWeb.Endpoint, :show, announcement)
+      url:
+        ConstableWeb.Router.Helpers.announcement_url(ConstableWeb.Endpoint, :show, announcement)
     }
   end
 end

--- a/lib/constable_web/views/api/comment_view.ex
+++ b/lib/constable_web/views/api/comment_view.ex
@@ -15,7 +15,7 @@ defmodule ConstableWeb.Api.CommentView do
       body: comment.body,
       announcement_id: comment.announcement_id,
       user_id: comment.user_id,
-      inserted_at: comment.inserted_at,
+      inserted_at: comment.inserted_at
     }
   end
 end

--- a/lib/constable_web/views/api/interest_view.ex
+++ b/lib/constable_web/views/api/interest_view.ex
@@ -13,7 +13,7 @@ defmodule ConstableWeb.Api.InterestView do
     %{
       id: interest.id,
       name: interest.name,
-      slack_channel: interest.slack_channel,
+      slack_channel: interest.slack_channel
     }
   end
 end

--- a/lib/constable_web/views/api/subscription_view.ex
+++ b/lib/constable_web/views/api/subscription_view.ex
@@ -2,11 +2,17 @@ defmodule ConstableWeb.Api.SubscriptionView do
   use ConstableWeb, :view
 
   def render("index.json", %{subscriptions: subscriptions}) do
-    %{subscriptions: render_many(subscriptions, ConstableWeb.Api.SubscriptionView, "subscription.json")}
+    %{
+      subscriptions:
+        render_many(subscriptions, ConstableWeb.Api.SubscriptionView, "subscription.json")
+    }
   end
 
   def render("show.json", %{subscription: subscription}) do
-    %{subscription: render_one(subscription, ConstableWeb.Api.SubscriptionView, "subscription.json")}
+    %{
+      subscription:
+        render_one(subscription, ConstableWeb.Api.SubscriptionView, "subscription.json")
+    }
   end
 
   def render("subscription.json", %{subscription: subscription}) do

--- a/lib/constable_web/views/api/user_interest_view.ex
+++ b/lib/constable_web/views/api/user_interest_view.ex
@@ -2,11 +2,17 @@ defmodule ConstableWeb.Api.UserInterestView do
   use ConstableWeb, :view
 
   def render("index.json", %{user_interests: user_interests}) do
-    %{user_interests: render_many(user_interests, ConstableWeb.Api.UserInterestView, "user_interest.json")}
+    %{
+      user_interests:
+        render_many(user_interests, ConstableWeb.Api.UserInterestView, "user_interest.json")
+    }
   end
 
   def render("show.json", %{user_interest: user_interest}) do
-    %{user_interest: render_one(user_interest, ConstableWeb.Api.UserInterestView, "user_interest.json")}
+    %{
+      user_interest:
+        render_one(user_interest, ConstableWeb.Api.UserInterestView, "user_interest.json")
+    }
   end
 
   def render("user_interest.json", %{user_interest: user_interest}) do

--- a/lib/constable_web/views/error_helpers.ex
+++ b/lib/constable_web/views/error_helpers.ex
@@ -10,7 +10,11 @@ defmodule ConstableWeb.ErrorHelpers do
   """
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error), id: "#{field}_error", class: "help-block", role: "alert")
+      content_tag(:span, translate_error(error),
+        id: "#{field}_error",
+        class: "help-block",
+        role: "alert"
+      )
     end)
   end
 

--- a/lib/constable_web/views/recipients_preview_view.ex
+++ b/lib/constable_web/views/recipients_preview_view.ex
@@ -2,7 +2,7 @@ defmodule ConstableWeb.RecipientsPreviewView do
   use ConstableWeb, :view
 
   def render("show.json", assigns) do
-    %{ recipients_preview_html: render_recipients_preview_html(assigns) }
+    %{recipients_preview_html: render_recipients_preview_html(assigns)}
   end
 
   defp render_recipients_preview_html(assigns) do

--- a/lib/enum_helper.ex
+++ b/lib/enum_helper.ex
@@ -1,6 +1,6 @@
 defmodule Constable.EnumHelper do
   def pluck(enumerable, property) do
-    Enum.map(enumerable, fn(object) ->
+    Enum.map(enumerable, fn object ->
       Map.get(object, property)
     end)
   end

--- a/lib/mix/tasks/refresh_last_discussed_at.ex
+++ b/lib/mix/tasks/refresh_last_discussed_at.ex
@@ -4,15 +4,16 @@ defmodule Mix.Tasks.Constable.RefreshLastDiscussedAt do
   import Ecto.Query
 
   def run(_opts) do
-    Mix.Task.run "app.start"
+    Mix.Task.run("app.start")
 
     for announcement <- Repo.all(Constable.Announcement) do
-      latest_comment_inserted_at = announcement
+      latest_comment_inserted_at =
+        announcement
         |> Ecto.assoc(:comments)
         |> limit(1)
         |> order_by(desc: :inserted_at)
         |> select([a], a.inserted_at)
-        |> Repo.one
+        |> Repo.one()
 
       last_discussed_at_params = %{
         last_discussed_at: latest_comment_inserted_at || announcement.inserted_at
@@ -20,7 +21,7 @@ defmodule Mix.Tasks.Constable.RefreshLastDiscussedAt do
 
       announcement
       |> Ecto.Changeset.cast(last_discussed_at_params, [:last_discussed_at], [])
-      |> Repo.update!
+      |> Repo.update!()
     end
   end
 end

--- a/lib/mix/tasks/send_daily_digest.ex
+++ b/lib/mix/tasks/send_daily_digest.ex
@@ -7,17 +7,21 @@ defmodule Mix.Tasks.Constable.SendDailyDigest do
   alias Constable.User
 
   def run(_) do
-    Mix.Task.run "app.start"
-    users = Repo.all(from u in User.active, where: u.daily_digest == true)
-    user_emails = for user <- users do
-      user.email
-    end
-    Logger.info """
+    Mix.Task.run("app.start")
+    users = Repo.all(from u in User.active(), where: u.daily_digest == true)
+
+    user_emails =
+      for user <- users do
+        user.email
+      end
+
+    Logger.info("""
     Users with Daily Digest enabled:
 
-    #{inspect user_emails}
-    """
-    since = Constable.Time.yesterday
+    #{inspect(user_emails)}
+    """)
+
+    since = Constable.Time.yesterday()
     Constable.Pact.get(:daily_digest).send_email(users, since)
   end
 end

--- a/priv/repo/migrations/20150206153434_create_users.exs
+++ b/priv/repo/migrations/20150206153434_create_users.exs
@@ -8,6 +8,7 @@ defmodule Constable.Repo.Migrations.CreateUsers do
 
       timestamps()
     end
+
     create index(:users, [:email], unique: true)
   end
 end

--- a/priv/repo/migrations/20150227200438_create_announcements_interests.exs
+++ b/priv/repo/migrations/20150227200438_create_announcements_interests.exs
@@ -10,9 +10,9 @@ defmodule Constable.Repo.Migrations.CreateAnnouncementsInterests do
     end
 
     create index(
-      :announcements_interests,
-      [:announcement_id, :interest_id],
-      unique: true
-    )
+             :announcements_interests,
+             [:announcement_id, :interest_id],
+             unique: true
+           )
   end
 end

--- a/priv/repo/migrations/20150227210639_create_users_interests.exs
+++ b/priv/repo/migrations/20150227210639_create_users_interests.exs
@@ -10,9 +10,9 @@ defmodule Constable.Repo.Migrations.CreateUsersInterests do
     end
 
     create index(
-      :users_interests,
-      [:interest_id, :user_id],
-      unique: true
-    )
+             :users_interests,
+             [:interest_id, :user_id],
+             unique: true
+           )
   end
 end

--- a/priv/repo/migrations/20150826133822_add_null_constraint_to_username.exs
+++ b/priv/repo/migrations/20150826133822_add_null_constraint_to_username.exs
@@ -5,7 +5,7 @@ defmodule Constable.Repo.Migrations.AddNullConstrainToUsername do
   def up do
     {:ok, %{rows: users}} = Ecto.Adapters.SQL.query(Repo, "SELECT id,email FROM users", [])
 
-    Enum.each(users, fn([id, email]) ->
+    Enum.each(users, fn [id, email] ->
       [name, _] = String.split(email, "@")
 
       query = "UPDATE users SET username = $1 WHERE id = $2"

--- a/priv/repo/migrations/20150921194253_generate_subscription_tokens.exs
+++ b/priv/repo/migrations/20150921194253_generate_subscription_tokens.exs
@@ -7,16 +7,16 @@ defmodule Constable.Repo.Migrations.GenerateSubscriptionTokens do
     use Ecto.Schema
 
     schema "subscriptions" do
-      field :token
+      field(:token)
     end
   end
 
   def up do
     subscriptions = Repo.all(Subscription)
 
-    Enum.each(subscriptions, fn(subscription) ->
+    Enum.each(subscriptions, fn subscription ->
       %{subscription | token: SecureRandom.urlsafe_base64(32)}
-      |> Repo.update
+      |> Repo.update()
     end)
 
     alter table(:subscriptions) do

--- a/test/acceptance/user_unsubscribes_test.exs
+++ b/test/acceptance/user_unsubscribes_test.exs
@@ -15,6 +15,7 @@ defmodule ConstableWeb.UserUnsubscribesTest do
 
   test "shows unsubscribed message when logged out", %{session: session} do
     subscription = insert(:subscription)
+
     session
     |> visit(Routes.unsubscribe_path(Endpoint, :show, subscription.token))
 

--- a/test/controllers/announcement_controller_test.exs
+++ b/test/controllers/announcement_controller_test.exs
@@ -36,16 +36,20 @@ defmodule ConstableWeb.AnnouncementControllerTest do
     %{conn: conn, user: user}
   ) do
     other_user = insert(:user)
+
     announcement_with_user_comment =
       insert(:announcement, title: "FooBar with My Comment", user: other_user)
+
     announcement_without_user_comment =
       insert(:announcement, title: "FizzBuzz without My Comments", user: user)
+
     insert(
       :comment,
       body: "First! 👋",
       announcement: announcement_with_user_comment,
       user: user
     )
+
     insert(
       :comment,
       body: "word",

--- a/test/controllers/api/announcement_controller_test.exs
+++ b/test/controllers/api/announcement_controller_test.exs
@@ -11,7 +11,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#index lists all announcements", %{conn: conn, user: user} do
     announcements = insert_pair(:announcement, user: user)
 
-    conn = get conn, Routes.api_announcement_path(conn, :index)
+    conn = get(conn, Routes.api_announcement_path(conn, :index))
 
     assert json_response(conn, 200) == render_json("index.json", announcements: announcements)
   end
@@ -19,7 +19,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#show renders single announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user)
 
-    conn = get conn, Routes.api_announcement_path(conn, :show, announcement)
+    conn = get(conn, Routes.api_announcement_path(conn, :show, announcement))
 
     assert json_response(conn, 200) == render_json("show.json", announcement: announcement)
   end
@@ -27,7 +27,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#show uses iso8601 timestamps", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user, updated_at: ~N[2018-01-01 15:15:15.000000])
 
-    conn = get conn, Routes.api_announcement_path(conn, :show, announcement)
+    conn = get(conn, Routes.api_announcement_path(conn, :show, announcement))
     body = json_response(conn, 200)
 
     # A previous Ecto version upgrade caused a regression around datetime formats
@@ -37,15 +37,18 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#create with valid attributes saves an announcement", %{conn: conn} do
     announcement_params = build(:announcement_params)
 
-    conn = post conn, Routes.api_announcement_path(conn, :create), %{
-      announcement: announcement_params,
-      interest_names: ["foo"]
-    }
+    conn =
+      post conn, Routes.api_announcement_path(conn, :create), %{
+        announcement: announcement_params,
+        interest_names: ["foo"]
+      }
 
     announcement = Repo.one(Announcement) |> Repo.preload(:interests)
-    interest_names = Enum.map(announcement.interests, fn(interest) ->
-      interest.name
-    end)
+
+    interest_names =
+      Enum.map(announcement.interests, fn interest ->
+        interest.name
+      end)
 
     assert json_response(conn, 201)
     assert announcement.title == announcement_params.title
@@ -54,10 +57,11 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   end
 
   test "#create with invalid attributes renders errors", %{conn: conn} do
-    conn = post conn,
-      Routes.api_announcement_path(conn, :create),
-      announcement: %{},
-      interest_names: %{}
+    conn =
+      post conn,
+           Routes.api_announcement_path(conn, :create),
+           announcement: %{},
+           interest_names: %{}
 
     assert %{"errors" => _} = json_response(conn, 422)
   end
@@ -65,13 +69,15 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#update with valid attributes updates announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user, title: "Foo")
 
-    put conn, Routes.api_announcement_path(conn, :update, announcement), announcement: %{
-      title: "Foobar",
-      body: "wat"
-    }, interest_names: ["foo"]
+    put conn, Routes.api_announcement_path(conn, :update, announcement),
+      announcement: %{
+        title: "Foobar",
+        body: "wat"
+      },
+      interest_names: ["foo"]
 
     announcement = Repo.one(Announcement) |> Repo.preload(:interests)
-    interest_names = Enum.map(announcement.interests, &(&1.name))
+    interest_names = Enum.map(announcement.interests, & &1.name)
     assert announcement.title == "Foobar"
     assert interest_names == ["foo"]
   end
@@ -79,10 +85,13 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#update with invalid attributes renders errors", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user)
 
-    conn = put conn, Routes.api_announcement_path(conn, :update, announcement), announcement: %{
-      title: nil,
-      body: nil
-    }, interest_names: ["Foo"]
+    conn =
+      put conn, Routes.api_announcement_path(conn, :update, announcement),
+        announcement: %{
+          title: nil,
+          body: nil
+        },
+        interest_names: ["Foo"]
 
     assert %{"errors" => _} = json_response(conn, 422)
   end
@@ -91,10 +100,11 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
     other_user = insert(:user)
     announcement = insert(:announcement, user: other_user)
 
-    conn = put conn,
-      Routes.api_announcement_path(conn, :update, announcement),
-      announcement: %{},
-      interest_names: []
+    conn =
+      put conn,
+          Routes.api_announcement_path(conn, :update, announcement),
+          announcement: %{},
+          interest_names: []
 
     assert response(conn, 401)
   end
@@ -102,7 +112,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
   test "#delete deletes announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement, user: user)
 
-    conn = delete conn, Routes.api_announcement_path(conn, :delete, announcement)
+    conn = delete(conn, Routes.api_announcement_path(conn, :delete, announcement))
 
     assert Repo.count(Announcement) == 0
     assert response(conn, 204)
@@ -112,7 +122,7 @@ defmodule ConstableWeb.Api.AnnouncementControllerTest do
     other_user = insert(:user)
     announcement = insert(:announcement, user: other_user)
 
-    conn = delete conn, Routes.api_announcement_path(conn, :delete, announcement)
+    conn = delete(conn, Routes.api_announcement_path(conn, :delete, announcement))
 
     assert response(conn, 401)
   end

--- a/test/controllers/api/comment_controller_test.exs
+++ b/test/controllers/api/comment_controller_test.exs
@@ -13,10 +13,12 @@ defmodule ConstableWeb.Api.CommentControllerTest do
     announcement = insert(:announcement)
     subscribed_user = insert(:user) |> with_subscription(announcement)
 
-    conn = post conn, Routes.api_comment_path(conn, :create), comment: %{
-      body: "Foo",
-      announcement_id: announcement.id
-    }
+    conn =
+      post conn, Routes.api_comment_path(conn, :create),
+        comment: %{
+          body: "Foo",
+          announcement_id: announcement.id
+        }
 
     assert json_response(conn, 201)
     comment = Repo.one(Comment) |> Repo.preload([:user, announcement: :user])
@@ -24,6 +26,6 @@ defmodule ConstableWeb.Api.CommentControllerTest do
     assert comment.user_id == user.id
     assert comment.announcement_id == announcement.id
 
-    assert_delivered_email Emails.new_comment(comment, [subscribed_user])
+    assert_delivered_email(Emails.new_comment(comment, [subscribed_user]))
   end
 end

--- a/test/controllers/api/interest_controller_test.exs
+++ b/test/controllers/api/interest_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ConstableWeb.Api.InterestControllerTest do
   test "#index displays all interests", %{conn: conn} do
     interests = insert_pair(:interest)
 
-    conn = get conn, Routes.api_interest_path(conn, :index)
+    conn = get(conn, Routes.api_interest_path(conn, :index))
 
     assert json_response(conn, 200) == render_json("index.json", interests: interests)
   end
@@ -18,7 +18,7 @@ defmodule ConstableWeb.Api.InterestControllerTest do
   test "#show displays a single interest", %{conn: conn} do
     interest = insert(:interest)
 
-    conn = get conn, Routes.api_interest_path(conn, :show, interest.id)
+    conn = get(conn, Routes.api_interest_path(conn, :show, interest.id))
 
     assert json_response(conn, 200)["interest"]["id"] == interest.id
   end

--- a/test/controllers/api/search_controller_test.exs
+++ b/test/controllers/api/search_controller_test.exs
@@ -8,28 +8,35 @@ defmodule ConstableWeb.Api.SearchesControllerTest do
   end
 
   test "returns matching announcements", %{conn: conn} do
-    announcement_1 = insert(
-      :announcement,
-      title: "foobar1",
-      last_discussed_at: ~N[2018-01-01 15:15:15.000000]
-    )
-    announcement_2 = insert(
-      :announcement,
-      body: "announcement body cool",
-      last_discussed_at: ~N[2018-01-02 15:15:15.000000]
-    )
-    announcement_3 = insert(
-      :announcement,
-      title: "awesome title",
-      body: "cool body",
-      last_discussed_at: ~N[2018-01-03 15:15:15.000000]
-    )
-    announcement_4 = insert(
-      :announcement,
-      title: "sweet 401(k) bro",
-      body: "sweet 401k",
-      last_discussed_at: ~N[2018-01-04 15:15:15.000000]
-    )
+    announcement_1 =
+      insert(
+        :announcement,
+        title: "foobar1",
+        last_discussed_at: ~N[2018-01-01 15:15:15.000000]
+      )
+
+    announcement_2 =
+      insert(
+        :announcement,
+        body: "announcement body cool",
+        last_discussed_at: ~N[2018-01-02 15:15:15.000000]
+      )
+
+    announcement_3 =
+      insert(
+        :announcement,
+        title: "awesome title",
+        body: "cool body",
+        last_discussed_at: ~N[2018-01-03 15:15:15.000000]
+      )
+
+    announcement_4 =
+      insert(
+        :announcement,
+        title: "sweet 401(k) bro",
+        body: "sweet 401k",
+        last_discussed_at: ~N[2018-01-04 15:15:15.000000]
+      )
 
     assert results_for(conn, query: "foobar1") == json_for(announcement_1)
     assert results_for(conn, query: "announcement body") == json_for(announcement_2)
@@ -44,14 +51,20 @@ defmodule ConstableWeb.Api.SearchesControllerTest do
     lame = insert(:interest, name: "lame")
     other = insert(:interest, name: "other")
     insert(:announcement, title: "foobar1") |> tag_with_interest(lame)
-    announcement_2 = insert(:announcement, body: "announcement body cool")
-      |> tag_with_interest(other)
-    insert(:announcement, title: "awesome title", body: "cool body")
-      |> tag_with_interest(lame)
+
+    announcement_2 =
+      insert(:announcement, body: "announcement body cool")
       |> tag_with_interest(other)
 
+    insert(:announcement, title: "awesome title", body: "cool body")
+    |> tag_with_interest(lame)
+    |> tag_with_interest(other)
+
     assert results_for(conn, query: "foobar1", exclude: ["lame"]) == json_for([])
-    assert results_for(conn, query: "announcement body", exclude: ["lame"]) == json_for(announcement_2)
+
+    assert results_for(conn, query: "announcement body", exclude: ["lame"]) ==
+             json_for(announcement_2)
+
     assert results_for(conn, query: "announcement body", exclude: []) == json_for(announcement_2)
     assert results_for(conn, query: "cool body", exclude: ["lame"]) == json_for(announcement_2)
   end
@@ -61,10 +74,11 @@ defmodule ConstableWeb.Api.SearchesControllerTest do
   end
 
   defp results_for(conn, query: search_term, exclude: exclude) do
-    response = post conn,
-      Routes.api_search_path(conn, :create),
-      query: search_term,
-      exclude_interests: exclude
+    response =
+      post conn,
+           Routes.api_search_path(conn, :create),
+           query: search_term,
+           exclude_interests: exclude
 
     json_response(response, 200)
   end

--- a/test/controllers/api/subscription_controller_test.exs
+++ b/test/controllers/api/subscription_controller_test.exs
@@ -14,7 +14,7 @@ defmodule ConstableWeb.Api.SubscriptionControllerTest do
     subscription_2 = insert(:subscription, user: user)
     insert(:subscription, user: other_user)
 
-    conn = get conn, Routes.api_subscription_path(conn, :index)
+    conn = get(conn, Routes.api_subscription_path(conn, :index))
 
     ids = fetch_json_ids("subscriptions", conn)
     assert ids == [subscription_1.id, subscription_2.id]
@@ -22,9 +22,11 @@ defmodule ConstableWeb.Api.SubscriptionControllerTest do
 
   test "#create subscribes the current user to an announcement", %{conn: conn, user: user} do
     announcement = insert(:announcement)
-    post conn, Routes.api_subscription_path(conn, :create), subscription: %{
-      announcement_id: announcement.id
-    }
+
+    post conn, Routes.api_subscription_path(conn, :create),
+      subscription: %{
+        announcement_id: announcement.id
+      }
 
     subscription = Repo.one!(Subscription)
     assert subscription.user_id == user.id
@@ -34,7 +36,7 @@ defmodule ConstableWeb.Api.SubscriptionControllerTest do
   test "#delete destroys subscription", %{conn: conn, user: user} do
     subscription = insert(:subscription, user: user)
 
-    conn = delete conn, Routes.api_subscription_path(conn, :delete, subscription.id)
+    conn = delete(conn, Routes.api_subscription_path(conn, :delete, subscription.id))
 
     assert response(conn, 204)
   end
@@ -43,7 +45,7 @@ defmodule ConstableWeb.Api.SubscriptionControllerTest do
     other_user = insert(:user)
     subscription = insert(:subscription, user: other_user)
 
-    conn = delete conn, Routes.api_subscription_path(conn, :delete, subscription.id)
+    conn = delete(conn, Routes.api_subscription_path(conn, :delete, subscription.id))
 
     assert response(conn, 401)
   end

--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -10,10 +10,13 @@ defmodule ConstableWeb.Api.UserControllerTest do
 
   test "#create creates a user", %{conn: conn} do
     name = "Ian D. Anderson"
-    conn = post conn, Routes.api_user_path(conn, :create), user: %{
-      name: name,
-      email: "ian@thoughtbot.com"
-    }
+
+    conn =
+      post conn, Routes.api_user_path(conn, :create),
+        user: %{
+          name: name,
+          email: "ian@thoughtbot.com"
+        }
 
     user = Repo.get_by!(User, email: "ian@thoughtbot.com", username: "ian")
     assert json_response(conn, 200) == render_json("show.json", user: user)
@@ -21,10 +24,13 @@ defmodule ConstableWeb.Api.UserControllerTest do
 
   test "#create doesn't create a user with invalid data", %{conn: conn} do
     Repo.delete_all(User)
-    conn = post conn, Routes.api_user_path(conn, :create), user: %{
-      name: "",
-      email: ""
-    }
+
+    conn =
+      post conn, Routes.api_user_path(conn, :create),
+        user: %{
+          name: "",
+          email: ""
+        }
 
     assert json_response(conn, :unprocessable_entity)
     refute Repo.one(User)
@@ -33,7 +39,7 @@ defmodule ConstableWeb.Api.UserControllerTest do
   test "#index returns all users", %{conn: conn, user: user} do
     other_user = insert(:user, name: "Aaron")
 
-    conn = get conn, Routes.api_user_path(conn, :index)
+    conn = get(conn, Routes.api_user_path(conn, :index))
 
     ids = fetch_json_ids("users", conn)
     assert ids == [other_user.id, user.id]
@@ -42,23 +48,25 @@ defmodule ConstableWeb.Api.UserControllerTest do
   test "#show returns user", %{conn: conn} do
     user = insert(:user)
 
-    conn = get conn, Routes.api_user_path(conn, :show, user.id)
+    conn = get(conn, Routes.api_user_path(conn, :show, user.id))
 
     assert json_response(conn, 200)["user"]["id"] == user.id
   end
 
   test "#show returns current user when id is me", %{conn: conn, user: user} do
-    conn = get conn, Routes.api_user_path(conn, :show, "me")
+    conn = get(conn, Routes.api_user_path(conn, :show, "me"))
 
     assert json_response(conn, 200)["user"]["id"] == user.id
   end
 
   test "#update updates the current user", %{conn: conn, user: user} do
-    conn = put conn, Routes.api_user_path(conn, :update), user: %{
-      daily_digest: false,
-      auto_subscribe: false,
-      name: "Ian Justin"
-    }
+    conn =
+      put conn, Routes.api_user_path(conn, :update),
+        user: %{
+          daily_digest: false,
+          auto_subscribe: false,
+          name: "Ian Justin"
+        }
 
     assert json_response(conn, 200)["user"]["id"] == user.id
     assert json_response(conn, 200)["user"]["name"] == "Ian Justin"

--- a/test/controllers/api/user_interest_controller_test.exs
+++ b/test/controllers/api/user_interest_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ConstableWeb.Api.UserInterestControllerTest do
   test "#index returns current users user_interests", %{conn: conn, user: user} do
     user_interests = insert_pair(:user_interest, user: user)
 
-    conn = get conn, Routes.api_user_interest_path(conn, :index)
+    conn = get(conn, Routes.api_user_interest_path(conn, :index))
 
     assert json_response(conn, 200) == render_json("index.json", user_interests: user_interests)
   end
@@ -18,7 +18,7 @@ defmodule ConstableWeb.Api.UserInterestControllerTest do
   test "#show returns invidual interest", %{conn: conn} do
     user_interest = insert(:user_interest)
 
-    conn = get conn, Routes.api_user_interest_path(conn, :show, user_interest.id)
+    conn = get(conn, Routes.api_user_interest_path(conn, :show, user_interest.id))
 
     assert json_response(conn, 200) == render_json("show.json", user_interest: user_interest)
   end
@@ -26,7 +26,7 @@ defmodule ConstableWeb.Api.UserInterestControllerTest do
   test "#destroy destroys a user's interest", %{conn: conn, user: user} do
     user_interest = insert(:user_interest, user: user)
 
-    conn = delete conn, Routes.api_user_interest_path(conn, :delete, user_interest.id)
+    conn = delete(conn, Routes.api_user_interest_path(conn, :delete, user_interest.id))
 
     assert response(conn, 204)
   end
@@ -35,7 +35,7 @@ defmodule ConstableWeb.Api.UserInterestControllerTest do
     other_user = insert(:user)
     user_interest = insert(:user_interest, user: other_user)
 
-    conn = delete conn, Routes.api_user_interest_path(conn, :delete, user_interest.id)
+    conn = delete(conn, Routes.api_user_interest_path(conn, :delete, user_interest.id))
 
     assert response(conn, 401)
   end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -11,9 +11,10 @@ defmodule ConstableWeb.CommentControllerTest do
   test "#create creates the comment", %{conn: conn, user: user} do
     announcement = insert(:announcement)
 
-    post conn, Routes.announcement_comment_path(conn, :create, announcement.id), comment: %{
-      body: "Foo"
-    }
+    post conn, Routes.announcement_comment_path(conn, :create, announcement.id),
+      comment: %{
+        body: "Foo"
+      }
 
     comment = Repo.one(Comment) |> Repo.preload([:user, announcement: :user])
     assert comment.body == "Foo"
@@ -24,9 +25,11 @@ defmodule ConstableWeb.CommentControllerTest do
   test "#create redirects back to announcement", %{conn: conn} do
     announcement = insert(:announcement)
 
-    conn = post conn, Routes.announcement_comment_path(conn, :create, announcement), comment: %{
-      body: "Foo"
-    }
+    conn =
+      post conn, Routes.announcement_comment_path(conn, :create, announcement),
+        comment: %{
+          body: "Foo"
+        }
 
     assert redirected_to(conn) =~ Routes.announcement_path(conn, :show, announcement.id)
   end
@@ -34,8 +37,7 @@ defmodule ConstableWeb.CommentControllerTest do
   test "#create redirects back to the announcement with flash on failure", %{conn: conn} do
     announcement = insert(:announcement)
 
-    conn = post conn, Routes.announcement_comment_path(conn, :create, announcement), comment: %{
-    }
+    conn = post conn, Routes.announcement_comment_path(conn, :create, announcement), comment: %{}
 
     assert Phoenix.ConnTest.get_flash(conn, :error) =~ "invalid"
   end
@@ -43,9 +45,11 @@ defmodule ConstableWeb.CommentControllerTest do
   test "#update updates the comments if the current user is the author", %{conn: conn, user: user} do
     comment = insert(:comment, body: "not updated", user: user)
 
-    conn = put conn, Routes.announcement_comment_path(conn, :update, comment.announcement, comment), comment: %{
-      body: "updated body"
-    }
+    conn =
+      put conn, Routes.announcement_comment_path(conn, :update, comment.announcement, comment),
+        comment: %{
+          body: "updated body"
+        }
 
     assert Repo.get_by!(Comment, body: "updated body")
     assert redirected_to(conn) == comment_on_announcement_page(conn, comment)
@@ -60,9 +64,10 @@ defmodule ConstableWeb.CommentControllerTest do
     comment = insert(:comment, body: "not updated", user: another_user)
 
     assert_error_sent :not_found, fn ->
-      put conn, Routes.announcement_comment_path(conn, :update, comment.announcement, comment), comment: %{
-        body: "updated body"
-      }
+      put conn, Routes.announcement_comment_path(conn, :update, comment.announcement, comment),
+        comment: %{
+          body: "updated body"
+        }
     end
   end
 end

--- a/test/controllers/email_forward_controller_test.exs
+++ b/test/controllers/email_forward_controller_test.exs
@@ -6,19 +6,25 @@ defmodule ConstableWeb.EmailForwardControllerTest do
 
   test "forwards email to admins" do
     System.put_env("ADMIN_EMAILS", "1@foo.com, 2@foo.com")
-    forwarded_emails = create_email_forward_webhook(
-      from_email: "someone@gmail.com",
-      text: "YO DAWG",
-      email: "admin@constable.io"
-    )
+
+    forwarded_emails =
+      create_email_forward_webhook(
+        from_email: "someone@gmail.com",
+        text: "YO DAWG",
+        email: "admin@constable.io"
+      )
+
     conn = build_conn()
 
     conn = post(conn, Routes.email_forward_path(Endpoint, :create), forwarded_emails)
 
     assert conn.status == 200
-    message = forwarded_emails.mandrill_events |> Poison.decode! |> List.first |> Map.fetch!("msg")
+
+    message =
+      forwarded_emails.mandrill_events |> Poison.decode!() |> List.first() |> Map.fetch!("msg")
+
     assert Emails.forwarded_email(message).to == ~w(1@foo.com 2@foo.com)
-    assert_delivered_email Emails.forwarded_email(message)
+    assert_delivered_email(Emails.forwarded_email(message))
   end
 
   defp create_email_forward_webhook(message_attributes) do
@@ -26,8 +32,9 @@ defmodule ConstableWeb.EmailForwardControllerTest do
 
     reply_events =
       build(:email_reply_event, msg: email_reply_message)
-      |> List.wrap
-      |> Poison.encode!
+      |> List.wrap()
+      |> Poison.encode!()
+
     build(:email_reply_webhook, mandrill_events: reply_events)
   end
 end

--- a/test/controllers/email_reply_controller_test.exs
+++ b/test/controllers/email_reply_controller_test.exs
@@ -10,11 +10,12 @@ defmodule ConstableWeb.EmailReplyTest do
     comment_author = insert(:user)
     conn = build_conn()
 
-    email_reply_webhook = create_email_reply_webhook(
-      from_email: comment_author.email,
-      text: "YO DAWG",
-      email: "announcement-#{announcement.id}@foo.com"
-    )
+    email_reply_webhook =
+      create_email_reply_webhook(
+        from_email: comment_author.email,
+        text: "YO DAWG",
+        email: "announcement-#{announcement.id}@foo.com"
+      )
 
     conn = post(conn, "/email_replies", email_reply_webhook)
 
@@ -24,7 +25,7 @@ defmodule ConstableWeb.EmailReplyTest do
     assert comment.user_id == comment_author.id
     assert comment.body == "YO DAWG"
 
-    assert_delivered_email Emails.new_comment(comment, [subscriber])
+    assert_delivered_email(Emails.new_comment(comment, [subscriber]))
   end
 
   test "removes the last quoted section from the email reply" do
@@ -35,16 +36,23 @@ defmodule ConstableWeb.EmailReplyTest do
 
     Sure looks like it!!
     """
+
     whole_email_with_quoted_text = """
-    #{user_text}\n> On Oct 16, 2015, at 5:05 PM, Paul Smith (Constable) <constable-40@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}> wrote:\n> \n> \t\n> my text\t\n\n\n
+    #{user_text}\n> On Oct 16, 2015, at 5:05 PM, Paul Smith (Constable) <constable-40@#{
+      Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")
+    }> wrote:\n> \n> \t\n> my text\t\n\n\n
     """
+
     comment_author = insert(:user)
     announcement = insert(:announcement)
-    email_reply_webhook = create_email_reply_webhook(
-      from_email: comment_author.email,
-      text: whole_email_with_quoted_text,
-      email: "announcement-#{announcement.id}@foo.com"
-    )
+
+    email_reply_webhook =
+      create_email_reply_webhook(
+        from_email: comment_author.email,
+        text: whole_email_with_quoted_text,
+        email: "announcement-#{announcement.id}@foo.com"
+      )
+
     conn = build_conn()
 
     post(conn, "/email_replies", email_reply_webhook)
@@ -58,8 +66,9 @@ defmodule ConstableWeb.EmailReplyTest do
 
     reply_events =
       build(:email_reply_event, msg: email_reply_message)
-      |> List.wrap
-      |> Poison.encode!
+      |> List.wrap()
+      |> Poison.encode!()
+
     build(:email_reply_webhook, mandrill_events: reply_events)
   end
 end

--- a/test/controllers/home_controller_test.exs
+++ b/test/controllers/home_controller_test.exs
@@ -6,13 +6,14 @@ defmodule ConstableWeb.HomeControllerTest do
   end
 
   test "when authenticated redirect to announcements", %{conn: conn} do
-    conn = get conn, Routes.home_path(conn, :index)
+    conn = get(conn, Routes.home_path(conn, :index))
 
     assert redirected_to(conn) == Routes.announcement_path(conn, :index)
   end
 
   test "redirects to the original request path and removes it from the session" do
-    conn = build_conn(:get, "/")
+    conn =
+      build_conn(:get, "/")
       |> assign(:current_user, build(:user))
       |> with_session(original_request_path: Routes.search_path(build_conn(), :new))
       |> ConstableWeb.Router.call(ConstableWeb.Router.init([]))

--- a/test/controllers/interest_controller_test.exs
+++ b/test/controllers/interest_controller_test.exs
@@ -10,7 +10,7 @@ defmodule ConstableWeb.InterestControllerTest do
     insert(:announcement, title: "Awesome") |> tag_with_interest(interest)
     insert(:announcement, title: "Nope") |> tag_with_interest(insert(:interest))
 
-    conn = get conn, Routes.interest_path(conn, :show, interest)
+    conn = get(conn, Routes.interest_path(conn, :show, interest))
 
     assert html_response(conn, :ok) =~ "Awesome"
     refute html_response(conn, :ok) =~ "Nope"
@@ -20,7 +20,7 @@ defmodule ConstableWeb.InterestControllerTest do
     interest = insert(:interest)
     insert(:announcement, title: "Awesome") |> tag_with_interest(interest)
 
-    conn = get conn, Routes.interest_path(conn, :show, interest.id)
+    conn = get(conn, Routes.interest_path(conn, :show, interest.id))
 
     assert html_response(conn, :ok) =~ "Awesome"
   end

--- a/test/controllers/recipients_preview_controller_test.exs
+++ b/test/controllers/recipients_preview_controller_test.exs
@@ -6,7 +6,7 @@ defmodule ContableWeb.RecipientsPreviewControllerTest do
   end
 
   describe ".show/2" do
-    test "returns the interested users' names", %{conn: conn}  do
+    test "returns the interested users' names", %{conn: conn} do
       interest = insert(:interest)
       insert(:announcement) |> tag_with_interest(interest)
       interested_user = insert(:user) |> with_interest(interest)

--- a/test/controllers/search_controller_test.exs
+++ b/test/controllers/search_controller_test.exs
@@ -5,13 +5,17 @@ defmodule ConstableWeb.SearchControllerTest do
     {:ok, browser_authenticate()}
   end
 
-  test "#show returns announcements matching search", %{conn: conn}do
+  test "#show returns announcements matching search", %{conn: conn} do
     foo = insert(:interest, name: "foo")
     insert(:announcement, title: "Awesome Post") |> tag_with_interest(foo)
-    insert(:announcement, title: "Not so much post", body: "awesome post!") |> tag_with_interest(foo)
-    insert(:announcement, title: "Don't show up!", body: "lame post!") |> tag_with_interest(insert(:interest))
 
-    conn = get conn, Routes.search_path(conn, :show, query: "awesome")
+    insert(:announcement, title: "Not so much post", body: "awesome post!")
+    |> tag_with_interest(foo)
+
+    insert(:announcement, title: "Don't show up!", body: "lame post!")
+    |> tag_with_interest(insert(:interest))
+
+    conn = get(conn, Routes.search_path(conn, :show, query: "awesome"))
 
     assert html_response(conn, :ok) =~ "Awesome Post"
     assert html_response(conn, :ok) =~ "Not so much post"
@@ -22,10 +26,15 @@ defmodule ConstableWeb.SearchControllerTest do
     foo = insert(:interest, name: "foo")
     bar = insert(:interest, name: "bar")
     insert(:announcement, title: "Awesome Post") |> tag_with_interest(foo)
-    insert(:announcement, title: "Not so much post", body: "awesome post!") |> tag_with_interest(foo)
-    insert(:announcement, title: "Good post!", body: "another awesome post!") |> tag_with_interest(bar)
 
-    conn = get conn, Routes.search_path(conn, :show, query: "awesome", exclude_interests: ["foo"])
+    insert(:announcement, title: "Not so much post", body: "awesome post!")
+    |> tag_with_interest(foo)
+
+    insert(:announcement, title: "Good post!", body: "another awesome post!")
+    |> tag_with_interest(bar)
+
+    conn =
+      get(conn, Routes.search_path(conn, :show, query: "awesome", exclude_interests: ["foo"]))
 
     refute html_response(conn, :ok) =~ "Awesome Post"
     refute html_response(conn, :ok) =~ "Not so much post"
@@ -33,7 +42,7 @@ defmodule ConstableWeb.SearchControllerTest do
   end
 
   test "#show runs empty search with no query param", %{conn: conn} do
-    conn = get conn, Routes.search_path(conn, :show)
+    conn = get(conn, Routes.search_path(conn, :show))
 
     assert html_response(conn, :ok) =~ "Search results for"
   end

--- a/test/controllers/session_controller_test.exs
+++ b/test/controllers/session_controller_test.exs
@@ -6,7 +6,7 @@ defmodule ConstableWeb.SessionControllerTest do
   end
 
   test "when authenticated redirect to home", %{conn: conn} do
-    conn = get conn, Routes.session_path(conn, :new)
+    conn = get(conn, Routes.session_path(conn, :new))
 
     assert redirected_to(conn) == Routes.home_path(conn, :index)
   end
@@ -14,13 +14,13 @@ defmodule ConstableWeb.SessionControllerTest do
   test "when not authenticated render login" do
     conn = build_conn()
 
-    conn = get conn, Routes.session_path(conn, :new)
+    conn = get(conn, Routes.session_path(conn, :new))
 
     assert html_response(conn, :ok) =~ "Sign in"
   end
 
   test "delete logs user out and redirects to home", %{conn: conn} do
-    conn = delete conn, Routes.session_path(conn, :delete)
+    conn = delete(conn, Routes.session_path(conn, :delete))
 
     assert redirected_to(conn) == Routes.home_path(conn, :index)
     refute conn.cookies["user_id"]

--- a/test/controllers/settings_controller_test.exs
+++ b/test/controllers/settings_controller_test.exs
@@ -7,8 +7,8 @@ defmodule ConstableWeb.SettingsControllerTest do
     {:ok, browser_authenticate()}
   end
 
-  test "show renders the settings form" , %{conn: conn} do
-    conn = get conn, Routes.settings_path(conn, :show)
+  test "show renders the settings form", %{conn: conn} do
+    conn = get(conn, Routes.settings_path(conn, :show))
 
     assert html_response(conn, :ok)
   end
@@ -17,11 +17,12 @@ defmodule ConstableWeb.SettingsControllerTest do
     user = insert(:user, name: "Joe Dirt", auto_subscribe: true, daily_digest: true)
     %{conn: conn, user: user} = browser_authenticate(user)
 
-    put conn, Routes.settings_path(conn, :update), user: %{
-      auto_subscribe: false,
-      daily_digest: false,
-      name: "Roger Murdoch",
-    }
+    put conn, Routes.settings_path(conn, :update),
+      user: %{
+        auto_subscribe: false,
+        daily_digest: false,
+        name: "Roger Murdoch"
+      }
 
     user = Repo.get(User, user.id)
     assert user.name == "Roger Murdoch"

--- a/test/controllers/subscription_controller_test.exs
+++ b/test/controllers/subscription_controller_test.exs
@@ -11,7 +11,7 @@ defmodule ConstableWeb.SubscriptionControllerTest do
   test "#create creates the subscription", %{conn: conn, user: user} do
     announcement = insert(:announcement)
 
-    post conn, Routes.announcement_subscription_path(conn, :create, announcement.id)
+    post(conn, Routes.announcement_subscription_path(conn, :create, announcement.id))
 
     subscription = Repo.one(Subscription) |> Repo.preload([:user, :announcement])
     assert subscription.user.id == user.id
@@ -22,7 +22,7 @@ defmodule ConstableWeb.SubscriptionControllerTest do
     announcement = insert(:announcement)
     subscription = insert(:subscription, user: user, announcement: announcement)
 
-    delete conn, Routes.announcement_subscription_path(conn, :delete, announcement.id)
+    delete(conn, Routes.announcement_subscription_path(conn, :delete, announcement.id))
 
     refute Repo.get(Subscription, subscription.id)
   end

--- a/test/controllers/unsubscribe_controller_test.exs
+++ b/test/controllers/unsubscribe_controller_test.exs
@@ -9,7 +9,7 @@ defmodule ConstableWeb.UsubscribeControllerTest do
     subscription = insert(:subscription, announcement: announcement)
     conn = build_conn()
 
-    conn = get conn, Routes.unsubscribe_path(conn, :show, subscription.token)
+    conn = get(conn, Routes.unsubscribe_path(conn, :show, subscription.token))
 
     assert Repo.one(Subscription) == nil
     assert redirected_to(conn) == Routes.announcement_path(conn, :show, announcement)
@@ -19,7 +19,7 @@ defmodule ConstableWeb.UsubscribeControllerTest do
     non_existent_token = "foo"
     conn = build_conn()
 
-    conn = get conn, Routes.unsubscribe_path(conn, :show, non_existent_token)
+    conn = get(conn, Routes.unsubscribe_path(conn, :show, non_existent_token))
 
     assert redirected_to(conn) == Routes.announcement_path(conn, :index)
   end

--- a/test/emails_test.exs
+++ b/test/emails_test.exs
@@ -14,19 +14,23 @@ defmodule Constable.EmailsTest do
 
     assert email.subject == "Daily Digest"
     assert email.to == users
+
     assert email.from == {
-      "Constable (thoughtbot)",
-      "constable@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
-    }
+             "Constable (thoughtbot)",
+             "constable@#{Constable.Env.get("OUTBOUND_EMAIL_DOMAIN")}"
+           }
+
     for interest <- interests do
       assert both_parts_contain(email, interest.name)
     end
+
     for announcement <- announcements do
       assert email |> both_parts_contain(announcement.title)
       assert email |> both_parts_contain(announcement.body)
       assert email.html_body =~ posted_by_html(announcement.user.name, announcement)
       assert email.text_body =~ posted_by_text(announcement.user.name, announcement)
     end
+
     for comment <- comments do
       assert email |> both_parts_contain(comment.user.name)
       assert email |> both_parts_contain(comment.body)
@@ -55,7 +59,7 @@ defmodule Constable.EmailsTest do
   defp interest_names(announcement) do
     announcement
     |> Map.get(:interests)
-    |> Enum.map(&("#{&1.name}"))
+    |> Enum.map(&"#{&1.name}")
     |> Enum.join(", ")
   end
 
@@ -68,7 +72,10 @@ defmodule Constable.EmailsTest do
 
   defp make_link(interest) do
     "#{interest.name}"
-    |> link(to: Routes.interest_url(ConstableWeb.Endpoint, :show, interest), style: "color: #aeaeae;")
+    |> link(
+      to: Routes.interest_url(ConstableWeb.Endpoint, :show, interest),
+      style: "color: #aeaeae;"
+    )
     |> safe_to_string
   end
 end

--- a/test/lib/mix/send_daily_digest_test.exs
+++ b/test/lib/mix/send_daily_digest_test.exs
@@ -9,11 +9,13 @@ defmodule Mix.Tasks.Constable.SendDailyDigestTest do
 
     Mix.Tasks.Constable.SendDailyDigest.run(nil)
 
-    assert_delivered_email Constable.Emails.daily_digest(
-      [],
-      [announcement],
-      [],
-      [daily_digest_user]
+    assert_delivered_email(
+      Constable.Emails.daily_digest(
+        [],
+        [announcement],
+        [],
+        [daily_digest_user]
+      )
     )
   end
 end

--- a/test/models/comment_test.exs
+++ b/test/models/comment_test.exs
@@ -5,7 +5,7 @@ defmodule Constable.CommentTest do
 
   test "when a comment is inserted, it updates the announcement last_discussed_at" do
     announcement = create_announcement_last_discussed(a_week_ago())
-    now = DateTime.utc_now |> DateTime.truncate(:second)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     comment = insert_comment_on_announcement(announcement, now)
     updated_last_discussed_at = DateTime.truncate(comment.announcement.last_discussed_at, :second)
@@ -25,7 +25,7 @@ defmodule Constable.CommentTest do
     }
 
     Comment.create_changeset(%Comment{}, comment_params, last_discussed_at)
-    |> Repo.insert!
+    |> Repo.insert!()
     |> Repo.preload(:announcement)
   end
 end

--- a/test/models/user_interest_test.exs
+++ b/test/models/user_interest_test.exs
@@ -8,7 +8,7 @@ defmodule Constable.UserInterestTest do
     second_user = insert(:user)
     interest = insert(:interest)
 
-    assert Repo.insert! %UserInterest{user_id: first_user.id, interest_id: interest.id}
-    assert Repo.insert! %UserInterest{user_id: second_user.id, interest_id: interest.id}
+    assert Repo.insert!(%UserInterest{user_id: first_user.id, interest_id: interest.id})
+    assert Repo.insert!(%UserInterest{user_id: second_user.id, interest_id: interest.id})
   end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -20,10 +20,11 @@ defmodule Constable.UserTest do
   end
 
   test "create_changeset sets token and username" do
-    changeset = User.create_changeset(%User{}, %{
-      email: @valid_email,
-      name: "Foo Bar"
-    })
+    changeset =
+      User.create_changeset(%User{}, %{
+        email: @valid_email,
+        name: "Foo Bar"
+      })
 
     assert changeset.valid?
     assert changeset.changes.username == "foo"
@@ -31,10 +32,11 @@ defmodule Constable.UserTest do
   end
 
   test "create_changeset validates email is for permitted domain" do
-    changeset = User.create_changeset(%User{}, %{
-      email: "user@not_permitted.com",
-      name: "Foo Bar"
-    })
+    changeset =
+      User.create_changeset(%User{}, %{
+        email: "user@not_permitted.com",
+        name: "Foo Bar"
+      })
 
     refute changeset.valid?
     assert changeset.errors[:email] == {"must be a member of #{@permitted_email_domain}", []}

--- a/test/plugs/api_auth_test.exs
+++ b/test/plugs/api_auth_test.exs
@@ -3,7 +3,9 @@ defmodule Constable.Plugs.RequireApiLoginTest do
 
   test "active user is assigned to current_user assigns on conn" do
     user = insert(:user, active: true)
-    conn = build_conn()
+
+    conn =
+      build_conn()
       |> bypass_through
       |> put_req_header("authorization", user.token)
       |> run_plug
@@ -13,7 +15,9 @@ defmodule Constable.Plugs.RequireApiLoginTest do
 
   test "inactive user is not assigned to current_user assigns on conn" do
     user = insert(:user, active: false)
-    conn = build_conn()
+
+    conn =
+      build_conn()
       |> bypass_through
       |> put_req_header("authorization", user.token)
       |> run_plug

--- a/test/plugs/fetch_current_user_test.exs
+++ b/test/plugs/fetch_current_user_test.exs
@@ -4,7 +4,9 @@ defmodule Constable.Plugs.FetchCurrentUserTest do
   test "active user is assigned to current_user assigns on conn" do
     user = insert(:user, active: true)
     token = Constable.UserIdentifier.sign_user_id(ConstableWeb.Endpoint, user.id)
-    conn = build_conn()
+
+    conn =
+      build_conn()
       |> bypass_through
       |> Phoenix.ConnTest.put_req_cookie("user_id", token)
       |> with_session
@@ -17,7 +19,9 @@ defmodule Constable.Plugs.FetchCurrentUserTest do
   test "inactive user is not assigned to current_user assigns on conn" do
     user = insert(:user, active: false)
     token = Constable.UserIdentifier.sign_user_id(ConstableWeb.Endpoint, user.id)
-    conn = build_conn()
+
+    conn =
+      build_conn()
       |> bypass_through
       |> Phoenix.ConnTest.put_req_cookie("user_id", token)
       |> with_session

--- a/test/services/comment_creator_test.exs
+++ b/test/services/comment_creator_test.exs
@@ -28,11 +28,12 @@ defmodule Constable.Services.CommentCreatorTest do
     {:ok, socket} = connect(ConstableWeb.UserSocket, %{"token" => user.token})
     subscribe_and_join!(socket, "update")
 
-    {:ok, comment} = CommentCreator.create(%{
-      user_id: insert(:user).id,
-      body: "Foo",
-      announcement_id: announcement.id
-    })
+    {:ok, comment} =
+      CommentCreator.create(%{
+        user_id: insert(:user).id,
+        body: "Foo",
+        announcement_id: announcement.id
+      })
 
     content = CommentView.render("show.json", %{comment: comment})
     assert_broadcast "comment:add", ^content
@@ -42,13 +43,14 @@ defmodule Constable.Services.CommentCreatorTest do
     user = insert(:user)
     announcement = insert(:announcement) |> with_subscriber(user)
 
-    {:ok, comment} = CommentCreator.create(%{
-      user_id: insert(:user).id,
-      body: "Foo",
-      announcement_id: announcement.id
-    })
+    {:ok, comment} =
+      CommentCreator.create(%{
+        user_id: insert(:user).id,
+        body: "Foo",
+        announcement_id: announcement.id
+      })
 
-    assert_delivered_email Emails.new_comment(comment, [user])
+    assert_delivered_email(Emails.new_comment(comment, [user]))
   end
 
   test "create emails mentioned users" do
@@ -56,13 +58,14 @@ defmodule Constable.Services.CommentCreatorTest do
     user = insert(:user, username: mentioned_username)
     announcement = insert(:announcement, user: user)
 
-    {:ok, comment} = CommentCreator.create(%{
-      user_id: insert(:user).id,
-      body: "Hey @#{mentioned_username}, @fakeuser was looking for you.",
-      announcement_id: announcement.id
-    })
+    {:ok, comment} =
+      CommentCreator.create(%{
+        user_id: insert(:user).id,
+        body: "Hey @#{mentioned_username}, @fakeuser was looking for you.",
+        announcement_id: announcement.id
+      })
 
-    assert_delivered_email Emails.new_comment_mention(comment, [user])
+    assert_delivered_email(Emails.new_comment_mention(comment, [user]))
   end
 
   test "create only sends mention email if subscribed and mentioned" do
@@ -70,24 +73,26 @@ defmodule Constable.Services.CommentCreatorTest do
     user = insert(:user, username: mentioned_username)
     announcement = insert(:announcement) |> with_subscriber(user)
 
-    {:ok, comment} = CommentCreator.create(%{
-      user_id: user.id,
-      body: "Hey @#{mentioned_username}",
-      announcement_id: announcement.id
-    })
+    {:ok, comment} =
+      CommentCreator.create(%{
+        user_id: user.id,
+        body: "Hey @#{mentioned_username}",
+        announcement_id: announcement.id
+      })
 
-    assert_delivered_email Emails.new_comment_mention(comment, [user])
+    assert_delivered_email(Emails.new_comment_mention(comment, [user]))
   end
 
   test "create does not email author of comment" do
     author = insert(:user)
     announcement = insert(:announcement) |> with_subscriber(author)
 
-    {:ok, _comment} = CommentCreator.create(%{
-      user_id: author.id,
-      body: "Foo!",
-      announcement_id: announcement.id
-    })
+    {:ok, _comment} =
+      CommentCreator.create(%{
+        user_id: author.id,
+        body: "Foo!",
+        announcement_id: announcement.id
+      })
 
     assert_no_emails_delivered()
   end

--- a/test/services/daily_digest_test.exs
+++ b/test/services/daily_digest_test.exs
@@ -19,12 +19,14 @@ defmodule Constable.DailyDigestTest do
     _old_interest = insert(:interest, inserted_at: yesterday())
     new_interest = insert(:interest, inserted_at: today())
     _old_announcement = insert(:announcement, inserted_at: yesterday())
-    new_announcement = insert(:announcement, inserted_at: today())
+
+    new_announcement =
+      insert(:announcement, inserted_at: today())
       |> Repo.preload(:interests)
 
     DailyDigest.send_email(users, yesterday())
 
-    assert_delivered_email Emails.daily_digest([new_interest], [new_announcement], [], users)
+    assert_delivered_email(Emails.daily_digest([new_interest], [new_announcement], [], users))
   end
 
   test "sends if there are only new announcements" do
@@ -34,7 +36,7 @@ defmodule Constable.DailyDigestTest do
 
     DailyDigest.send_email(users, yesterday())
 
-    assert_delivered_email Emails.daily_digest([], [new_announcement], [], users)
+    assert_delivered_email(Emails.daily_digest([], [new_announcement], [], users))
   end
 
   test "sends if there are only new interests" do
@@ -44,7 +46,7 @@ defmodule Constable.DailyDigestTest do
 
     DailyDigest.send_email(users, yesterday())
 
-    assert_delivered_email Emails.daily_digest([new_interest], [], [], users)
+    assert_delivered_email(Emails.daily_digest([new_interest], [], [], users))
   end
 
   test "sends if there are only new comments" do
@@ -54,11 +56,11 @@ defmodule Constable.DailyDigestTest do
 
     DailyDigest.send_email(users, yesterday())
 
-    assert_delivered_email Emails.daily_digest([], [], [new_comment], users)
+    assert_delivered_email(Emails.daily_digest([], [], [new_comment], users))
   end
 
   def today() do
-    Constable.Time.now
+    Constable.Time.now()
   end
 
   def yesterday() do

--- a/test/services/email_reply_parser_test.exs
+++ b/test/services/email_reply_parser_test.exs
@@ -2,32 +2,31 @@ defmodule Constable.EmailReplyParserTest do
   use ExUnit.Case
 
   @possible_email_body_formats [
-      """
-      Sweet. Yay London and Calle!
+    """
+    Sweet. Yay London and Calle!
 
-      On Fri, Apr 29, 2016 at 5:51 AM, Nick Charlton (Constable) <email@example.com> wrote:
-      > Old email contents
-      """,
+    On Fri, Apr 29, 2016 at 5:51 AM, Nick Charlton (Constable) <email@example.com> wrote:
+    > Old email contents
+    """,
+    """
+    Sweet. Yay London and Calle!
 
-      """
-      Sweet. Yay London and Calle!
+    On Fri, Apr 29, 2016 at 5:51 AM, Nick Charlton (Constable) <
+    email@example.com> wrote:
+    > Old email contents
+    """,
+    """
+    Sweet. Yay London and Calle!
 
-      On Fri, Apr 29, 2016 at 5:51 AM, Nick Charlton (Constable) <
-      email@example.com> wrote:
-      > Old email contents
-      """,
-
-      """
-      Sweet. Yay London and Calle!
-
-      On 05/02, Nick Charlton (Constable) wrote:
-      > Old email contents
-      """
+    On 05/02, Nick Charlton (Constable) wrote:
+    > Old email contents
+    """
   ]
 
   for phrase <- @possible_email_body_formats do
     test ".parse_body parses possible inputs correctly '#{phrase}'" do
-      assert Constable.EmailReplyParser.remove_original_email(unquote(phrase)) == "Sweet. Yay London and Calle!"
+      assert Constable.EmailReplyParser.remove_original_email(unquote(phrase)) ==
+               "Sweet. Yay London and Calle!"
     end
   end
 end

--- a/test/support/acceptance_case.ex
+++ b/test/support/acceptance_case.ex
@@ -13,7 +13,7 @@ defmodule ConstableWeb.AcceptanceCase do
       import ConstableWeb.WallabyHelper
       import Wallaby.Query, only: [link: 1, button: 1, css: 1, text_field: 1]
 
-      Application.put_env(:wallaby, :base_url, ConstableWeb.Endpoint.url)
+      Application.put_env(:wallaby, :base_url, ConstableWeb.Endpoint.url())
     end
   end
 

--- a/test/support/conn_case_helper.ex
+++ b/test/support/conn_case_helper.ex
@@ -4,21 +4,26 @@ defmodule ConstableWeb.ConnCaseHelper do
   import Plug.Conn
 
   def browser_authenticate(user \\ insert(:user)) do
-    conn = build_conn()
-    |> assign(:current_user, user)
+    conn =
+      build_conn()
+      |> assign(:current_user, user)
+
     %{conn: conn, user: user}
   end
 
   def api_authenticate(user \\ insert(:user)) do
-    conn = build_conn()
-    |> put_req_header("accept", "application/json")
-    |> put_req_header("authorization", user.token)
+    conn =
+      build_conn()
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", user.token)
+
     %{conn: conn, user: user}
   end
 
   def fetch_json_ids(key, conn, status \\ 200) do
     records = json_response(conn, status)[key]
-    Enum.map(records, fn(json) ->
+
+    Enum.map(records, fn json ->
       Map.get(json, "id")
     end)
   end
@@ -35,27 +40,30 @@ defmodule ConstableWeb.ConnCaseHelper do
     conn
     |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
     |> Plug.Session.call(session_opts)
-    |> Plug.Conn.fetch_session
-    |> Plug.Conn.fetch_query_params
+    |> Plug.Conn.fetch_session()
+    |> Plug.Conn.fetch_query_params()
     |> put_session_params_in_session(session_params)
   end
 
   defp put_session_params_in_session(conn, session_params) do
-    List.foldl(session_params, conn, fn ({key, value}, acc)
-    -> Plug.Conn.put_session(acc, key, value) end)
+    List.foldl(session_params, conn, fn {key, value}, acc ->
+      Plug.Conn.put_session(acc, key, value)
+    end)
   end
 
   defmacro render_json(template, assigns) do
     view = Module.get_attribute(__CALLER__.module, :view)
+
     quote do
       render_json(unquote(template), unquote(view), unquote(assigns))
     end
   end
+
   def render_json(template, view, assigns) do
     view.render(template, assigns) |> format_json
   end
 
   defp format_json(data) do
-    data |> Poison.encode! |> Poison.decode!
+    data |> Poison.encode!() |> Poison.decode!()
   end
 end

--- a/test/support/view_case_helper.ex
+++ b/test/support/view_case_helper.ex
@@ -1,6 +1,6 @@
 defmodule ConstableWeb.ViewCaseHelper do
   def ids_from(enumerable) do
-    Enum.map(enumerable, fn(object) ->
+    Enum.map(enumerable, fn object ->
       Map.get(object, :id)
     end)
   end

--- a/test/views/api/announcement_view_test.exs
+++ b/test/views/api/announcement_view_test.exs
@@ -14,17 +14,17 @@ defmodule ConstableWeb.Api.AnnouncementViewTest do
     rendered_announcement = render_one(announcement, AnnouncementView, "show.json")
 
     assert rendered_announcement == %{
-      announcement: %{
-        id: announcement.id,
-        title: announcement.title,
-        body: announcement.body,
-        inserted_at: announcement.inserted_at,
-        updated_at: announcement.updated_at,
-        user_id: announcement.user_id,
-        comments: render_many([comment], CommentView, "comment.json"),
-        interest_ids: [interest.id],
-        url: announcement_url,
-      }
-    }
+             announcement: %{
+               id: announcement.id,
+               title: announcement.title,
+               body: announcement.body,
+               inserted_at: announcement.inserted_at,
+               updated_at: announcement.updated_at,
+               user_id: announcement.user_id,
+               comments: render_many([comment], CommentView, "comment.json"),
+               interest_ids: [interest.id],
+               url: announcement_url
+             }
+           }
   end
 end

--- a/test/views/api/comment_view_test.exs
+++ b/test/views/api/comment_view_test.exs
@@ -8,13 +8,13 @@ defmodule ConstableWeb.Api.CommentViewTest do
     rendered_comment = render_one(comment, CommentView, "show.json")
 
     assert rendered_comment == %{
-      comment: %{
-        id: comment.id,
-        body: comment.body,
-        announcement_id: comment.announcement_id,
-        user_id: comment.user_id,
-        inserted_at: comment.inserted_at,
-      }
-    }
+             comment: %{
+               id: comment.id,
+               body: comment.body,
+               announcement_id: comment.announcement_id,
+               user_id: comment.user_id,
+               inserted_at: comment.inserted_at
+             }
+           }
   end
 end

--- a/test/views/api/interest_view_test.exs
+++ b/test/views/api/interest_view_test.exs
@@ -8,11 +8,11 @@ defmodule ConstableWeb.Api.InterestViewTest do
     rendered_interest = render_one(interest, InterestView, "show.json")
 
     assert rendered_interest == %{
-      interest: %{
-        id: interest.id,
-        name: interest.name,
-        slack_channel: interest.slack_channel,
-      }
-    }
+             interest: %{
+               id: interest.id,
+               name: interest.name,
+               slack_channel: interest.slack_channel
+             }
+           }
   end
 end

--- a/test/views/api/subscription_view_test.exs
+++ b/test/views/api/subscription_view_test.exs
@@ -8,11 +8,11 @@ defmodule ConstableWeb.Api.SubscriptionViewTest do
     rendered_subscription = render_one(subscription, SubscriptionView, "show.json")
 
     assert rendered_subscription == %{
-      subscription: %{
-        id: subscription.id,
-        announcement_id: subscription.announcement_id,
-        user_id: subscription.user_id,
-      }
-    }
+             subscription: %{
+               id: subscription.id,
+               announcement_id: subscription.announcement_id,
+               user_id: subscription.user_id
+             }
+           }
   end
 end

--- a/test/views/api/user_interest_view_test.exs
+++ b/test/views/api/user_interest_view_test.exs
@@ -8,11 +8,11 @@ defmodule ConstableWeb.Api.UserInterestViewTest do
     rendered_user_interest = render_one(user_interest, UserInterestView, "show.json")
 
     assert rendered_user_interest == %{
-      user_interest: %{
-        id: user_interest.id,
-        interest_id: user_interest.interest_id,
-        user_id: user_interest.user_id,
-      }
-    }
+             user_interest: %{
+               id: user_interest.id,
+               interest_id: user_interest.interest_id,
+               user_id: user_interest.user_id
+             }
+           }
   end
 end

--- a/test/views/email_view_test.exs
+++ b/test/views/email_view_test.exs
@@ -3,10 +3,11 @@ defmodule ConstableWeb.EmailViewTest do
   alias ConstableWeb.EmailView
 
   test "unsubscribe_link shows a mandrill merge field" do
-    assert EmailView.unsubscribe_link == "#{ConstableWeb.Endpoint.url}/unsubscribe/{{subscription_id}}"
+    assert EmailView.unsubscribe_link() ==
+             "#{ConstableWeb.Endpoint.url()}/unsubscribe/{{subscription_id}}"
   end
 
   test "notification_settings_link shows a link to the settings page" do
-    assert EmailView.notification_settings_link == "#{ConstableWeb.Endpoint.url}/settings"
+    assert EmailView.notification_settings_link() == "#{ConstableWeb.Endpoint.url()}/settings"
   end
 end


### PR DESCRIPTION
Elixir's formatter was introduced back in version 1.6 ([read the announcement](https://elixir-lang.org/blog/2018/01/17/elixir-v1-6-0-released/)).

We use the formatter in other projects like [ExMachina](https://github.com/thoughtbot/ex_machina/), and it is very beneficial for standardizing the style of the project. We also seem to have added the `.formatter.exs` file in commit 7e1252ea so it seems like we already intended to use it.

Why format everything in a single commit?
-----------------------------------------

From my experience introducing formatting into other projects, it's easiest to run it once across the entire codebase and add a check in CI that ensures we no longer introduce code that is not formatted (we do that in this commit). It has the downside of ruining commit history a bit when using `git blame`, but seems to be the fastest way to introduce a formatter into a codebase.