### PR TITLE
Do not use ConstableWeb, :view in ConnCase

### DIFF
--- a/test/constable/emails_test.exs
+++ b/test/constable/emails_test.exs
@@ -1,6 +1,9 @@
 defmodule Constable.EmailsTest do
   use ConstableWeb.ConnCase, async: true
+
   import Constable.Factory
+  import Phoenix.HTML, only: [safe_to_string: 1]
+  import Phoenix.HTML.Link
 
   test "daily_digest" do
     users = insert_pair(:user)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,7 +22,6 @@ defmodule ConstableWeb.ConnCase do
       import Phoenix.ConnTest
       alias ConstableWeb.Router.Helpers, as: Routes
 
-      use ConstableWeb, :view
       import ConstableWeb.ConnCaseHelper
 
       # Alias the data repository and import query/model functions


### PR DESCRIPTION
What changed?
============

We remove the `use ConstableWeb, :view` from our `ConnCase` test helper.

Using `ConstableWeb, :view` brings in a lot of helpers, but it's meant to be used from Phoenix views, not in conn helpers. Putting it in `ConnCase` effectively turns every test that uses `ConnCase` into a Phoenix view.

It seems we haven't had issues with that so far, but in future work (in a separate branch), I ran into issues because Phoenix views import a `render` function.

So, instead of `use`ing `ConstableWeb, :view`, I found the test that needed the helpers (EmailTest) and imported the `link` and `safe_to_string` helpers directly.