### PR TITLE
Extract Slug.deslugify module

### DIFF
--- a/lib/constable/plugs/deslugifier.ex
+++ b/lib/constable/plugs/deslugifier.ex
@@ -1,4 +1,6 @@
 defmodule Constable.Plugs.Deslugifier do
+  alias Constable.Slug
+
   def init(opts) do
     case Keyword.get(opts, :slugified_key) do
       nil -> raise "Must provide a :slugified_key to #{inspect(__MODULE__)}"
@@ -8,17 +10,10 @@ defmodule Constable.Plugs.Deslugifier do
 
   def call(conn, key) do
     with {:ok, slugified_id} <- Map.fetch(conn.params, key),
-         {:ok, id} <- deslugify(slugified_id) do
+         {:ok, id} <- Slug.deslugify(slugified_id) do
       put_in(conn, [Access.key!(:params), key], id)
     else
       _ -> conn
-    end
-  end
-
-  defp deslugify(slugified_id) do
-    case Integer.parse(slugified_id) do
-      {int, _} when int > 0 -> {:ok, int}
-      _ -> :error
     end
   end
 end

--- a/lib/constable/slug.ex
+++ b/lib/constable/slug.ex
@@ -1,0 +1,15 @@
+defmodule Constable.Slug do
+  def deslugify!(slugified_id) do
+    case deslugify(slugified_id) do
+      {:ok, int} -> int
+      :error -> raise "Invalid slug"
+    end
+  end
+
+  def deslugify(slugified_id) do
+    case Integer.parse(slugified_id) do
+      {int, _} when int > 0 -> {:ok, int}
+      _ -> :error
+    end
+  end
+end

--- a/test/constable/slug_test.exs
+++ b/test/constable/slug_test.exs
@@ -1,0 +1,27 @@
+defmodule Constable.SlugTest do
+  use ExUnit.Case, async: true
+
+  alias Constable.Slug
+
+  describe "deslugify/1" do
+    test "separates the id from the title slug" do
+      title = "23-slugified-title"
+
+      {:ok, id} = Slug.deslugify(title)
+
+      assert id == 23
+    end
+
+    test "returns :error if no id is present" do
+      title = "slugified-title"
+
+      assert :error = Slug.deslugify(title)
+    end
+
+    test "returns :error if id is 0 (an invalid id)" do
+      title = "0-slugified-title"
+
+      assert :error = Slug.deslugify(title)
+    end
+  end
+end


### PR DESCRIPTION
In preparation for other work, we separate the `deslugify` functionality from `Plug.Deslugifier` into its own `Slug` module.