### PR TITLE
avoid module attributes to avoid compile time vs runtime bug in user creation

### DIFF
--- a/lib/constable/models/user.ex
+++ b/lib/constable/models/user.ex
@@ -4,13 +4,13 @@ defmodule Constable.User do
   alias Constable.UserInterest
   alias Constable.Subscription
 
-  @permitted_email_domain Application.fetch_env!(:constable, :permitted_email_domain)
-
   defimpl Bamboo.Formatter do
     def format_email_address(user, _opts) do
       {user.name, user.email}
     end
   end
+
+  def permitted_email_domain, do: Application.fetch_env!(:constable, :permitted_email_domain)
 
   schema "users" do
     field :email
@@ -71,9 +71,10 @@ defmodule Constable.User do
   defp require_permitted_email_domain(changeset) do
     changeset
     |> validate_change(:email, fn :email, value ->
-      case String.split(value, "@") do
-        [_, @permitted_email_domain] -> []
-        _ -> [email: "must be a member of #{@permitted_email_domain}"]
+      if String.split(value, "@") == permitted_email_domain() do
+        []
+      else
+        [email: "must be a member of #{permitted_email_domain()}"]
       end
     end)
   end

--- a/lib/constable_web/controllers/auth_controller.ex
+++ b/lib/constable_web/controllers/auth_controller.ex
@@ -10,7 +10,8 @@ defmodule ConstableWeb.AuthController do
     UserInterest
   }
 
-  @permitted_email_domain Application.fetch_env!(:constable, :permitted_email_domain)
+  def permitted_email_domain, do: Application.fetch_env!(:constable, :permitted_email_domain)
+
   @one_year_in_seconds 365 * 24 * 60 * 60
 
   def index(conn, %{"browser" => "true"}) do
@@ -36,7 +37,7 @@ defmodule ConstableWeb.AuthController do
     case find_or_insert_user(email, name) do
       nil ->
         conn
-        |> put_flash(:error, "You must sign up with a #{@permitted_email_domain} email address")
+        |> put_flash(:error, "You must sign up with a #{permitted_email_domain()} email address")
         |> redirect(external: "/")
 
       user ->
@@ -87,7 +88,7 @@ defmodule ConstableWeb.AuthController do
       nil ->
         conn
         |> put_status(403)
-        |> json(%{error: "must sign up with a #{@permitted_email_domain} email"})
+        |> json(%{error: "must sign up with a #{permitted_email_domain()} email"})
 
       user ->
         conn
@@ -122,7 +123,7 @@ defmodule ConstableWeb.AuthController do
 
       {:error, _changeset} ->
         Logger.info(
-          "Email address `#{email}` not from permitted `#{@permitted_email_domain}` domain"
+          "Email address `#{email}` not from permitted `#{permitted_email_domain()}` domain"
         )
 
         nil

--- a/test/controllers/auth_controller_test.exs
+++ b/test/controllers/auth_controller_test.exs
@@ -5,9 +5,8 @@ defmodule ConstableWeb.AuthControllerTest do
   require Constable.Pact
 
   @google_authorize_url "https://accounts.google.com/o/oauth2/auth"
-  @permitted_email_domain Application.fetch_env!(:constable, :permitted_email_domain)
-
-  def valid_email_address, do: "fake@#{@permitted_email_domain}"
+  def permitted_email_domain, do: Application.fetch_env!(:constable, :permitted_email_domain)
+  def valid_email_address, do: "fake@#{permitted_email_domain()}"
 
   defmodule FakeTokenRetriever do
     def get_token!(_conn, _code, _token_params) do

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -3,8 +3,8 @@ defmodule Constable.UserTest do
 
   alias Constable.User
 
-  @permitted_email_domain Application.fetch_env!(:constable, :permitted_email_domain)
-  @valid_email "foo@#{@permitted_email_domain}"
+  def permitted_email_domain, do: Application.fetch_env!(:constable, :permitted_email_domain)
+  def valid_email, do: "foo@#{permitted_email_domain()}"
 
   test "settings_changeset validates length of name" do
     changeset = User.settings_changeset(%User{}, %{name: "ab"})
@@ -22,7 +22,7 @@ defmodule Constable.UserTest do
   test "create_changeset sets token and username" do
     changeset =
       User.create_changeset(%User{}, %{
-        email: @valid_email,
+        email: valid_email(),
         name: "Foo Bar"
       })
 
@@ -43,7 +43,7 @@ defmodule Constable.UserTest do
   end
 
   test "create_changeset sets name from username only if the name is blank" do
-    changeset = User.create_changeset(%User{}, %{email: @valid_email, name: "Real Name"})
+    changeset = User.create_changeset(%User{}, %{email: valid_email(), name: "Real Name"})
     assert changeset.changes[:name] == "Real Name"
 
     username = "foobar"


### PR DESCRIPTION
This OR replaces the use of a module attribute for the permnitted email domain when creating a user. 

### Why?
The issue with the module attribute is that is is evaluated at compile time, not runtime (https://ropig.com/blog/be-careful-when-using-elixirs-module-attributes/). This can cause a bug where the value is not there, because `System.get_env` can only be run at runtime. I ran into this today when trying to log in, and I've run into it before in phoenix projects.