### PR TITLE
Change Sass import order

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,10 +1,11 @@
 @import "~bourbon/core/bourbon";
 
+@import "~normalize.css/normalize";
+
 @import "~@thoughtbot/design-system/src/index";
 
 @import "settings/variables";
 
-@import "~normalize.css/normalize";
 @import "generic/fonts";
 
 @import "elements/layout";


### PR DESCRIPTION
We want to import normalize.css before our design system. Importing it
after causing some of our base HTML styles in the design system to be
overridden by normalize.css.

Closes: https://github.com/thoughtbot/design-system/issues/135

## Before

![65803271-1a81f780-e14c-11e9-8a20-89cbdb968471](https://user-images.githubusercontent.com/903327/76237892-5b0a9480-6205-11ea-96fd-265c7fe9e7fc.png)

## After

![IMG_0478](https://user-images.githubusercontent.com/903327/76237905-5fcf4880-6205-11ea-8d32-27598efdcea4.png)
