### PR TITLE
Fetch Profiles info rather than memoize calls

### DIFF
--- a/lib/constable/application.ex
+++ b/lib/constable/application.ex
@@ -20,18 +20,12 @@ defmodule Constable.Application do
 
     setup_dependencies()
 
-    # List all child processes to be supervised
     children = [
-      # Start the Ecto repository
       Constable.Repo,
-      # Start the endpoint when the application starts
-      ConstableWeb.Endpoint
-      # Starts a worker by calling: ConstableWeb.Worker.start_link(arg)
-      # {ConstableWeb.Worker, arg},
+      ConstableWeb.Endpoint,
+      {Task.Supervisor, name: Constable.TaskSupervisor}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Constable.Supervisor]
     Supervisor.start_link(children, opts)
   end

--- a/lib/constable/factory.ex
+++ b/lib/constable/factory.ex
@@ -35,7 +35,9 @@ defmodule Constable.Factory do
       email: sequence(:email, &"test#{&1}@thoughtbot.com"),
       daily_digest: true,
       auto_subscribe: false,
-      token: sequence(:token, &"omgtokens#{&1}")
+      token: sequence(:token, &"omgtokens#{&1}"),
+      profile_image_url: "someurlimage.com",
+      profile_url: "example.com/people/gumbo"
     }
   end
 

--- a/lib/constable/profiles.ex
+++ b/lib/constable/profiles.ex
@@ -1,0 +1,27 @@
+defmodule Constable.Profiles do
+  alias Constable.{User, Repo}
+
+  def update_profile_info(user) do
+    provider = Constable.Pact.get(:profile_provider)
+    profile_url = provider.fetch_profile_url(user)
+    image_url = provider.fetch_image_url(user)
+
+    user
+    |> User.profile_changeset(%{profile_url: profile_url, profile_image_url: image_url})
+    |> Repo.update()
+  end
+
+  def update_profile_image_urls(users) do
+    provider = Constable.Pact.get(:profile_provider)
+
+    Enum.map(users, fn user ->
+      image_url = provider.fetch_image_url(user)
+
+      user
+      |> User.profile_changeset(%{profile_image_url: image_url})
+      |> Repo.update()
+    end)
+
+    :ok
+  end
+end

--- a/lib/constable/serializers/user.ex
+++ b/lib/constable/serializers/user.ex
@@ -9,7 +9,7 @@ defimpl Poison.Encoder, for: Constable.User do
       id: user.id,
       email: user.email,
       name: user.name,
-      profile_image_url: profile_provider().image_url(user),
+      profile_image_url: user.profile_image_url,
       user_interests: user.user_interests,
       subscriptions: user.subscriptions
     }

--- a/lib/constable/services/fake_profile_provider.ex
+++ b/lib/constable/services/fake_profile_provider.ex
@@ -4,12 +4,12 @@ defmodule FakeProfileProvider do
   @behaviour ProfileProvider
 
   @impl ProfileProvider
-  def profile_url(_user) do
+  def fetch_profile_url(_user) do
     "http://example.com/"
   end
 
   @impl ProfileProvider
-  def image_url(_user) do
+  def fetch_image_url(_user) do
     "#{Endpoint.url()}/images/ralph.png"
   end
 end

--- a/lib/constable/services/hub_profile_provider.ex
+++ b/lib/constable/services/hub_profile_provider.ex
@@ -1,24 +1,20 @@
 defmodule Constable.Services.HubProfileProvider do
-  alias ConstableWeb.Endpoint
   alias Constable.Services.ProfileProvider
   @behaviour ProfileProvider
-  use Memoize
-
-  @default_image_path "/images/ralph.png"
 
   @impl ProfileProvider
-  defmemo profile_url(user) do
+  def fetch_profile_url(user) do
     "#{Application.fetch_env!(:constable, :hub_url)}/people/#{fetch_slug(user)}"
   end
 
   @impl ProfileProvider
-  defmemo image_url(user) do
+  def fetch_image_url(user) do
     case Neuron.query(person_image_url_by_email_query(user.email)) do
       {:ok, %Neuron.Response{body: %{"data" => %{"person" => %{"image_url" => image_url}}}}} ->
         image_url
 
       _ ->
-        "#{Endpoint.url()}#{@default_image_path}"
+        nil
     end
   end
 

--- a/lib/constable/services/profile_provider.ex
+++ b/lib/constable/services/profile_provider.ex
@@ -1,6 +1,6 @@
 defmodule Constable.Services.ProfileProvider do
   alias Constable.User
 
-  @callback profile_url(User.t()) :: String.t()
-  @callback image_url(User.t()) :: String.t()
+  @callback fetch_profile_url(User.t()) :: String.t()
+  @callback fetch_image_url(User.t()) :: String.t()
 end

--- a/lib/constable/task_supervisor.ex
+++ b/lib/constable/task_supervisor.ex
@@ -1,0 +1,5 @@
+defmodule Constable.TaskSupervisor do
+  def one_off_task(function_to_perform) do
+    Task.Supervisor.start_child(__MODULE__, function_to_perform)
+  end
+end

--- a/lib/constable/user.ex
+++ b/lib/constable/user.ex
@@ -20,6 +20,8 @@ defmodule Constable.User do
     field :auto_subscribe, :boolean, default: true
     field :daily_digest, :boolean, default: true
     field :active, :boolean, default: true
+    field :profile_url
+    field :profile_image_url
 
     has_many :comments, Constable.Comment
     has_many :user_interests, UserInterest, on_delete: :delete_all
@@ -40,6 +42,11 @@ defmodule Constable.User do
     user
     |> cast(params, ~w(auto_subscribe daily_digest name)a)
     |> validate_length(:name, min: 3)
+  end
+
+  def profile_changeset(user, params) do
+    user
+    |> cast(params, ~w(profile_url profile_image_url)a)
   end
 
   def create_changeset(user \\ %__MODULE__{}, params) do

--- a/lib/constable_web/templates/email/author_footer.html.eex
+++ b/lib/constable_web/templates/email/author_footer.html.eex
@@ -3,7 +3,7 @@
     <table border="0" cellpadding="0" cellspacing="0" class="flex-size" style="color: #454f52; font-family: Helvetica, Tahoma, sans-serif; font-size: 16px; line-height: 1.5;">
       <tr>
         <td width="50" vertical-align="middle">
-          <img alt="<%= @author.name %>" class="avatar-rounded avatar-large" src="<%= profile_image_url(@author) %>">
+          <img alt="<%= @author.name %>" class="avatar-rounded avatar-large" src="<%= profile_image_url(@author)%>">
         </td>
         <td>
           <%= @author.name %><br>

--- a/lib/constable_web/templates/settings/show.html.eex
+++ b/lib/constable_web/templates/settings/show.html.eex
@@ -36,7 +36,7 @@
       </div>
 
       <label class="tbds-media__body">
-        The profile image used on Constable can be changed by visiting your <%= link "Hub profile", to: profile_url(@current_user) %>.
+        The profile image used on Constable can be changed by visiting your <%= link "Hub profile", to: @current_user.profile_url %>.
       </label>
     </div>
 

--- a/lib/constable_web/views/api/user_view.ex
+++ b/lib/constable_web/views/api/user_view.ex
@@ -17,7 +17,7 @@ defmodule ConstableWeb.Api.UserView do
       name: user.name,
       auto_subscribe: user.auto_subscribe,
       daily_digest: user.daily_digest,
-      profile_image_url: profile_provider().image_url(user),
+      profile_image_url: profile_image_url(user),
       username: user.username,
       user_interests: pluck(user.user_interests, :id),
       subscriptions: pluck(user.subscriptions, :id)

--- a/lib/constable_web/views/shared_view.ex
+++ b/lib/constable_web/views/shared_view.ex
@@ -3,6 +3,8 @@ defmodule ConstableWeb.SharedView do
   alias Constable.Services.MentionFinder
   use Phoenix.HTML
 
+  @default_image_path "/images/ralph.png"
+
   def current_user(conn) do
     conn.assigns[:current_user]
   end
@@ -15,16 +17,11 @@ defmodule ConstableWeb.SharedView do
     "Constable"
   end
 
-  def profile_provider do
-    Constable.Pact.get(:profile_provider)
-  end
-
-  def profile_url(user) do
-    profile_provider().profile_url(user)
-  end
-
   def profile_image_url(user) do
-    profile_provider().image_url(user)
+    case user.profile_image_url do
+      url when is_binary(url) -> url
+      _ -> "#{ConstableWeb.Endpoint.url()}#{@default_image_path}"
+    end
   end
 
   def relative_timestamp(datetime) do

--- a/lib/mix/tasks/constable.update_profile_image_urls.ex
+++ b/lib/mix/tasks/constable.update_profile_image_urls.ex
@@ -1,0 +1,36 @@
+defmodule Mix.Tasks.Constable.UpdateProfileImageUrls do
+  use Mix.Task
+
+  import Ecto.Query, only: [where: 3]
+
+  require Logger
+
+  alias Constable.{User, Repo, Profiles}
+
+  @moduledoc """
+  Fetches all user's image urls from hub and updates the user's profile_image_url.
+
+  ## Sample use
+
+    mix constable.update_profile_image_urls
+  """
+
+  @doc "Fetches and updates all users' image urls (from hub)"
+  def run(_) do
+    Mix.Task.run("app.start")
+
+    users =
+      User
+      |> where([u], u.active == true)
+      |> where([u], is_nil(u.profile_image_url))
+      |> Repo.all()
+
+    Logger.info("""
+    Active users without a valid profile_image_url
+
+    #{inspect(Enum.map(users, & &1.email))}
+    """)
+
+    Profiles.update_profile_image_urls(users)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,6 @@ defmodule Constable.MixProject do
       {:html_sanitize_ex, "~> 1.4.0"},
       {:httpoison, "~> 1.3", override: true},
       {:jason, "~> 1.1"},
-      {:memoize, "~> 1.2"},
       {:mock, "~> 0.3.0", only: :test},
       {:neuron, "~> 4.1.0"},
       {:oauth2, "~> 2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -24,7 +24,6 @@
   "idna": {:hex, :idna, "6.0.1", "1d038fb2e7668ce41fbf681d2c45902e52b3cb9e9c77b55334353b222c2ee50c", [:rebar3], [{:unicode_util_compat, "0.5.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "a02c8a1c4fd601215bb0b0324c8a6986749f807ce35f25449ec9e69758708122"},
   "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
   "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm", "d34f013c156db51ad57cc556891b9720e6a1c1df5fe2e15af999c84d6cebeb1a"},
-  "memoize": {:hex, :memoize, "1.3.0", "c82eaf40cd2afd0cc050ee0d7e6b298aa2a0d5faa8680b48147deecb4b94300d", [:mix], [], "hexpm", "e7821b08820b39f090c8a2a321c639068fd11690d0477a5a32d477696329058e"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm", "6cbe761d6a0ca5a31a0931bf4c63204bceb64538e664a8ecf784a9a6f3b875f1"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},

--- a/priv/repo/migrations/20200527201059_add_profile_fields_to_users.exs
+++ b/priv/repo/migrations/20200527201059_add_profile_fields_to_users.exs
@@ -1,0 +1,10 @@
+defmodule Constable.Repo.Migrations.AddProfileFieldsToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :profile_url, :string
+      add :profile_image_url, :string
+    end
+  end
+end

--- a/test/constable/profiles_test.exs
+++ b/test/constable/profiles_test.exs
@@ -1,0 +1,29 @@
+defmodule Constable.ProfilesTest do
+  use Constable.DataCase, async: true
+
+  alias Constable.{User, Profiles}
+
+  describe "update_profile_info/1" do
+    test "fetches and updates a user's profile info" do
+      user = insert(:user, profile_url: nil, profile_image_url: nil)
+
+      Profiles.update_profile_info(user)
+
+      updated_user = User |> Repo.get!(user.id)
+      assert updated_user.profile_url == "http://example.com/"
+      assert String.ends_with?(updated_user.profile_image_url, "/images/ralph.png")
+    end
+  end
+
+  describe "update_profile_image_urls/0" do
+    test "updates all image urls of users" do
+      users = insert_pair(:user, profile_image_url: nil)
+
+      :ok = Profiles.update_profile_image_urls(users)
+
+      [user1, user2] = User |> Repo.all()
+      assert String.ends_with?(user1.profile_image_url, "/images/ralph.png")
+      assert String.ends_with?(user2.profile_image_url, "/images/ralph.png")
+    end
+  end
+end

--- a/test/controllers/api/user_controller_test.exs
+++ b/test/controllers/api/user_controller_test.exs
@@ -2,24 +2,25 @@ defmodule ConstableWeb.Api.UserControllerTest do
   use ConstableWeb.ConnCase, async: true
   alias Constable.User
 
-  @view ConstableWeb.Api.UserView
-
   setup do
     {:ok, api_authenticate()}
   end
 
   test "#create creates a user", %{conn: conn} do
     name = "Ian D. Anderson"
+    email = "ian@thoughtbot.com"
 
-    conn =
-      post conn, Routes.api_user_path(conn, :create),
-        user: %{
-          name: name,
-          email: "ian@thoughtbot.com"
-        }
+    json_response =
+      conn
+      |> post(Routes.api_user_path(conn, :create),
+        user: %{name: name, email: email}
+      )
+      |> json_response(200)
 
     user = Repo.get_by!(User, email: "ian@thoughtbot.com", username: "ian")
-    assert json_response(conn, 200) == render_json("show.json", user: user)
+    assert user.name == name
+    assert user.email == email
+    assert %{"user" => %{"name" => ^name, "username" => "ian"}} = json_response
   end
 
   test "#create doesn't create a user with invalid data", %{conn: conn} do

--- a/test/mailers/announcement_mailer_test.exs
+++ b/test/mailers/announcement_mailer_test.exs
@@ -51,7 +51,7 @@ defmodule Constable.Mailers.AnnouncementTest do
 
     assert email.html_body =~ html_announcement_body
     assert email.html_body =~ author.name
-    assert email.html_body =~ FakeProfileProvider.image_url(author)
+    assert email.html_body =~ author.profile_image_url
     assert email.html_body =~ interest_1.name
     assert email.html_body =~ interest_2.name
     assert email.text_body =~ announcement.body

--- a/test/mailers/comment_mailer_test.exs
+++ b/test/mailers/comment_mailer_test.exs
@@ -44,7 +44,7 @@ defmodule Constable.Mailers.CommentMailerTest do
     html_comment_body = Constable.Markdown.to_html(comment.body)
     assert email.html_body =~ html_comment_body
     assert email.html_body =~ author.name
-    assert email.html_body =~ FakeProfileProvider.image_url(author)
+    assert email.html_body =~ author.profile_image_url
 
     assert email.text_body =~ comment.body
   end
@@ -76,7 +76,7 @@ defmodule Constable.Mailers.CommentMailerTest do
     html_comment_body = Constable.Markdown.to_html(comment.body)
     assert email.html_body =~ html_comment_body
     assert email.html_body =~ author.name
-    assert email.html_body =~ FakeProfileProvider.image_url(author)
+    assert email.html_body =~ author.profile_image_url
 
     assert email.text_body =~ comment.body
   end

--- a/test/services/hub_profile_test.exs
+++ b/test/services/hub_profile_test.exs
@@ -4,7 +4,7 @@ defmodule Constable.Services.HubProfileProviderTest do
   import Mock
   alias Constable.Services.HubProfileProvider
 
-  describe "#profile_url" do
+  describe "#fetch_profile_url" do
     test "returns the hub profile url for a user" do
       email = "test@example.com"
       user = insert(:user, email: email)
@@ -25,14 +25,14 @@ defmodule Constable.Services.HubProfileProviderTest do
 
       profile_url =
         Mock.with_mock Neuron, query: query_mock do
-          HubProfileProvider.profile_url(user)
+          HubProfileProvider.fetch_profile_url(user)
         end
 
       assert profile_url == "#{Application.fetch_env!(:constable, :hub_url)}/people/#{mock_slug}"
     end
   end
 
-  describe "#image_url" do
+  describe "#fetch_image_url" do
     test "returns the hub profile image url for a user" do
       email = "test@example.com"
       user = insert(:user, email: email)
@@ -53,7 +53,7 @@ defmodule Constable.Services.HubProfileProviderTest do
 
       image_url =
         Mock.with_mock Neuron, query: query_mock do
-          HubProfileProvider.image_url(user)
+          HubProfileProvider.fetch_image_url(user)
         end
 
       assert image_url == mock_image_url

--- a/test/views/api/user_view_test.exs
+++ b/test/views/api/user_view_test.exs
@@ -15,7 +15,7 @@ defmodule ConstableWeb.Api.UserViewTest do
              user: %{
                id: user.id,
                name: user.name,
-               profile_image_url: FakeProfileProvider.image_url(user),
+               profile_image_url: user.profile_image_url,
                daily_digest: user.daily_digest,
                auto_subscribe: user.auto_subscribe,
                username: user.username,


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/constable/issues/887

What?
=====

We make a change in how and when we fetch profile information for users (profile_url and profile_image_url). Currently in production we memoize the calls to hub when we're trying to load a user's profile image url or profile image. The problem with that is that if the cache isn't warm, we have to make N queries to hub trying to fetch every user's image url when loading a list of announcements, where N is the number of users that have made a comment, made an announcement, plug the current user. That makes for a very slow page load, which sometimes times out.

In order to get around that, we now store the profile_url and profile_image_url as part of the users table. This gets rid of the N queries at load time, and we perform those actions when (a) a user is created, (b) a user is reactivated, or (c) daily via a mix task (the mix task only updates users who do not have a url set).

When a user is created or reactivated, we fetch the profile information asynchronously. To achieve this, we add a `Constable.TaskSupervisor` which can handle "one off" tasks.

The mix task, on the other hand, performs a "brute force" approach to fetching the image urls, making N requests for N users. But since we're doing it on a background job, this seems to be fine for now.

Finally, an even better approach that can be taken in the future (though it requires changes in hub) would be for hub to provide the information to us on user creation. I believe hub is already the source of truth for the email and name, and it provides those to constable on user creation (see api/user_controller#create). If it could also provide the profile_url and profile_image_url at that point, we wouldn't have to fetch them afterwards.

Currently, we roughly have this workflow on user creation:

```
hub | -- create a user (email, name)       --> | constable
hub | <-- what is the user's profile info? --  | constable
hub | -- profile_url and profile_image_url --> | constable
```

If hub could provide the information needed upon creation, we would simplify the workflow to:

```
hub | -- create a user (email, name, profile fields) --> | constable
```