### PR TITLE
Render live flash in live views

### DIFF
--- a/lib/constable_web/templates/layout/app.html.eex
+++ b/lib/constable_web/templates/layout/app.html.eex
@@ -1,3 +1,5 @@
 <main id="main" class="app-main tbds-app-frame__body">
+  <%= render "_flashes.html", conn: @conn %>
+
   <%= @inner_content %>
 </main>

--- a/lib/constable_web/templates/layout/live.html.leex
+++ b/lib/constable_web/templates/layout/live.html.leex
@@ -1,3 +1,17 @@
 <main id="main" class="app-main tbds-app-frame__body">
+  <header role="banner">
+    <%= if live_flash(@flash, :info) do %>
+      <div class="flash flash-info">
+        <%= live_flash(@flash, :info) %>
+      </div>
+    <% end %>
+
+    <%= if live_flash(@flash, :error) do %>
+      <div class="flash flash-error">
+        <%= live_flash(@flash, :error) %>
+      </div>
+    <% end %>
+  </header>
+
   <%= @inner_content %>
 </main>

--- a/lib/constable_web/templates/layout/login.html.eex
+++ b/lib/constable_web/templates/layout/login.html.eex
@@ -1,3 +1,5 @@
 <main id="main" class="app-main tbds-app-frame__body tbds-app-frame__body--center-items">
+  <%= render "_flashes.html", conn: @conn %>
+
   <%= @inner_content %>
 </main>

--- a/lib/constable_web/templates/layout/root.html.leex
+++ b/lib/constable_web/templates/layout/root.html.leex
@@ -28,8 +28,6 @@
       <%= render "_header.html", conn: @conn %>
     <% end %>
 
-    <%= render "_flashes.html", conn: @conn %>
-
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
We update the `root.html` template to separate regular flash notices from live flash notices.

The behavior is slightly different, and it seems like we forgot to perform that separation when adding live view. Separating those flashes allows us to render flash notices directly from live views.