### PR TITLE
Do not pass unused conn to comment template

### DIFF
--- a/lib/constable_web/templates/announcement/show.html.eex
+++ b/lib/constable_web/templates/announcement/show.html.eex
@@ -73,7 +73,7 @@
       No one has commented on this announcement yet.<br />You could be the first!
     </li>
     <%= for comment <- @announcement.comments do %>
-      <%= render "_comment.html", comment: comment, conn: @conn, current_user: @current_user %>
+      <%= render "_comment.html", comment: comment, current_user: @current_user %>
     <% end %>
   </ul>
 


### PR DESCRIPTION
While working on other things, I realized we're passing a `conn` to the `comment` template, but it isn't used in the template. This commit removes the need to pass it in.