### PR TITLE
Fix comment area overflow from being cutoff on selection

### DIFF
--- a/assets/css/components/_comments.scss
+++ b/assets/css/components/_comments.scss
@@ -15,7 +15,7 @@
 }
 
 .comment-container {
-  overflow-x: auto;
+  min-width: 0;
 }
 
 .comment-body {


### PR DESCRIPTION
I had inadvertently introduced a layout bug where the author section buttons, when selected, are cutoff thanks to a greedy overflow rule I added. This was originally added to contain overflowing `pre` and `code` blocks back in #823.

We can apply a minimum width here instead, while preserving the desired behavior from before _without_ cutting off elements on selection!

~ | ~
--|--
Before | ![before](https://user-images.githubusercontent.com/5240843/77117625-a4ba6280-69ef-11ea-9d9d-feafa15f0d0e.png)
After | ![after](https://user-images.githubusercontent.com/5240843/77117798-f236cf80-69ef-11ea-9346-41e591535739.png)
