### PR TITLE
Do not compile assets every `mix test`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,16 +83,15 @@ defmodule Constable.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: [
-        "assets.compile --quiet",
         "ecto.create --quiet",
         "ecto.migrate",
         "test"
       ],
-      "assets.compile": &compile_assets/1
+      "assets.watch": &watch_assets/1
     ]
   end
 
-  defp compile_assets(_) do
-    Mix.shell().cmd("cd assets && node_modules/.bin/webpack --mode production && cd ..")
+  defp watch_assets(_) do
+    Mix.shell().cmd("cd assets && node_modules/.bin/webpack --watch && cd ..")
   end
 end


### PR DESCRIPTION
What changed?
=============

Currently we compile our assets every time we run `mix test`. That's true regardless of whether we're running the entire test suite or a single test. That causes terribly slow feedback cycles when doing TDD.

In this commit, we remove the automatic compilation of assets when running `mix test`, and we create a new alias `mix assets.watch` to easily watch assets when we're making changes to CSS or JS.

Thus, if you're running tests iteratively and are making changes to CSS or JS, you can open a new pane and run `mix assets.watch` and do your normal TDD on a different pane.