### PR TITLE
Print Chromedriver, Elixir/Erlang, node/npm versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,18 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Chromedriver version
+          command: chromedriver -v
+
+      - run:
+          name: Elixir & Erlang versions
+          command: elixir -v
+
+      - run:
+          name: npm & node versions
+          command: npm -v && node -v
+
       - run: mix local.hex --force
       - run: mix local.rebar --force
 


### PR DESCRIPTION
What? 
=====

I noticed the last two builds in CI have failed (https://circleci.com/gh/thoughtbot/constable/2989 and https://circleci.com/gh/thoughtbot/constable/2987). For some reason, I cannot get the builds to fail in this PR, but I still think the work in this PR makes sense to commit. 

When CI fails, I frequently want to see which versions of dependencies we are running. We now print the versions of Chromedriver, Elixir, Erlang, npm, and node.js so when builds fail we can quickly check which versions are running in CI and if a discrepancy in versions contributes to the issues at hand.

## Screenshots

Now we get these nice sections in CI

<img width="553" alt="Screen Shot 2020-07-06 at 12 27 03 PM" src="https://user-images.githubusercontent.com/3245976/86616584-0e04b800-bf84-11ea-990a-86c452c12d76.png">
