### PR TITLE
Press cmd+enter to add comment

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -56,7 +56,17 @@ Hooks.CommentPreview = {
   },
 };
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute('content');
-let liveSocket = new LiveSocket('/live', Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}});
+let liveSocket = new LiveSocket('/live', Socket, {
+  hooks: Hooks,
+  params: { _csrf_token: csrfToken },
+  metadata: {
+    keydown: (event, _element) => ({
+      key: event.key,
+      metaKey: event.metaKey,
+      ctrlKey: event.ctrlKey,
+    }),
+  },
+});
 liveSocket.connect();
 window.liveSocket = liveSocket;
 

--- a/lib/constable_web/templates/announcement/show.html.leex
+++ b/lib/constable_web/templates/announcement/show.html.leex
@@ -92,7 +92,8 @@
             id: "comment_body",
             required: true,
             placeholder: "Comment on this announcement",
-            phx_hook: "ImageUploader"
+            phx_hook: "ImageUploader",
+            phx_keydown: "keydown"
           ) %>
           <div class="comment-body comment-preview"></div>
           <%= submit gettext("Post Comment"), id: "submit-comment", class: "tbds-button" %>

--- a/test/constable_web/live/announcement_live/show_test.exs
+++ b/test/constable_web/live/announcement_live/show_test.exs
@@ -37,6 +37,38 @@ defmodule ConstableWeb.AnnouncementLive.ShowTest do
     assert has_element?(view, ".comment-body", "This is great!")
   end
 
+  test "user can create a comment by pressing meta + enter", %{conn: conn} do
+    announcement = insert(:announcement)
+    path = Routes.announcement_path(conn, :show, announcement)
+    {:ok, view, _html} = live(conn, path)
+
+    view
+    |> element("#comment_body")
+    |> render_keydown(%{
+      "key" => "Enter",
+      "metaKey" => true,
+      "value" => "Hey a comment"
+    })
+
+    assert has_element?(view, ".comment-body", "Hey a comment")
+  end
+
+  test "user can create a comment by pressing ctrl + enter", %{conn: conn} do
+    announcement = insert(:announcement)
+    path = Routes.announcement_path(conn, :show, announcement)
+    {:ok, view, _html} = live(conn, path)
+
+    view
+    |> element("#comment_body")
+    |> render_keydown(%{
+      "key" => "Enter",
+      "ctrlKey" => true,
+      "value" => "Hey a comment"
+    })
+
+    assert has_element?(view, ".comment-body", "Hey a comment")
+  end
+
   test "renders error if comment cannot be created", %{conn: conn} do
     announcement = insert(:announcement)
 


### PR DESCRIPTION
When commenting on an announcement, you can now press cmd + enter to
create the comment.

To support Linux and Windows, you can also do ctrl + enter.