### PR TITLE
Load shubox script asynchronously

### DIFF
--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -19,7 +19,7 @@
     <%= if current_user(@conn) do %>
       <script>window.userToken = "<%= @current_user.token %>";</script>
       <script src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
-      <script src="<%= Application.fetch_env!(:constable, :shubox_script_url) %>"></script>
+      <script async src="<%= Application.fetch_env!(:constable, :shubox_script_url) %>"></script>
     <% end %>
   </head>
   <body class="tbds-app-frame">


### PR DESCRIPTION
A (maybe temporary) fix for https://github.com/thoughtbot/constable/issues/909

What changed?
============

From time to time, Constable seems completely unresponsive. When looking into it, George and Adam, discovered that the shubox script is not loading. Looking at shubox's docs, it seems like we might have an old way of dealing with this. We'll update that in a future commit. For now, we just load it asynchronously so as to not block the loading of the page.

Shubox docs: https://github.com/shuboxio/shubox.js/blob/master/README.md