### PR TITLE
Clean up unused alias warnings

### DIFF
--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -2,7 +2,6 @@ defmodule Constable.Mailers.AnnouncementTest do
   use Constable.TestWithEcto, async: false
   alias ConstableWeb.Router.Helpers, as: Routes
   alias Constable.Emails
-  alias Constable.Services.HubProfileProvider
 
   test "sends a correctly formatted email to a list of users" do
     author = insert(:user)

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -1,7 +1,6 @@
 defmodule Constable.Mailers.CommentMailerTest do
   use Constable.TestWithEcto, async: true
   alias Constable.Emails
-  alias Constable.Services.HubProfileProvider
 
   test "new comment email" do
     author = insert(:user)

--- a/test/views/api/user_view_test.exs
+++ b/test/views/api/user_view_test.exs
@@ -1,7 +1,6 @@
 defmodule ConstableWeb.Api.UserViewTest do
   use ConstableWeb.ViewCase, async: true
   alias ConstableWeb.Api.UserView
-  alias Constable.Services.HubProfileProvider
 
   test "show.json returns correct fields" do
     user =


### PR DESCRIPTION
Cleans up the `alias Constable.Services.HubProfileProvider` found through the codebase when it's unused. Not removing it shows a warning when running tests.