### PR TITLE
Adds notice of how to attach images

### DIFF
--- a/lib/constable_web/templates/announcement/_form.html.eex
+++ b/lib/constable_web/templates/announcement/_form.html.eex
@@ -42,6 +42,7 @@
           class: "tbds-form__textarea uploadable-input",
           placeholder: gettext("Markdown is supported. You can @mention specific people to notify them.")
         )%>
+        <span class="tbds-form__help-text"><small>Attach images by dragging and dropping them.</small></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes https://github.com/thoughtbot/constable/issues/694

What changed?
============

We add a notice that images can be attached by dragging and dropping them (much like GitHub has a little notice). I use `tbds-form__help-text` as formatting to try to keep with tbds classes.

## Screenshot

![Screen Shot 2020-09-04 at 2 51 10 PM](https://user-images.githubusercontent.com/3245976/92276140-71e12980-eebe-11ea-846d-7b9213256bb8.png)
