### PR TITLE
Use full URLs for profile and image in User factory

### DIFF
--- a/lib/constable/factory.ex
+++ b/lib/constable/factory.ex
@@ -36,8 +36,8 @@ defmodule Constable.Factory do
       daily_digest: true,
       auto_subscribe: false,
       token: sequence(:token, &"omgtokens#{&1}"),
-      profile_image_url: "someurlimage.com",
-      profile_url: "example.com/people/gumbo"
+      profile_image_url: "http://localhost:4000/someurlimage.com",
+      profile_url: "http://localhost:4000/people/gumbo"
     }
   end
 


### PR DESCRIPTION
What changed?
-----------

We use full URLs for profile URLs and image URLs in the user factory.

Why?
----

Not doing so makes it so that the paths in HTML templates (in tests) are relative paths (e.g. /announcemets/someurlimage.com). That results in odd tests failures at times when websockets are involved.